### PR TITLE
Add data model and initial implementation for backup

### DIFF
--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -162,6 +162,11 @@
       <artifactId>snappy-java</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>27.0.1-jre</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupFileInfo.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupFileInfo.java
@@ -1,0 +1,136 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup;
+
+import java.io.File;
+
+import com.google.common.collect.Range;
+
+import org.apache.zookeeper.server.backup.BackupUtil.BackupFileType;
+import org.apache.zookeeper.server.backup.BackupUtil.ZxidPart;
+import org.apache.zookeeper.server.persistence.Util;
+
+/**
+ * Metadata for a file that has been backed-up
+ * Assumes that the name of the backed up file uses the format:
+ * prefix.lowzxid-highzxid where prefix is one of the standard snap or log file prefixes, or
+ * "lostLog".
+ */
+public class BackupFileInfo {
+  private final File backupFile;
+  private final File standardFile;
+  private final Range<Long> zxidRange;
+  private final BackupFileType fileType;
+  private final long modificationTime;
+  private final long size;
+
+  /**
+   * Constructor that pulls backup metadata based on the backed-up filename
+   * @param backedupFile the backed-up file with the name in the form prefix.lowzxid-highzxid
+   *                     for example snapshot.9a0000a344-9a0000b012
+   * @param modificationTime the file modification time
+   * @param size the size of the file in bytes
+   */
+  public BackupFileInfo(File backedupFile, long modificationTime, long size) {
+    this.backupFile = backedupFile;
+    this.modificationTime = modificationTime;
+    this.size = size;
+
+    String backedupFilename = this.backupFile.getName();
+
+    if (backedupFilename.startsWith(BackupUtil.LOST_LOG_PREFIX)) {
+      this.fileType = BackupFileType.LOSTLOG;
+      this.standardFile = this.backupFile;
+    } else if (backedupFilename.startsWith(Util.SNAP_PREFIX)) {
+      this.fileType = BackupFileType.SNAPSHOT;
+      this.standardFile =
+          new File(this.backupFile.getParentFile(), backedupFilename.split("-")[0]);
+    } else if (backedupFilename.startsWith(Util.TXLOG_PREFIX)) {
+      this.fileType = BackupFileType.TXNLOG;
+      this.standardFile =
+          new File(this.backupFile.getParentFile(), backedupFilename.split("-")[0]);
+    } else {
+      throw new IllegalArgumentException("Not a known backup file type: " + backedupFilename);
+    }
+
+    this.zxidRange = BackupUtil.getZxidRangeFromName(
+        backedupFilename,
+        BackupUtil.getPrefix(this.fileType));
+  }
+
+  /**
+   * Get the zxid range for the backed up file.
+   * @return the zxid range
+   */
+  public Range<Long> getZxidRange() {
+    return this.zxidRange;
+  }
+
+  /**
+   * Convenience method for getting a specific zxid part
+   * @param whichZxid which part to get
+   * @return the value of the requested zxid part
+   */
+  public long getZxid(ZxidPart whichZxid) {
+    return whichZxid == ZxidPart.MIN_ZXID
+        ? this.zxidRange.lowerEndpoint()
+        : this.zxidRange.upperEndpoint();
+  }
+
+  /**
+   * Get the backedup file
+   * @return the backedup file
+   */
+  public File getBackedUpFile() {
+    return this.backupFile;
+  }
+
+  /**
+   * Get the files corresponding to the standard name of the backed up file.  I.e. removes the
+   * high zxid from the filename.
+   * @return the standard file corresponding to the backed up file
+   */
+  public File getStandardFile() {
+    return this.standardFile;
+  }
+
+  /**
+   * Get the type of the file (snap, log, lostLog)
+   * @return the type of file that was backed up
+   */
+  public BackupFileType getFileType() {
+    return this.fileType;
+  }
+
+  /**
+   * Get the modification time for the file
+   * @return the modification time
+   */
+  public long getModificationTime() {
+    return this.modificationTime;
+  }
+
+  /**
+   * Get the file size in bytes
+   * @return file size in bytes
+   */
+  public long getSize() {
+    return this.size;
+  }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
@@ -282,7 +282,7 @@ public class BackupManager {
         logger.error("Hit unexpected exception", e);
       }
 
-      logger.warn("Thread exited loop!");
+      logger.warn("BackupProcess thread exited loop!");
     }
 
     /**
@@ -318,7 +318,7 @@ public class BackupManager {
    */
   protected class TxnLogBackup extends BackupProcess {
     private long iterationEndPoint;
-    private FileTxnSnapLog snapLog;
+    private final FileTxnSnapLog snapLog;
 
     /**
      * Constructor for TxnLogBackup
@@ -383,7 +383,7 @@ public class BackupManager {
       FileTxnLog newFile = null;
       long lastZxid = -1;
       int txnCopied = 0;
-      BackupFile ret = null;
+      BackupFile ret;
 
       logger.info("Creating backup file from zxid {}.", ZxidUtils.zxidToString(startingZxid));
 
@@ -393,6 +393,7 @@ public class BackupManager {
         // Use a temp directory to avoid conflicts with live txnlog files
         newFile = new FileTxnLog(tmpDir);
 
+        // TODO: Ideally, we should have have a way to prevent lost TxLogs
         // Check for lost txnlogs; <=1 indicates that no backups have been done before so
         // nothing can be considered lost.
         // If a lost sequence is found then return a file whose name encodes the lost
@@ -469,6 +470,7 @@ public class BackupManager {
         return null;
       }
 
+      // The logFile gets initialized with the first transaction's zxid
       File logFile = backupTxnLog.getCurrentFile();
 
       if (logFile == null) {
@@ -498,8 +500,8 @@ public class BackupManager {
    * Implements snapshot specific logic for BackupProcess
    */
   protected class SnapBackup extends BackupProcess {
-    private FileTxnSnapLog snapLog;
-    private List<BackupFile> filesToBackup = new ArrayList<BackupFile>();
+    private final FileTxnSnapLog snapLog;
+    private final List<BackupFile> filesToBackup = new ArrayList<>();
 
     /**
      * Constructor for SnapBackup
@@ -594,7 +596,7 @@ public class BackupManager {
       filesToBackup.clear();
     }
 
-    protected BackupFile getNextFileToBackup() throws IOException {
+    protected BackupFile getNextFileToBackup() {
       if (filesToBackup.isEmpty()) {
         return null;
       }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
@@ -1,0 +1,763 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup;
+
+import com.google.common.base.Preconditions;
+import org.apache.commons.lang.NullArgumentException;
+import org.apache.commons.lang.time.StopWatch;
+// TODO: Implement MetricsReceiver
+// import org.apache.zookeeper.metrics.MetricsReceiver;
+import org.apache.zookeeper.server.persistence.*;
+import org.apache.zookeeper.server.backup.BackupUtil.BackupFileType;
+import org.apache.zookeeper.server.backup.BackupUtil.ZxidPart;
+import org.apache.zookeeper.server.util.ZxidUtils;
+import org.apache.zookeeper.txn.TxnHeader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * This class manages the backing up of txnlog and snap files to remote
+ * storage for longer term and durable retention than is possible on
+ * an ensemble server
+ */
+public class BackupManager {
+  private final Logger logger;
+  private final File snapDir;
+  private final File dataLogDir;
+  private final File tmpDir;
+  private final int backupIntervalInMilliseconds;
+  // private final MetricsReceiver metricsReceiver;
+  private BackupProcess logBackup = null;
+  private BackupProcess snapBackup = null;
+
+  // backupStatus, backupLogZxid and backedupSnapZxid need to be access while synchronized
+  // on backupStatus.
+  private final BackupStatus backupStatus;
+  private long backedupLogZxid;
+  private long backedupSnapZxid;
+
+  private final BackupStorageProvider backupStorage;
+
+  /**
+   * Tracks a file that needs to be backed up, including temporary copies of the file
+   */
+  protected static class BackupFile {
+    private final File file;
+    private final boolean isTemporary;
+    private final ZxidRange zxidRange;
+
+    /**
+     * Create an instance of a BackupFile for the given initial file and zxid range
+     * @param backupFile the initial/original file
+     * @param isTemporaryFile whether the file is a temporary file
+     * @param fileMinZxid the min zxid associated with this file
+     * @param fileMaxZxid the max zxid associated with this file
+     */
+    public BackupFile(File backupFile, boolean isTemporaryFile, long fileMinZxid, long fileMaxZxid) {
+      this(backupFile, isTemporaryFile, new ZxidRange(fileMinZxid, fileMaxZxid));
+    }
+
+    /**
+     * Create an instance of a BackupFile for the given initial file and zxid range
+     * @param backupFile the initial/original file
+     * @param isTemporaryFile whether the file is a temporary file
+     * @param zxidRange the zxid range associated with this file
+     */
+    public BackupFile(File backupFile, boolean isTemporaryFile, ZxidRange zxidRange) {
+      Preconditions.checkNotNull(zxidRange);
+
+      if (!zxidRange.isHighPresent()) {
+        throw new IllegalArgumentException("ZxidRange must have a high value");
+      }
+
+      this.file = backupFile;
+      this.isTemporary = isTemporaryFile;
+      this.zxidRange = zxidRange;
+    }
+
+    /**
+     * Perform cleanup including deleting temporary files.
+     */
+    public void cleanup() {
+      if (isTemporary && exists()) {
+        file.delete();
+      }
+    }
+
+    /**
+     * Whether the file representing the zxids exists
+     * @return whether the file represented exists
+     */
+    public boolean exists() {
+      return file != null && file.exists();
+    }
+
+    /**
+     * Get the current file (topmost on the stack)
+     * @return the current file
+     */
+    public File getFile() { return file; }
+
+    /**
+     * Get the zxid range associated with this file
+     * @return the zxid range
+     */
+    public ZxidRange getZxidRange() {
+      return zxidRange;
+    }
+
+    /**
+     * Get the min zxid associated with this file
+     * @return the min associated zxid
+     */
+    public long getMinZxid() { return zxidRange.getLow(); }
+
+    /**
+     * Get the max zxid associated with this file
+     * @return the max associated zxid
+     */
+    public long getMaxZxid() { return zxidRange.getHigh(); }
+
+    @Override
+    public String toString() {
+      return String.format("%s : %s : %d - %d",
+          file == null ? "[empty]" : file.getPath(),
+          isTemporary ? "temp" : "perm",
+          zxidRange.getLow(),
+          zxidRange.getHigh());
+    }
+  }
+
+  /**
+   * Base class for the txnlog and snap back processes.
+   * Provides the main backup loop and copying to remote storage (via HDFS APIs)
+   */
+  public abstract class BackupProcess implements Runnable {
+    protected final Logger logger;
+    private volatile boolean isRunning = true;
+
+    /**
+     * Initialize starting backup point based on remote storage and backupStatus file
+     */
+    protected abstract void initialize() throws IOException;
+
+    /**
+     * Marks the start of a backup iteration.  A backup iteration is run every
+     * backup.interval.  This is called at the start of the iteration and before
+     * any calls to getNextFileToBackup
+     * @throws IOException
+     */
+    protected abstract void startIteration() throws IOException;
+
+    /**
+     * Marks the end of a backup iteration.  After this call there will be no more
+     * calls to getNextFileToBackup or backupComplete until startIteration is
+     * called again.
+     * @param errorFree whether the iteration was error free
+     * @throws IOException
+     */
+    protected abstract void endIteration(boolean errorFree);
+
+    /**
+     * Get the next file to backup
+     * @return the next file to copy to backup storage.
+     * @throws IOException
+     */
+    protected abstract BackupFile getNextFileToBackup() throws IOException;
+
+    /**
+     * Marks that the copy of the specified file to backup storage has completed
+     * @param file the file to backup
+     * @throws IOException
+     */
+    protected abstract void backupComplete(BackupFile file) throws IOException;
+
+    /**
+     * Create an instance of the backup process
+     * @param logger the logger to use for this process.
+     */
+    public BackupProcess(Logger logger) {
+      if (logger == null) {
+        throw new NullArgumentException("logger");
+      }
+
+      this.logger = logger;
+    }
+
+    /**
+     * Runs the main file based backup loop indefinitely.
+     */
+    public void run() {
+      run(0);
+    }
+
+    /**
+     * Runs the main file based backup loop the specified number of time.
+     * Calls methods implemented by derived classes to get the next file to copy.
+     */
+    public void run(int iterations) {
+      try {
+        boolean errorFree = true;
+        logger.debug("Thread starting.");
+
+        while (isRunning) {
+          BackupFile fileToCopy;
+          StopWatch sw = new StopWatch();
+
+          sw.start();
+
+          try {
+            if (logger.isDebugEnabled()) {
+              logger.debug("Starting iteration");
+            }
+
+            // Cleanup any invalid backups that may have been left behind by the
+            // previous failed iteration.
+            // NOTE: Not done on first iteration (errorFree initialized to true) since
+            //       initialize already does this.
+            if (!errorFree) {
+              backupStorage.cleanupInvalidFiles(null);
+            }
+
+            startIteration();
+
+            while ((fileToCopy = getNextFileToBackup()) != null) {
+              // Consider: compress file before sending to remote storage
+              copyToRemoteStorage(fileToCopy);
+              backupComplete(fileToCopy);
+              fileToCopy.cleanup();
+            }
+
+            errorFree = true;
+          } catch (IOException e) {
+            errorFree = false;
+            logger.warn("Exception hit during backup", e);
+          }
+
+          endIteration(errorFree);
+
+          sw.stop();
+          long elapsedTime = sw.getTime();
+
+          logger.info("Completed backup iteration in {} milliseconds.  ErrorFree: {}.",
+              elapsedTime, errorFree);
+
+          if (iterations != 0) {
+            iterations--;
+
+            if (iterations < 1) {
+              break;
+            }
+          }
+
+          // Count elapsed time towards the backup interval
+          long waitTime = backupIntervalInMilliseconds - elapsedTime;
+
+          synchronized (this) {  // synchronized to get notification of termination
+            if (waitTime > 0) {
+              wait(waitTime);
+            }
+          }
+        }
+      } catch (InterruptedException e) {
+        logger.warn("Interrupted exception while waiting for backup interval.", e);
+      } catch (Exception e) {
+        logger.error("Hit unexpected exception", e);
+      }
+
+      logger.warn("Thread exited loop!");
+    }
+
+    /**
+     * Copy given file to remote storage via HDFS APIs.
+     * @param fileToCopy the file to copy
+     * @throws IOException
+     */
+    private void copyToRemoteStorage(BackupFile fileToCopy) throws IOException {
+      if (fileToCopy.getFile() == null) {
+        return;
+      }
+
+      // Use the file name to encode the max included zxid
+      String backedupName = BackupUtil.makeBackupName(
+          fileToCopy.getFile().getName(), fileToCopy.getMaxZxid());
+
+      backupStorage.copyToBackupStorage(fileToCopy.getFile(), new File(backedupName));
+    }
+
+    /**
+     * Shutdown the backup process
+     */
+    public void shutdown() {
+      synchronized (this) {
+        isRunning = false;
+        notifyAll();
+      }
+    }
+  }
+
+  /**
+   * Implements txnlog specific logic for BackupProcess
+   */
+  protected class TxnLogBackup extends BackupProcess {
+    private long iterationEndPoint;
+    private FileTxnSnapLog snapLog;
+
+    /**
+     * Constructor for TxnLogBackup
+     * @param snapLog the FileTxnSnapLog object to use
+     */
+    public TxnLogBackup(FileTxnSnapLog snapLog) {
+      super(LoggerFactory.getLogger(TxnLogBackup.class));
+      this.snapLog = snapLog;
+    }
+
+    protected void initialize() throws IOException {
+      backupStorage.cleanupInvalidFiles(null);
+
+      BackupFileInfo latest =
+          BackupUtil.getLatest(backupStorage, BackupFileType.TXNLOG, ZxidPart.MIN_ZXID);
+
+      long rZxid = latest == null
+          ? BackupUtil.INVALID_LOG_ZXID
+          : latest.getZxid(ZxidPart.MAX_ZXID);
+
+      logger.info("Latest Zxid from storage: {}  from status: {}",
+          ZxidUtils.zxidToString(rZxid), ZxidUtils.zxidToString(backedupLogZxid));
+
+      if (rZxid != backedupLogZxid) {
+        synchronized (backupStatus) {
+          backedupLogZxid = rZxid;
+          backupStatus.update(backedupLogZxid, backedupSnapZxid);
+        }
+      }
+    }
+
+    protected void startIteration() {
+      // Store the current last logged zxid.  This becomes the stopping point
+      // for the current iteration so we don't keep chasing our own tail as
+      // new transactions get written.
+      iterationEndPoint = snapLog.getLastLoggedZxid();
+//      getStats().setLastTxnLogBackupIterationStart();
+    }
+
+    protected void endIteration(boolean errorFree) {
+      iterationEndPoint = 0L;
+//      getStats().txnLogIterationDone(errorFree);
+    }
+
+    /**
+     * Gets the next txnlog file to backup.  This is a temporary file created by copying
+     * all transaction from the previous backup point until the end zxid for this iteration, or
+     * a file indicating that some log records were lost.
+     * @return the file that needs to be backed-up.  The minZxid is the first
+     *      zxid contained in the file.  The maxZxid is the last zxid that is contained in the
+     *      file.
+     * @throws IOException
+     */
+    protected BackupFile getNextFileToBackup() throws IOException {
+      long startingZxid = backupStatus.read().getLogZxid() + 1;
+
+      // Don't keep chasing the tail so stop if past the last zxid at the time
+      // this iteration started.
+      if (startingZxid > iterationEndPoint) {
+        return null;
+      }
+
+      TxnLog.TxnIterator iter = null;
+      FileTxnLog newFile = null;
+      long lastZxid = -1;
+      int txnCopied = 0;
+      BackupFile ret = null;
+
+      logger.info("Creating backup file from zxid {}.", ZxidUtils.zxidToString(startingZxid));
+
+      try {
+        iter = snapLog.readTxnLog(startingZxid, true);
+
+        // Use a temp directory to avoid conflicts with live txnlog files
+        // TODO: Implement MetricsReceiver
+        // newFile = new FileTxnLog(tmpDir, metricsReceiver);
+        newFile = new FileTxnLog(tmpDir);
+
+        // Check for lost txnlogs; <=1 indicates that no backups have been done before so
+        // nothing can be considered lost.
+        // If a lost sequence is found then return a file whose name encodes the lost
+        // sequence and back that up so the backup store has a record of the lost sequence
+        if (startingZxid > 1 &&
+            iter.getHeader() != null &&
+            iter.getHeader().getZxid() > startingZxid) {
+
+          logger.error("TxnLog backups lost.  Required starting zxid={}  First available zxid={}",
+              ZxidUtils.zxidToString(startingZxid),
+              ZxidUtils.zxidToString(iter.getHeader().getZxid()));
+
+          String fileName = String.format("%s.%s",
+              BackupUtil.LOST_LOG_PREFIX,
+              Long.toHexString(startingZxid));
+          File lostZxidFile = new File(tmpDir, fileName);
+          lostZxidFile.createNewFile();
+
+          return new BackupFile(lostZxidFile, true, startingZxid, iter.getHeader().getZxid() - 1);
+        }
+
+        while (iter.getHeader() != null) {
+          TxnHeader hdr = iter.getHeader();
+
+          if (hdr.getZxid() > iterationEndPoint) {
+            break;
+          }
+
+          newFile.append(hdr, iter.getTxn());
+
+          // update position and count only AFTER the record has been successfully
+          // copied
+          lastZxid = hdr.getZxid();
+          txnCopied++;
+
+          iter.next();
+        }
+
+        ret = makeBackupFileFromCopiedLog(newFile, lastZxid);
+
+        if (ret != null) {
+          logger.info("Copied {} records starting at {} and ending at zxid {}.",
+              txnCopied,
+              ZxidUtils.zxidToString(ret.getMinZxid()),
+              ZxidUtils.zxidToString(ret.getMaxZxid()));
+        }
+
+      } catch (IOException e) {
+        logger.warn("Hit exception after {} records.  Exception: {} ", txnCopied, e);
+
+        // If any records were copied return those and ignore the error.  Otherwise
+        // rethrow the error to be handled by the caller as a failed backup iteration.
+        if (txnCopied <= 0) {
+          throw e;
+        }
+
+        ret = makeBackupFileFromCopiedLog(newFile, lastZxid);
+      } finally {
+        if (iter != null) {
+          iter.close();
+        }
+
+        if (newFile != null) {
+          newFile.close();
+        }
+      }
+
+      return ret;
+    }
+
+    private BackupFile makeBackupFileFromCopiedLog(FileTxnLog backupTxnLog, long lastZxid) {
+
+      if (backupTxnLog == null) {
+        return null;
+      }
+
+      File logFile = backupTxnLog.getCurrentFile();
+
+      if (logFile == null) {
+        return null;
+      }
+
+      long firstZxid = Util.getZxidFromName(logFile.getName(), Util.TXLOG_PREFIX);
+
+      if (lastZxid == -1) {
+        lastZxid = firstZxid;
+      }
+
+      return new BackupFile(logFile, true, new ZxidRange(firstZxid, lastZxid));
+    }
+
+    protected void backupComplete(BackupFile file) throws IOException {
+      synchronized (backupStatus) {
+        backedupLogZxid = file.getMaxZxid();
+        backupStatus.update(backedupLogZxid, backedupSnapZxid);
+      }
+
+//      if (file.exists()) {
+//        getStats().updateTxnLogSent(file.getFile().length());
+//      }
+
+      logger.info("Updated backedup tnxlog zxid to {}", ZxidUtils.zxidToString(backedupLogZxid));
+    }
+  }
+
+  /**
+   * Implements snapshot specific logic for BackupProcess
+   */
+  protected class SnapBackup extends BackupProcess {
+    private FileTxnSnapLog snapLog;
+    private List<BackupFile> filesToBackup = new ArrayList<BackupFile>();
+
+    /**
+     * Constructor for SnapBackup
+     * @param snapLog the FileTxnSnapLog object to use
+     */
+    public SnapBackup(FileTxnSnapLog snapLog) {
+      super(LoggerFactory.getLogger(SnapBackup.class));
+      this.snapLog = snapLog;
+    }
+
+    protected void initialize() throws IOException {
+      backupStorage.cleanupInvalidFiles(null);
+
+      BackupFileInfo latest =
+          BackupUtil.getLatest(backupStorage, BackupFileType.SNAPSHOT, ZxidPart.MIN_ZXID);
+
+      long rZxid = latest == null
+          ? BackupUtil.INVALID_SNAP_ZXID
+          : latest.getZxid(ZxidPart.MIN_ZXID);
+
+      logger.info("Latest Zxid from storage: {}  from status: {}",
+          ZxidUtils.zxidToString(rZxid), ZxidUtils.zxidToString(backedupLogZxid));
+
+      if (rZxid != backedupSnapZxid) {
+        synchronized (backupStatus) {
+          backedupSnapZxid = rZxid;
+          backupStatus.update(backedupLogZxid, backedupSnapZxid);
+        }
+      }
+    }
+
+    protected void startIteration() throws IOException {
+//      getStats().setLastSnapBackupIterationStart();
+
+      filesToBackup.clear();
+
+      List<File> candidateSnapshots = snapLog.findValidSnapshots(0, backedupSnapZxid);
+      Collections.reverse(candidateSnapshots);
+
+      if (candidateSnapshots.size() == 0) {
+        return;
+      }
+
+      if (backedupSnapZxid == BackupUtil.INVALID_SNAP_ZXID) {
+        File f = candidateSnapshots.get(0);
+        ZxidRange zxidRange = Util.getZxidRangeFromName(f.getName(), Util.SNAP_PREFIX);
+
+        // Handle backwards compatibility for snapshots that use old style naming where
+        // only the starting zxid is included.
+        // TODO: Can be removed after all snapshots being produced have ending zxid --
+        // TODO: see COORD-1947
+        if (!zxidRange.isHighPresent()) {
+          long latestZxid = snapLog.getLastLoggedZxid();
+          long consistentAt = latestZxid == -1 ? zxidRange.getLow() : latestZxid;
+
+          // Consistency point can be moved earlier if this is not the only file
+          if (candidateSnapshots.size() > 1) {
+            long nextSnapshotStartZxid =
+                Util.getZxidFromName(
+                    candidateSnapshots.get(1).getName(),
+                    Util.SNAP_PREFIX);
+
+            if (nextSnapshotStartZxid > zxidRange.getLow()) {
+              consistentAt = nextSnapshotStartZxid - 1;
+            }
+          }
+
+          zxidRange = new ZxidRange(zxidRange.getLow(), consistentAt);
+        }
+
+
+        filesToBackup.add(new BackupFile(f, false, zxidRange));
+      }
+
+      // Always include the last snapshot to be copied as long as it was not already added
+      // above and has not already been backed up.
+      if (backedupSnapZxid != BackupUtil.INVALID_SNAP_ZXID || candidateSnapshots.size() > 1) {
+        File f = candidateSnapshots.get(candidateSnapshots.size() - 1);
+        ZxidRange zxidRange = Util.getZxidRangeFromName(f.getName(), Util.SNAP_PREFIX);
+
+        // Handle backwards compatibility for snapshots that use old style naming where
+        // only the starting zxid is included.
+        // TODO: Can be removed after all snapshots being produced have ending zxid --
+        // TODO: see COORD-1947
+        if (!zxidRange.isHighPresent()) {
+          long latestZxid = snapLog.getLastLoggedZxid();
+          zxidRange = new ZxidRange(
+              zxidRange.getLow(), latestZxid == -1 ? zxidRange.getLow() : latestZxid);
+        }
+
+        if (zxidRange.getLow() > backedupSnapZxid) {
+          filesToBackup.add(new BackupFile(f, false, zxidRange));
+        }
+      }
+    }
+
+    protected void endIteration(boolean errorFree) {
+      filesToBackup.clear();
+      // TODO: enable when Stats is implemented
+      // getStats().snapIterationDone(errorFree);
+    }
+
+    protected BackupFile getNextFileToBackup() throws IOException {
+      if (filesToBackup.isEmpty()) {
+        return null;
+      }
+
+      return filesToBackup.remove(0);
+    }
+
+    protected void backupComplete(BackupFile file) throws IOException {
+      synchronized (backupStatus) {
+        backedupSnapZxid = file.getMinZxid();
+        backupStatus.update(backedupLogZxid, backedupSnapZxid);
+      }
+
+      // getStats().updateSnapSent(file.getFile().length());
+
+      logger.info("Updated backedup snap zxid to {}", ZxidUtils.zxidToString(backedupSnapZxid));
+    }
+  }
+
+// TODO: Enable when MetricsReceiver is ready
+//  /**
+//   * Constructor for the BackupManager.
+//   * @param snapDir the snapshot directory
+//   * @param dataLogDir the txnlog directory
+//   * @param backupStatusDir the backup status directory
+//   * @param tmpDir temporary directory
+//   * @param backupIntervalInMinutes the interval backups should run at in minutes
+//   */
+//  public BackupManager(File snapDir, File dataLogDir, File backupStatusDir, File tmpDir, int backupIntervalInMinutes,
+//      BackupStorageProvider backupStorageProvider, MetricsReceiver metricsReceiver) throws IOException {
+//    logger = LoggerFactory.getLogger(BackupManager.class);
+//    logger.info("snapDir={}", snapDir.getPath());
+//    logger.info("dataLogDir={}", dataLogDir.getPath());
+//    logger.info("backupStatusDir={}", backupStatusDir.getPath());
+//    logger.info("tmpDir={}", tmpDir.getPath());
+//    logger.info("backupIntervalInMinutes={}", backupIntervalInMinutes);
+//
+//    this.snapDir = snapDir;
+//    this.dataLogDir = dataLogDir;
+//    this.tmpDir = tmpDir;
+//    this.backupStatus = new BackupStatus(backupStatusDir);
+//    this.backupIntervalInMilliseconds = backupIntervalInMinutes * 60 * 1000;
+//    this.backupStorage = backupStorageProvider;
+//    this.metricsReceiver = metricsReceiver;
+//
+//    initialize();
+//  }
+
+  /**
+   * Constructor for the BackupManager.
+   * @param snapDir the snapshot directory
+   * @param dataLogDir the txnlog directory
+   * @param backupStatusDir the backup status directory
+   * @param tmpDir temporary directory
+   * @param backupIntervalInMinutes the interval backups should run at in minutes
+   */
+  public BackupManager(File snapDir, File dataLogDir, File backupStatusDir, File tmpDir, int backupIntervalInMinutes,
+      BackupStorageProvider backupStorageProvider) throws IOException {
+    logger = LoggerFactory.getLogger(BackupManager.class);
+    logger.info("snapDir={}", snapDir.getPath());
+    logger.info("dataLogDir={}", dataLogDir.getPath());
+    logger.info("backupStatusDir={}", backupStatusDir.getPath());
+    logger.info("tmpDir={}", tmpDir.getPath());
+    logger.info("backupIntervalInMinutes={}", backupIntervalInMinutes);
+
+    this.snapDir = snapDir;
+    this.dataLogDir = dataLogDir;
+    this.tmpDir = tmpDir;
+    this.backupStatus = new BackupStatus(backupStatusDir);
+    this.backupIntervalInMilliseconds = backupIntervalInMinutes * 60 * 1000;
+    this.backupStorage = backupStorageProvider;
+
+    initialize();
+  }
+
+  /**
+   * Start the backup processes.
+   * @throws IOException
+   */
+  public synchronized void start() throws IOException {
+    logger.info("BackupManager starting.");
+
+//    getStats().updateBackupManagerState(true);
+
+    initialize();
+
+    (new Thread(logBackup)).start();
+    (new Thread(snapBackup)).start();
+  }
+
+  /**
+   * Stop the backup processes.
+   */
+  public void stop() {
+    logger.info("BackupManager shutting down.");
+
+//    getStats().updateBackupManagerState(false);
+
+    synchronized (this) {
+      logBackup.shutdown();
+      snapBackup.shutdown();
+      logBackup = null;
+      snapBackup = null;
+    }
+  }
+
+  public BackupProcess getLogBackup() { return logBackup; }
+  public BackupProcess getSnapBackup() { return snapBackup; }
+
+  public long getBackedupLogZxid() {
+    synchronized (backupStatus) {
+      return backedupLogZxid;
+    }
+  }
+
+  public long getBackedupSnapZxid() {
+    synchronized (backupStatus) {
+      return backedupSnapZxid;
+    }
+  }
+
+  public synchronized void initialize() throws IOException {
+    synchronized (backupStatus) {
+      backupStatus.createIfNeeded();
+      BackupPoint bp = backupStatus.read();
+      backedupLogZxid = bp.getLogZxid();
+      backedupSnapZxid = bp.getSnapZxid();
+    }
+
+    if (!tmpDir.exists()) {
+      tmpDir.mkdirs();
+    }
+
+    // TODO: enable when metricsReceiver is ready
+//    logBackup = new TxnLogBackup(new FileTxnSnapLog(dataLogDir, snapDir, metricsReceiver));
+//    snapBackup = new SnapBackup(new FileTxnSnapLog(dataLogDir, snapDir, metricsReceiver));
+    logBackup = new TxnLogBackup(new FileTxnSnapLog(dataLogDir, snapDir));
+    snapBackup = new SnapBackup(new FileTxnSnapLog(dataLogDir, snapDir));
+
+    logBackup.initialize();
+    snapBackup.initialize();
+  }
+
+//  public static BackupStats getStats() {
+//    return BackupStats.getSingleton();
+//  }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
@@ -566,6 +566,7 @@ public class BackupManager {
             // approach
             // TODO: Because this is the best effort approach, the zxidRange will not be accurate
             // TODO: Consider rewriting these latest snapshots to backup storage if necessary
+            // TODO: when we know the high zxid when we get a newer snapshot
             long latestZxid = snapLog.getLastLoggedZxid();
             long consistentAt = latestZxid == -1 ? zxidRange.getLow() : latestZxid;
             zxidRange = new ZxidRange(zxidRange.getLow(), consistentAt);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupPoint.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupPoint.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup;
+
+/**
+ * Describes the point to which backups of log and snap files have been completed.
+ */
+public class BackupPoint {
+  private final long logZxid;
+  private final long snapZxid;
+
+  /**
+   * Create an instance of a BackupPoint
+   * @param logZxid the highest log zxid that has been backed up
+   * @param snapZxid the start zxid of the latest snap that has been backedup
+   */
+  public BackupPoint(long logZxid, long snapZxid) {
+    this.logZxid = logZxid;
+    this.snapZxid = snapZxid;
+  }
+
+  /**
+   * Get the zxid up to which the log has been backed up.
+   * @return the highest zxid that has been backed up
+   */
+  public long getLogZxid() { return logZxid; }
+
+  /**
+   * Get the starting zxid of the latest backed up snap
+   * @return the starting zxid of the latest backed up snap
+   */
+  public long getSnapZxid() { return snapZxid; }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupStatus.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupStatus.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.FileLock;
+
+import org.apache.jute.BinaryInputArchive;
+import org.apache.jute.BinaryOutputArchive;
+import org.apache.jute.InputArchive;
+import org.apache.jute.OutputArchive;
+
+/**
+ * Coordinate the backup status among processes local to a server;
+ * coordination across servers is better served via either an extension
+ * to the ZAB protocol or by some external mechanism.
+ */
+public class BackupStatus {
+  /**
+   * The name for the backup status file.
+   */
+  public final static String STATUS_FILENAME = "zkBackupStatus";
+
+  private final static String BACKEDUP_ZXID_TAG = "backedupLogZxid";
+  private final static String BACKEDUP_SNAP_TAG = "backedupSnapZxid";
+  private File statusFile;
+
+  /**
+   * Create an instance of BackupStatus for reading and updating the
+   * status
+   * @param backupStatusDir the directory for the backup status file
+   * @throws IOException
+   */
+  public BackupStatus(File backupStatusDir) {
+    statusFile = null;
+
+    if (backupStatusDir != null) {
+      statusFile = new File(backupStatusDir, STATUS_FILENAME);
+    }
+  }
+
+  /**
+   * Create the backup status if it does not already exist;  Initializes backup
+   * point to 0L, 0L.  Otherwise returns the current backup point.
+   * @return the current backup point
+   * @throws IOException
+   */
+  public synchronized BackupPoint createIfNeeded() throws IOException {
+    if (statusFile == null) {
+      throw new IllegalArgumentException("A backup status directory has not been specified.");
+    }
+
+    if (!statusFile.getParentFile().exists()) {
+      statusFile.getParentFile().mkdirs();
+    }
+
+    if (!statusFile.exists()) {
+      update(BackupUtil.INVALID_LOG_ZXID, BackupUtil.INVALID_SNAP_ZXID);
+    }
+
+    return read();
+  }
+
+  /**
+   * Get the latest backup point
+   * @return the latest backup point, or MAX_VALUE, MAX_VALUE if the backup
+   *      status file does not exist
+   */
+  public synchronized BackupPoint read() throws IOException {
+    BackupPoint status = new BackupPoint(Long.MAX_VALUE, Long.MAX_VALUE);
+
+    if (statusFile != null && statusFile.exists()) {
+      FileInputStream is = null;
+      FileLock fileLock = null;
+
+      // Synchronize with writers from other processes
+      try {
+        is = new FileInputStream(statusFile);
+        InputArchive ia = BinaryInputArchive.getArchive(is);
+        fileLock = is.getChannel().lock(0L, Long.MAX_VALUE, true);
+        status = new BackupPoint(ia.readLong(BACKEDUP_ZXID_TAG), ia.readLong(BACKEDUP_SNAP_TAG));
+      } finally {
+        if (fileLock != null) {
+          fileLock.release();
+        }
+
+        if (is != null) {
+          is.close();
+        }
+      }
+    }
+
+    return status;
+  }
+
+  /**
+   * Update the backup point in the status file.  Creates the status file if needed.
+   * @param backupPoint the new backup point
+   * @throws IOException
+   */
+  public synchronized void update(BackupPoint backupPoint) throws IOException {
+    update(backupPoint.getLogZxid(), backupPoint.getSnapZxid());
+  }
+
+  /**
+   * Update the backup point in the status file, Creates the status file if needed.
+   * @param logZxid the latest backed up txn log zxid
+   * @param snapZxid the starting zxid of the latest backed up snapshot
+   * @throws IOException
+   */
+  public synchronized void update(long logZxid, long snapZxid) throws IOException {
+    if (statusFile == null) {
+      throw new IllegalArgumentException("A backup status file has not been specified.");
+    }
+
+    if (!statusFile.exists()) {
+      System.out.println("Creating file " + statusFile.getAbsolutePath());
+      statusFile.createNewFile();
+    }
+
+    FileOutputStream os = null;
+    FileLock fileLock = null;
+
+    try {
+      os = new FileOutputStream(statusFile, false);
+      OutputArchive oa = BinaryOutputArchive.getArchive(os);
+      // Synchronize with readers and writers from other processes
+      fileLock = os.getChannel().lock();
+      oa.writeLong(logZxid, BACKEDUP_ZXID_TAG);
+      oa.writeLong(snapZxid, BACKEDUP_SNAP_TAG);
+    } finally {
+      if (os != null) {
+        os.flush();
+      }
+
+      if (fileLock != null) {
+        fileLock.release();
+      }
+
+      if (os != null) {
+        os.close();
+      }
+    }
+  }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupStorageProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupStorageProvider.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+/**
+ * Interface for a backup storage provider
+ */
+public interface BackupStorageProvider {
+
+  /**
+   * Get the metadata for a backed-up file with the given name.
+   * @param file the file name relative to the root of the backup storage provider
+   * @return the metadata for the backed-up file
+   * @throws IOException
+   */
+  BackupFileInfo getBackupFileInfo(File file) throws IOException;
+
+  /**
+   * Get the metadata for backedup files with the given prefix.
+   * @param path path relative to the root of the backup storage provider
+   * @param prefix The file prefix
+   * @return the list of files matching the prefix
+   * @throws IOException
+   */
+  List<BackupFileInfo> getBackupFileInfos(File path, String prefix) throws IOException;
+
+  /**
+   * Get the list of directories under the given path
+   * @param path the location from where to get the list of directories
+   * @return list of the full child directory names relative to the root of the storage provider
+   * @throws IOException
+   */
+  List<File> getDirectories(File path) throws IOException;
+
+  /**
+   * Open a file
+   * @param path the path of the file to open
+   * @return stream of the file
+   * @throws IOException
+   */
+  InputStream open(File path) throws IOException;
+
+  /**
+   * Copy a local file to backup storage.
+   * This method must guarantee a valid and transactional operation, or implement the operation
+   * in such a way that the {@link #cleanupInvalidFiles(File path) cleanup} method can cleanup
+   * after any interrupted operations.
+   * @param srcFile the local file
+   * @param destName the name to use in backup storage
+   * @throws IOException
+   */
+  void copyToBackupStorage(File srcFile, File destName) throws IOException;
+
+  /**
+   * Copy a file from backup storage to local storage
+   * @param srcName the name of the backup file to copy
+   * @param destFile the local file to which to copy the file
+   * @throws IOException
+   */
+  void copyToLocalStorage(File srcName, File destFile) throws IOException;
+
+  /**
+   * Delete a file from backup storage
+   * @param fileToDelete the name of the backup file to delete
+   * @throws IOException
+   */
+  void delete(File fileToDelete) throws IOException;
+
+  /**
+   * Cleanup any invalid files that may have been left behind by failed operations on the
+   * storage provider
+   * @throws IOException
+   */
+  void cleanupInvalidFiles(File path) throws IOException;
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupUtil.java
@@ -1,0 +1,343 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.*;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Range;
+
+import org.apache.zookeeper.server.persistence.Util;
+
+/**
+ * Utility methods related to backups
+ */
+public class BackupUtil {
+  // first valid tnxlog zxid is 1 while first valid zxid for snapshots is 0
+  public static final long INVALID_LOG_ZXID = 0;
+  public static final long INVALID_SNAP_ZXID = -1;
+  public static final String LOST_LOG_PREFIX = "lostLogs";
+
+  /**
+   * Identifiers for the two zxids in a backedup file name
+   */
+  public enum ZxidPart {
+    MIN_ZXID,
+    MAX_ZXID
+  }
+
+  /**
+   * Identifiers for the backup file types
+   */
+  public enum BackupFileType {
+    SNAPSHOT(Util.SNAP_PREFIX),
+    TXNLOG(Util.TXLOG_PREFIX),
+    LOSTLOG(BackupUtil.LOST_LOG_PREFIX);
+
+    private final String prefix;
+
+    BackupFileType(String prefix) {
+      this.prefix = prefix;
+    }
+
+    public String getPrefix() {
+      return prefix;
+    }
+
+    public static BackupFileType fromPrefix(String prefix) {
+      switch (prefix) {
+        case BackupUtil.LOST_LOG_PREFIX:
+          return LOSTLOG;
+        default:
+          return fromBaseFileType(Util.FileType.fromPrefix(prefix));
+      }
+    }
+
+    public static BackupFileType fromBaseFileType(Util.FileType type) {
+      switch (type) {
+        case SNAPSHOT:
+          return BackupFileType.SNAPSHOT;
+        case TXNLOG:
+          return BackupFileType.TXNLOG;
+        default:
+          throw new IllegalArgumentException("Unknown base file type: " + type);
+      }
+    }
+
+    public static Util.FileType toBaseFileType(BackupFileType type) {
+      switch (type) {
+        case SNAPSHOT:
+          return Util.FileType.SNAPSHOT;
+        case TXNLOG:
+          return Util.FileType.TXNLOG;
+        default:
+          throw new IllegalArgumentException("No matching base file type for: " + type);
+      }
+    }
+  }
+
+  /**
+   * Identifiers for sort direction
+   */
+  public enum SortOrder {
+    ASCENDING,
+    DESCENDING
+  }
+
+  private static class BackupFileComparator implements Comparator<BackupFileInfo>, Serializable
+  {
+    private static final long serialVersionUID = -2648639884525140318L;
+
+    private SortOrder sortOrder;
+    private ZxidPart whichZxid;
+
+    public BackupFileComparator(ZxidPart whichZxid, SortOrder sortOrder) {
+      this.sortOrder = sortOrder;
+      this.whichZxid = whichZxid;
+    }
+
+    public int compare(BackupFileInfo o1, BackupFileInfo o2) {
+      long z1 = o1.getZxid(whichZxid);
+      long z2 = o2.getZxid(whichZxid);
+
+      int result = Long.compare(z1, z2);
+
+      if (result == 0) {
+        File f1 = o1.getBackedUpFile();
+        File f2 = o2.getBackedUpFile();
+
+        result = f1.compareTo(f2);
+      }
+
+      return sortOrder == SortOrder.ASCENDING ? result : -result;
+    }
+  }
+
+  private static Function<BackupFileInfo, Range<Long>> zxidRangeExtractor =
+      new Function<BackupFileInfo, Range<Long>>() {
+        public Range<Long> apply(BackupFileInfo fileInfo) {
+          return fileInfo.getZxidRange();
+        }
+      };
+
+  public static String makeBackupName(String standardName, long highZxid) {
+    return standardName.indexOf('-') >= 0
+        ? standardName
+        : String.format("%s-%x", standardName, highZxid);
+  }
+
+  /**
+   * Helper method for getting the proper file prefix for a backup file type.
+   * @param fileType the file type whose prefix to get
+   * @return the prefix for the file
+   */
+  public static String getPrefix(BackupFileType fileType) {
+    return fileType.getPrefix();
+  }
+
+  /**
+   * Sort a list of backup files based on the specified zxid in the requested sort order
+   * @param files the files to sort
+   * @param whichZxid which zxid to sort by
+   * @param sortOrder which direction in which to sort the zxid
+   */
+  public static void sort(List<BackupFileInfo> files, ZxidPart whichZxid, SortOrder sortOrder) {
+    Collections.sort(files, new BackupFileComparator(whichZxid, sortOrder));
+  }
+
+  /**
+   * Get an zxid range from the backup file name
+   * @param name the name of the file
+   * @param prefix the prefix to match
+   * @return return the zxid range for the file
+   */
+  public static Range<Long> getZxidRangeFromName(String name, String prefix) {
+    Range<Long> zxidRange = Range.singleton(-1L);
+    String nameParts[] = name.split("[\\.-]");
+
+    if (nameParts.length == 3 && nameParts[0].equals(prefix)) {
+      try {
+        zxidRange = Range.closed(Long.parseLong(nameParts[1], 16), Long.parseLong(nameParts[2], 16));
+      } catch (NumberFormatException e) { }
+    }
+
+    return zxidRange;
+  }
+
+  /**
+   * Sort backup files by the min zxid part in ascending order
+   * @param bsp the backup provide from which to get the files
+   * @param fileType the backup file to get
+   * @return the files listed in the specified order using the request zxid
+   */
+  public static List<BackupFileInfo> getBackupFilesByMin(BackupStorageProvider bsp, BackupFileType fileType)
+      throws IOException {
+    return getBackupFilesByMin(bsp, null, fileType);
+  }
+
+  /**
+   * Sort backup files by the min zxid part in ascending order
+   * @param bsp the backup provide from which to get the files
+   * @param fileType the backup file to get
+   * @return the files listed in the specified order using the request zxid
+   */
+  public static List<BackupFileInfo> getBackupFilesByMin(
+      BackupStorageProvider bsp,
+      File path,
+      BackupFileType fileType) throws IOException {
+
+    return getBackupFiles(bsp, path, fileType, ZxidPart.MIN_ZXID, SortOrder.ASCENDING);
+  }
+
+  /**
+   * Sort backup files by the specified zxid part
+   * @param bsp the backup provide from which to get the files
+   * @param fileType the backup file to get
+   * @param whichZxid which zxid to sort by
+   * @param sortOrder which direction to sort the zxid in
+   * @return the file info for the matching files sorted on the request zxid
+   */
+  public static List<BackupFileInfo> getBackupFiles(
+      BackupStorageProvider bsp,
+      BackupFileType fileType,
+      ZxidPart whichZxid,
+      SortOrder sortOrder) throws IOException {
+
+    return getBackupFiles(bsp, null, fileType, whichZxid, sortOrder);
+  }
+
+  /**
+   * Sort backup files by the specified zxid part
+   * @param bsp the backup provide from which to get the files
+   * @param fileType the backup file to get
+   * @param whichZxid which zxid to sort by
+   * @param sortOrder which direction to sort the zxid in
+   * @return the file info for the matching files sorted on the request zxid
+   */
+  public static List<BackupFileInfo> getBackupFiles(
+      BackupStorageProvider bsp,
+      File path,
+      BackupFileType fileType,
+      ZxidPart whichZxid, SortOrder
+      sortOrder) throws IOException {
+
+    return getBackupFiles(bsp, path, new BackupFileType[] { fileType }, whichZxid, sortOrder);
+  }
+
+  /**
+   * Sort the backup files of the requested types by the specified zxid part
+   * @param bsp the backup provide from which to get the files
+   * @param fileTypes the backup file types to get
+   * @param whichZxid which zxid to sort by
+   * @param sortOrder which direction in which to sort based on the requested zxid
+   * @return the file info for the matching files sorted on the request zxid
+   */
+  public static List<BackupFileInfo> getBackupFiles(
+      BackupStorageProvider bsp,
+      BackupFileType[] fileTypes,
+      ZxidPart whichZxid,
+      SortOrder sortOrder) throws IOException {
+
+    return getBackupFiles(bsp, null, fileTypes, whichZxid, sortOrder);
+  }
+
+  /**
+   * Sort the backup files of the requested types by the specified zxid part
+   * @param bsp the backup provide from which to get the files
+   * @param fileTypes the backup file types to get
+   * @param whichZxid which zxid to sort by
+   * @param sortOrder which direction in which to sort based on the requested zxid
+   * @return the file info for the matching files sorted on the request zxid
+   */
+  public static List<BackupFileInfo> getBackupFiles(
+      BackupStorageProvider bsp,
+      File path,
+      BackupFileType[] fileTypes,
+      ZxidPart whichZxid,
+      SortOrder sortOrder) throws IOException {
+
+    List<BackupFileInfo> files = new ArrayList<BackupFileInfo>();
+
+    if (fileTypes.length == 1) {
+      files = bsp.getBackupFileInfos(path, getPrefix(fileTypes[0]));
+    } else {
+      for (BackupFileType fileType : fileTypes) {
+        files.addAll(bsp.getBackupFileInfos(path, getPrefix(fileType)));
+      }
+    }
+
+    sort(files, whichZxid, sortOrder);
+    return files;
+  }
+
+  /**
+   * Get the latest backup file of the given type.
+   * @param bsp the backup storage provider
+   * @param fileType the file to get
+   * @param whichZxid sorted based on which zxid
+   * @return the latest backup file if one exists, null otherwise
+   * @throws IOException
+   */
+  public static BackupFileInfo getLatest(
+      BackupStorageProvider bsp,
+      BackupFileType fileType,
+      ZxidPart whichZxid) throws IOException {
+    List<BackupFileInfo> files = getBackupFiles(bsp, fileType, whichZxid, SortOrder.DESCENDING);
+
+    return files.isEmpty() ? null : files.get(0);
+  }
+
+  /**
+   * Get both the zxids for each of the files matching the prefix
+   * @param bsp the backup storage provide to get the files from
+   * @param fileType the backup file to get
+   * @return the list of zxid pairs
+   * @throws IOException
+   */
+  public static List<Range<Long>> getZxids(BackupStorageProvider bsp, BackupFileType fileType)
+      throws IOException {
+
+    return getZxids(bsp, null, fileType);
+  }
+
+  /**
+   * Get both the zxids for each of the files matching the prefix
+   * @param bsp the backup storage provide to get the files from
+   * @param fileType the backup file to get
+   * @return the list of zxid pairs
+   * @throws IOException
+   */
+  public static List<Range<Long>> getZxids(
+      BackupStorageProvider bsp,
+      File path,
+      BackupFileType fileType) throws IOException {
+
+    return Lists.newArrayList(
+        Lists.transform(
+            getBackupFiles(bsp, path, fileType, ZxidPart.MIN_ZXID, SortOrder.ASCENDING),
+            zxidRangeExtractor));
+  }
+
+  // Utility class
+  private BackupUtil() {}
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileSnap.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileSnap.java
@@ -32,6 +32,7 @@ import org.apache.jute.InputArchive;
 import org.apache.jute.OutputArchive;
 import org.apache.zookeeper.server.DataTree;
 import org.apache.zookeeper.server.util.SerializeUtils;
+import org.eclipse.jetty.util.IO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -199,6 +200,29 @@ public class FileSnap implements SnapShot {
             }
             if (Util.getZxidFromName(f.getName(), SNAPSHOT_FILE_PREFIX) != -1) {
                 count++;
+                list.add(f);
+            }
+        }
+        return list;
+    }
+
+    /**
+     * returns all valid snapshots excluding the zxid interval given
+     * for example, if the interval given is [A, B], then snapshot.B will not be included in the
+     * returned list
+     * @param startZxid starting zxid of the interval
+     * @param endZxid ending zxid of the interval
+     * @return all valid snapshots excluding the snapshots whose last processed zxid does not fall
+     * into the interval (startZxid, endZxid) given
+     * @throws IOException
+     */
+    public List<File> findValidSnapshots(long startZxid, long endZxid) throws IOException {
+        List<File> files = Util.sortDataDir(snapDir.listFiles(), SNAPSHOT_FILE_PREFIX, false);
+        List<File> list = new ArrayList<>();
+        for (File f : files) {
+            long zxidFromName = Util.getZxidFromName(f.getName(), SNAPSHOT_FILE_PREFIX);
+            if (SnapStream.isValidSnapshot(f) && (zxidFromName < startZxid ||
+                zxidFromName > endZxid)) {
                 list.add(f);
             }
         }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnLog.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnLog.java
@@ -202,6 +202,14 @@ public class FileTxnLog implements TxnLog, Closeable {
     }
 
     /**
+     * Returns the reference to the current log file.
+     * @return
+     */
+    public synchronized File getCurrentFile() {
+        return logFileWrite;
+    }
+
+    /**
      * Return the current on-disk size of log size. This will be accurate only
      * after commit() is called. Otherwise, unflushed txns may not be included.
      */

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
@@ -560,6 +560,20 @@ public class FileTxnSnapLog {
     }
 
     /**
+     * returns all valid snapshots excluding the zxid interval given
+     * for example, if the interval given is [A, B], then snapshot.B will not be included in the
+     * returned list
+     * @param startZxid start of the zxid interval
+     * @param endZxid end of the zxid interval
+     * @return the list of snapshots in the most recent in front
+     * @throws IOException
+     */
+    public List<File> findValidSnapshots(long startZxid, long endZxid) throws IOException {
+        FileSnap snaplog = new FileSnap(snapDir);
+        return snaplog.findValidSnapshots(startZxid, endZxid);
+    }
+
+    /**
      * get the snapshot logs which may contain transactions newer than the given zxid.
      * This includes logs with starting zxid greater than given zxid, as well as the
      * newest transaction log with starting zxid less than given zxid.  The latter log

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/Util.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/Util.java
@@ -45,6 +45,28 @@ import org.slf4j.LoggerFactory;
  */
 public class Util {
 
+    /**
+     * Constants and enums added for backup and restore.
+     */
+    public static final String SNAP_PREFIX = FileSnap.SNAPSHOT_FILE_PREFIX;
+    public static final String TXLOG_PREFIX = FileTxnLog.LOG_FILE_PREFIX;
+
+    public enum FileType {
+        SNAPSHOT,
+        TXNLOG;
+
+        public static FileType fromPrefix(String prefix) {
+            switch (prefix) {
+                case SNAP_PREFIX:
+                    return SNAPSHOT;
+                case TXLOG_PREFIX:
+                    return TXNLOG;
+                default:
+                    throw new IllegalArgumentException("Unknown FileType prefix: " + prefix);
+            }
+        }
+    }
+
     private static final Logger LOG = LoggerFactory.getLogger(Util.class);
     private static final String SNAP_DIR = "snapDir";
     private static final String LOG_DIR = "logDir";

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/Util.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/Util.java
@@ -170,6 +170,26 @@ public class Util {
     }
 
     /**
+     * Returns a ZxidRange whose high Zxid could be absent.
+     * @param name
+     * @param prefix
+     * @return
+     */
+    public static ZxidRange getZxidRangeFromName(String name, String prefix) {
+        ZxidRange zxidRange = ZxidRange.INVALID;
+        String nameParts[] = name.split("[\\.-]");
+        try {
+            if (nameParts.length == 2 && nameParts[0].equals(prefix)) {
+                zxidRange = new ZxidRange(Long.parseLong(nameParts[1], 16));
+            } else if (nameParts.length == 3 && nameParts[0].equals(prefix)) {
+                zxidRange = new ZxidRange(Long.parseLong(nameParts[1], 16),
+                    Long.parseLong(nameParts[2], 16));
+            }
+        } catch (NumberFormatException e) {}
+        return zxidRange;
+    }
+
+    /**
      * Reads a transaction entry from the input archive.
      * @param ia archive to read from
      * @return null if the entry is corrupted or EOF has been reached; a buffer

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/ZxidRange.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/ZxidRange.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.persistence;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Range;
+
+/**
+ * A range of Zxids with an optional high zxid.
+ */
+public class ZxidRange {
+  public static final ZxidRange INVALID = new ZxidRange(-1L, Optional.of(-1L), true);
+
+  private long low;
+  private Optional<Long> high;
+
+  private ZxidRange(long low, Optional<Long> high, boolean allowNeg) {
+    Preconditions.checkNotNull(high);
+    Preconditions.checkArgument(allowNeg || low >= 0, "Zxid must be 0 or greater");
+    Preconditions.checkArgument(allowNeg || !high.isPresent() || high.get() >= 0,
+        "Zxid must be 0 or greater");
+    Preconditions.checkArgument(!high.isPresent() || low <= high.get(),
+        "Invalid zxid range, low must not be greater than high");
+
+    this.low = low;
+    this.high = high;
+  }
+
+  public ZxidRange(long low, long high) {
+    this(low, Optional.of(high), false);
+  }
+
+  public ZxidRange(long low) {
+    this(low, Optional.<Long>absent(), false);
+  }
+
+  public ZxidRange(Range<Long> range) {
+    this(range.lowerEndpoint(), range.upperEndpoint());
+  }
+
+  public static ZxidRange parse(String value) {
+    String[] zxidParts = value.split("-");
+
+    if (zxidParts.length == 1 && !value.endsWith("-")) {
+      try {
+        return new ZxidRange(Long.parseLong(zxidParts[0], 16));
+      } catch (NumberFormatException e) { }
+    } else if (zxidParts.length == 2) {
+      try {
+        return new ZxidRange(Long.parseLong(zxidParts[0], 16), Long.parseLong(zxidParts[1], 16));
+      } catch (NumberFormatException e) { }
+    }
+
+    return ZxidRange.INVALID;
+  }
+
+  public Range<Long> toRange() {
+    return Range.closed(low, high.isPresent() ? high.get() : Long.MAX_VALUE);
+  }
+
+  public long getLow() {
+    return low;
+  }
+
+  public long getHigh() {
+    Preconditions.checkState(high.isPresent());
+    return high.get();
+  }
+
+  public boolean isHighPresent() {
+    return high.isPresent();
+  }
+}


### PR DESCRIPTION
This PR includes the following changes:

- Removes all proprietary implementations
- Implements methods that are necessary to build for backup

_________________

More detailed implementation notes are available below:

- Classes added:

**POJO**
```
BackupFileInfo
BackupUtil
ZxidRange
BackupManager
BackupStatus
BackupPoint
BackupStats
```
**Interface**
`BackupStorageProvider`

- Logic that needs to be re-implemented that were removed in this particular implementation (due to the use of proprietary libraries/logic - compare to https://github.com/apache/zookeeper/pull/1492/files)
```
MetricsReceiver
BackupStats
```

- Logic/classes that were changed and implemented anew:
org.apache.zookeeper.server.persistence.Util
Util.getZxidRangeFromName
	the difference between BackupUtil.getZxidRangeFromName is that the return value is different.
	this one needs to return ZxidRange whereas BackupUtil's returns Range
FileTxnSnapLog.findValidSnapshots(long start, long end)

- Style changes:
```
org.apache.zookeeper.server.backup.BackupStatus
org.apache.zookeeper.server.backup.BackupPoint (ZK Apache License and make fields final)
```

- Things to consider to simplify the implementation:
`getZxidRangeFromName()` -> just use one range instead of having it in Util and BackupUtil since we are going to continue creating snapshots with one Zxid (lastProcessedZxid)