### PR TITLE
Deploy binary assembly tarball to Bintray  

### DIFF
--- a/zookeeper-assembly/pom.xml
+++ b/zookeeper-assembly/pom.xml
@@ -168,8 +168,8 @@
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
         <configuration>
-          <!-- this module isn't to be deployed to Maven Central -->
-          <skip>true</skip>
+          <!-- Deploy binary assembly to bintray -->
+          <skip>false</skip>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
### Description
Resolve #17 

Also deploy the binary tarball so server deployment can directly use the tarball without building it from source.

### Testing
Tested in a pre-release and the tarball ` zookeeper-assembly-3.6.2.1-rc4.tar.gz` is deployed to Bintray: 
<img width="949" alt="image" src="https://user-images.githubusercontent.com/5187721/102857699-c365e380-43dd-11eb-9ae9-820713323214.png">
