### PR TITLE
Add NFSBackupStorage

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupFileInfo.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupFileInfo.java
@@ -39,6 +39,7 @@ public class BackupFileInfo {
   private final BackupFileType fileType;
   private final long modificationTime;
   private final long size;
+  public static final long NOT_SET = -1;
 
   /**
    * Constructor that pulls backup metadata based on the backed-up filename

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
@@ -21,6 +21,7 @@ package org.apache.zookeeper.server.backup;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang.NullArgumentException;
 import org.apache.commons.lang.time.StopWatch;
+import org.apache.zookeeper.server.backup.storage.BackupStorageProvider;
 import org.apache.zookeeper.server.persistence.*;
 import org.apache.zookeeper.server.backup.BackupUtil.BackupFileType;
 import org.apache.zookeeper.server.backup.BackupUtil.ZxidPart;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupUtil.java
@@ -27,6 +27,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 
+import org.apache.zookeeper.server.backup.storage.BackupStorageProvider;
 import org.apache.zookeeper.server.persistence.Util;
 
 /**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/exception/BackupException.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/exception/BackupException.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.server.backup.exception;
+
+/**
+ * Signals a logical error has occurred during the ZooKeeper backup/restore process.
+ * Note this error does not mean an error in I/O, but means the object for the operation is not in appropriate state.
+ * For example: failure to copy a file which maybe due to invalid path or source file does not exist.
+ */
+public class BackupException extends RuntimeException {
+  public BackupException(String message) {
+    super(message);
+  }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/storage/BackupStorageProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/storage/BackupStorageProvider.java
@@ -16,12 +16,14 @@
  * limitations under the License.
  */
 
-package org.apache.zookeeper.server.backup;
+package org.apache.zookeeper.server.backup.storage;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+
+import org.apache.zookeeper.server.backup.BackupFileInfo;
 
 /**
  * Interface for a backup storage provider

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/storage/BackupStorageUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/storage/BackupStorageUtil.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.server.backup.storage;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.apache.zookeeper.server.backup.exception.BackupException;
+import org.apache.zookeeper.server.persistence.Util;
+
+/**
+ * Util methods for backup storage
+ */
+public class BackupStorageUtil {
+  public static final String TMP_FILE_PREFIX = "TMP_";
+
+  /**
+   * Parse the prefix from a file name, also works for temporary file names in backup storage
+   * @param fileName The file name to be parsed
+   * @return "log" for ZK transaction log files or "snapshot" for ZK snapshots
+   */
+  public static String getFileTypePrefix(String fileName) {
+    String backupFileName = fileName;
+
+    //Remove the temporary file name prefix in order to determine file type
+    if (fileName.startsWith(TMP_FILE_PREFIX)) {
+      backupFileName = fileName.substring(TMP_FILE_PREFIX.length());
+    }
+
+    String fileTypePrefix;
+    if (backupFileName.startsWith(Util.SNAP_PREFIX)) {
+      fileTypePrefix = Util.SNAP_PREFIX;
+    } else if (backupFileName.startsWith(Util.TXLOG_PREFIX)) {
+      fileTypePrefix = Util.TXLOG_PREFIX;
+    } else {
+      throw new BackupException("No matching base file type found for file " + fileName);
+    }
+
+    return fileTypePrefix;
+  }
+
+  /**
+   * Construct the path of a backup file in the backup storage
+   * @param fileName The name of the file
+   * @param parentDir The path to the parent directory of the backup file.
+   * @return The path of the backup file in the format of:
+   * 1. parentDir path is not supplied: log/{fileName} or snapshot/{fileName}
+   * 2. parentDir path is provided: {parentDir}/log/{fileName} or {parentDir}/snapshot/{fileName}
+   */
+  public static String constructBackupFilePath(String fileName, String parentDir) {
+    if (parentDir != null) {
+      return String.join(File.separator, parentDir, getFileTypePrefix(fileName), fileName);
+    }
+    return String.join(File.separator, getFileTypePrefix(fileName), fileName);
+  }
+
+  /**
+   * Construct temporary file name using backup file name
+   * @param fileName A backup file name: log.lowzxid-highzxid, snapshot.lowzxid-highzxid
+   * @return A temporary backup file name: TMP_log.lowzxid-highzxid, TMP_snapshot.lowzxid-highzxid
+   */
+  public static String constructTempFileName(String fileName) {
+    return TMP_FILE_PREFIX + fileName;
+  }
+
+  /**
+   * A basic method for streaming data from an input stream to an output stream
+   * @param inputStream The stream to read from
+   * @param outputStream The stream to write to
+   * @throws IOException
+   */
+  public static void streamData(InputStream inputStream, OutputStream outputStream)
+      throws IOException {
+    byte[] buffer = new byte[1024];
+    int lengthRead;
+    while ((lengthRead = inputStream.read(buffer)) > 0) {
+      outputStream.write(buffer, 0, lengthRead);
+      outputStream.flush();
+    }
+  }
+
+  /**
+   * Create a new file in a specified path, create the parent directories if they do not exist.
+   * @param file The path to create the file.
+   * @param overwriteIfExist If a file already exists in the location,
+   *                         1. true: delete the existing file and retry the creation of the new file,
+   *                         or 2. false: keep the existing file.
+   * @throws IOException
+   */
+  public static void createFile(File file, boolean overwriteIfExist) throws IOException {
+    file.getParentFile().mkdirs();
+    if (!file.getParentFile().exists()) {
+      throw new BackupException("Failed to create parent directories for file " + file.getName());
+    }
+
+    boolean retry = true;
+    while (retry) {
+      retry = overwriteIfExist;
+      if (!file.createNewFile()) {
+        if (file.exists()) {
+          if (retry && !file.delete()) {
+            throw new BackupException("A file with the file path " + file.getPath()
+                + " already exists, and failed to be overwritten.");
+          }
+        } else {
+          throw new BackupException("Failed to create a file at path: " + file.getPath());
+        }
+      }
+      retry = false;
+    }
+  }
+
+  /**
+   * Get a list of all files whose file name starts with a certain prefix under a directory
+   * @param directory The directory to search for the files
+   * @param prefix The prefix of file name
+   * @return
+   */
+  public static File[] getFilesWithPrefix(File directory, String prefix) {
+    FilenameFilter fileFilter = (dir, name) -> name.startsWith(prefix);
+    return directory.listFiles(fileFilter);
+  }
+
+  /**
+   * Delete all the files whose file names starts with temporary file name prefix
+   * @param directory The directory to search for temporary files
+   * @throws IOException
+   */
+  public static void cleanUpTempFiles(File directory) throws IOException {
+    File[] tempFiles = getFilesWithPrefix(directory, TMP_FILE_PREFIX);
+    for (File tempFile : tempFiles) {
+      Files.delete(Paths.get(tempFile.getPath()));
+    }
+  }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/storage/impl/NfsBackupStorage.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/storage/impl/NfsBackupStorage.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup.storage.impl;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.zookeeper.server.backup.BackupConfig;
+import org.apache.zookeeper.server.backup.BackupFileInfo;
+import org.apache.zookeeper.server.backup.exception.BackupException;
+import org.apache.zookeeper.server.backup.storage.BackupStorageProvider;
+import org.apache.zookeeper.server.backup.storage.BackupStorageUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation for NFS-based backup storage provider
+ */
+public class NfsBackupStorage implements BackupStorageProvider {
+  private static final Logger LOG = LoggerFactory.getLogger(NfsBackupStorage.class);
+  private final BackupConfig backupConfig;
+  private final String fileRootPath;
+
+  /**
+   * Constructor using BackupConfig to get backup storage info
+   * @param backupConfig The information and settings about backup storage, to be set as a part of ZooKeeper server config
+   */
+  public NfsBackupStorage(BackupConfig backupConfig) {
+    this.backupConfig = backupConfig;
+    fileRootPath = String
+        .join(File.separator, this.backupConfig.getMountPath(), this.backupConfig.getNamespace());
+  }
+
+  @Override
+  public BackupFileInfo getBackupFileInfo(File file) throws IOException {
+    String backupFilePath = BackupStorageUtil.constructBackupFilePath(file.getName(), fileRootPath);
+    File backupFile = new File(backupFilePath);
+
+    if (!backupFile.exists()) {
+      return new BackupFileInfo(backupFile, BackupFileInfo.NOT_SET,
+          BackupFileInfo.NOT_SET);
+    }
+
+    BasicFileAttributes fileAttributes =
+        Files.readAttributes(Paths.get(backupFilePath), BasicFileAttributes.class);
+    return new BackupFileInfo(backupFile, fileAttributes.lastModifiedTime().toMillis(),
+        fileAttributes.size());
+  }
+
+  @Override
+  public List<BackupFileInfo> getBackupFileInfos(File path, String prefix) throws IOException {
+    String backupDirPath = BackupStorageUtil.constructBackupFilePath(path.getName(), fileRootPath);
+    File backupDir = new File(backupDirPath);
+
+    if (!backupDir.exists()) {
+      throw new BackupException(
+          "Backup directory " + path.getPath() + " does not exist, could not get file info.");
+    }
+
+    File[] files = BackupStorageUtil.getFilesWithPrefix(backupDir, prefix);
+
+    // Read the file info and add to the list. If an exception is thrown, the entire operation will fail
+    List<BackupFileInfo> backupFileInfos = new ArrayList<>();
+    if (files != null) {
+      for (File file : files) {
+        backupFileInfos.add(getBackupFileInfo(file));
+      }
+    }
+    return backupFileInfos;
+  }
+
+  @Override
+  public List<File> getDirectories(File path) {
+    String backupDirPath = BackupStorageUtil.constructBackupFilePath(path.getName(), fileRootPath);
+    File backupDir = new File(backupDirPath);
+
+    if (!backupDir.exists()) {
+      throw new BackupException(
+          "Backup directory " + path.getPath() + " does not exist, could not get directory list.");
+    }
+
+    // Filter out all the files which are directories
+    FilenameFilter fileFilter = (dir, name) -> new File(dir, name).isDirectory();
+    File[] dirs = backupDir.listFiles(fileFilter);
+
+    if (dirs == null) {
+      throw new BackupException("The provided directory path " + path.getPath()
+          + " is invalid, could not get directory list.");
+    }
+    return Arrays.asList(dirs);
+  }
+
+  @Override
+  public InputStream open(File path) throws IOException {
+    if (!path.exists() || path.isDirectory()) {
+      throw new BackupException("The file with the file path " + path
+          + " does not exist or is a directory, could not open the file.");
+    }
+    return new FileInputStream(path);
+  }
+
+  @Override
+  public void copyToBackupStorage(File srcFile, File destName) throws IOException {
+    InputStream inputStream = null;
+    OutputStream outputStream = null;
+    String backupTempFilePath;
+    File backupTempFile;
+
+    try {
+      inputStream = open(srcFile);
+
+      backupTempFilePath = BackupStorageUtil
+          .constructBackupFilePath(BackupStorageUtil.constructTempFileName(destName.getName()),
+              fileRootPath);
+      backupTempFile = new File(backupTempFilePath);
+
+      BackupStorageUtil.createFile(backupTempFile, true);
+      outputStream = new FileOutputStream(backupTempFile);
+
+      BackupStorageUtil.streamData(inputStream, outputStream);
+    } finally {
+      if (inputStream != null) {
+        inputStream.close();
+      }
+      if (outputStream != null) {
+        outputStream.close();
+      }
+    }
+
+    Files.move(Paths.get(backupTempFilePath),
+        Paths.get(BackupStorageUtil.constructBackupFilePath(destName.getName(), fileRootPath)),
+        StandardCopyOption.REPLACE_EXISTING);
+    BackupStorageUtil.cleanUpTempFiles(backupTempFile.getParentFile());
+  }
+
+  @Override
+  public void copyToLocalStorage(File srcName, File destFile) throws IOException {
+    InputStream inputStream = null;
+    OutputStream outputStream = null;
+
+    // Create input stream from the source file in backup storage
+    String backupFilePath =
+        BackupStorageUtil.constructBackupFilePath(srcName.getName(), fileRootPath);
+    File backupFile = new File(backupFilePath);
+
+    try {
+      inputStream = open(backupFile);
+
+      BackupStorageUtil.createFile(destFile, true);
+      outputStream = new FileOutputStream(destFile);
+
+      BackupStorageUtil.streamData(inputStream, outputStream);
+    } finally {
+      if (inputStream != null) {
+        inputStream.close();
+      }
+      if (outputStream != null) {
+        outputStream.close();
+      }
+    }
+  }
+
+  @Override
+  public void delete(File fileToDelete) throws IOException {
+    String backupFilePath =
+        BackupStorageUtil.constructBackupFilePath(fileToDelete.getName(), fileRootPath);
+    Files.deleteIfExists(Paths.get(backupFilePath));
+  }
+
+  @Override
+  public void cleanupInvalidFiles(File path) throws IOException {
+    BackupStorageUtil.cleanUpTempFiles(path);
+  }
+}


### PR DESCRIPTION
### Description
Resolves #13 
Classes added: NfsBackupStorage, BackupException, BackupConstants, BackupStorageUtil
Class Modified: BackupConfig

### Run Test
Tests will be added in the next several PRs:
1. A "LocalBackupStorage" class is going to be created in the next PR which have same functionalities as NfsBackupStorage but will back up the files to a local space. The testing for NfsBackupStorage will be covered by unit tests for LocalBackupStorage.
2. Integration tests for the entire zk backup process (including BackupManager, LocalBackupStorage, etc.) are also going to be added, which could also test the logic.