### PR TITLE
Implement BackupConfig, BackupStorageType, BackupSystemProperty

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/ConfigException.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/ConfigException.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.common;
+
+public class ConfigException extends Exception {
+  public ConfigException(String msg) {
+    super(msg);
+  }
+
+  public ConfigException(String msg, Exception exception) {
+    super(msg, exception);
+  }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -18,26 +18,98 @@
 
 package org.apache.zookeeper.server.backup;
 
+import java.io.File;
+import java.util.Optional;
+import java.util.Properties;
+
+import org.apache.zookeeper.common.ConfigException;
+import org.apache.zookeeper.server.util.VerifyingFileFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
- * Backup-related configurations
+ * Backup-related configurations.
  */
 public class BackupConfig {
-  public static final String NFS_BACKUP_STORAGE = "NFSBackupStorage";
-  private final String storageProviderClassName;
-  private final String mountPath;
-  private final String namespace;
-  private final int retentionPeriodInDays;
+  private static final Logger LOG = LoggerFactory.getLogger(BackupConfig.class);
 
-  private BackupConfig(String storageProviderClassName, String mountPath, String namespace,
-      int retentionPeriodInDays) {
-    this.storageProviderClassName = storageProviderClassName;
-    this.mountPath = mountPath;
-    this.namespace = namespace;
-    this.retentionPeriodInDays = retentionPeriodInDays;
+  /*
+   * Default constants
+   */
+  private static final boolean DEFAULT_BACKUP_ENABLED = false;
+  public static final int DEFAULT_RETENTION_DAYS = 20;
+  public static final long DEFAULT_BACKUP_INTERVAL_MS = 30 * 60 * 1000L; // 30 minutes
+  /*
+   * For retention maintenance, -1 indicates no maintenance by default.
+   * Some storage backends support TTL natively.
+   */
+  public static final long DEFAULT_RETENTION_MAINTENANCE_INTERVAL_MS = -1L;
+
+  private final File statusDir;
+  private final File tmpDir;
+  private final long backupIntervalInMs;
+  private final int retentionPeriodInDays;
+  private final long retentionMaintenanceIntervalInMs;
+  /*
+   * Fully-qualified Java class name for the storage implementation. See BackupStorageType.java
+   * for example.
+   */
+  private final String storageProviderClassName;
+  /*
+   * Storage config file (optional).
+   * E.g.) HDFS config
+   */
+  private final File storageConfig;
+  /*
+   * The custom path under which the backup files will be stored in.
+   */
+  private final String mountPath;
+  /*
+   * The custom namespace string under which the backup files will be stored in.
+   * E.g.) <mountPath>/<namespace>/snapshot/snapshot-123456
+   *       <mountPath>/<namespace>/translog/translog-123456
+   */
+  private final String namespace;
+
+  public BackupConfig(Builder builder) {
+    this.statusDir = builder.statusDir.get();
+    this.tmpDir = builder.tmpDir.get();
+    this.backupIntervalInMs = builder.backupIntervalInMs.orElse(DEFAULT_BACKUP_INTERVAL_MS);
+    this.retentionPeriodInDays = builder.retentionPeriodInDays.orElse(DEFAULT_RETENTION_DAYS);
+    this.retentionMaintenanceIntervalInMs =
+        builder.retentionMaintenanceIntervalInMs.orElse(DEFAULT_RETENTION_MAINTENANCE_INTERVAL_MS);
+    this.storageProviderClassName = builder.storageProviderClassName.get();
+    this.storageConfig = builder.storageConfig.orElse(null);
+    this.mountPath = builder.mountPath.orElse("");
+    this.namespace = builder.namespace.orElse("");
+  }
+
+  public File getStatusDir() {
+    return statusDir;
+  }
+
+  public File getTmpDir() {
+    return tmpDir;
+  }
+
+  public long getBackupInterval() {
+    return backupIntervalInMs;
+  }
+
+  public int getRetentionPeriod() {
+    return retentionPeriodInDays;
+  }
+
+  public long getRetentionMaintenanceInterval() {
+    return retentionMaintenanceIntervalInMs;
   }
 
   public String getStorageProviderClassName() {
     return storageProviderClassName;
+  }
+
+  public File getStorageConfig() {
+    return storageConfig;
   }
 
   public String getMountPath() {
@@ -48,52 +120,214 @@ public class BackupConfig {
     return namespace;
   }
 
-  public int getRetentionPeriodInDays() {
-    return retentionPeriodInDays;
-  }
-
   public static class Builder {
-    private String _storageProviderClassName;
-    private String _mountPath;
-    private String _namespace;
-    private int _retentionPeriodInDays = 20;
+    private static final VerifyingFileFactory vff =
+        new VerifyingFileFactory.Builder(LOG).warnForRelativePath().build();
 
-    public Builder setStorageProviderClassName(String storageProviderClassName) {
-      _storageProviderClassName = storageProviderClassName;
+    private Optional<Boolean> enabled = Optional.empty();
+    private Optional<File> statusDir = Optional.empty();
+    private Optional<File> tmpDir = Optional.empty();
+    private Optional<Long> backupIntervalInMs = Optional.of(DEFAULT_BACKUP_INTERVAL_MS);
+    private Optional<Integer> retentionPeriodInDays = Optional.of(DEFAULT_RETENTION_DAYS);
+    private Optional<Long> retentionMaintenanceIntervalInMs =
+        Optional.of(DEFAULT_RETENTION_MAINTENANCE_INTERVAL_MS);
+    private Optional<String> storageProviderClassName = Optional.empty();
+    private Optional<File> storageConfig = Optional.empty();
+    private Optional<String> mountPath = Optional.empty();
+    private Optional<String> namespace = Optional.empty();
+
+    public Builder setEnabled(boolean enabled) {
+      this.enabled = Optional.of(enabled);
       return this;
     }
 
-    public Builder setMountPath(String mountPath) {
-      _mountPath = mountPath;
+    public Builder setStatusDir(File dir) {
+      this.statusDir = Optional.of(dir);
       return this;
     }
 
-    public Builder setNamespace(String namespace) {
-      this._namespace = namespace;
+    public Builder setTmpDir(File dir) {
+      this.tmpDir = Optional.of(dir);
+      return this;
+    }
+
+    public Builder setBackupInterval(long intervalInMs) {
+      this.backupIntervalInMs = Optional.of(intervalInMs);
       return this;
     }
 
     public Builder setRetentionPeriodInDays(int retentionPeriodInDays) {
-      this._retentionPeriodInDays = retentionPeriodInDays;
+      this.retentionPeriodInDays = Optional.of(retentionPeriodInDays);
       return this;
     }
 
-    public BackupConfig build() {
-      validate();
-      return new BackupConfig(_storageProviderClassName, _mountPath, _namespace,
-          _retentionPeriodInDays);
+    public Builder setRetentionMaintenanceInterval(long retentionMaintenanceInterval) {
+      this.retentionMaintenanceIntervalInMs = Optional.of(retentionMaintenanceInterval);
+      return this;
     }
 
-    private void validate() {
-      if (_storageProviderClassName == null) {
-        throw new IllegalArgumentException(
-            "Please specify a storage provider as the backup storage.");
+    public Builder setStorageProviderClassName(String storageProviderClassName) {
+      this.storageProviderClassName = Optional.of(storageProviderClassName);
+      return this;
+    }
+
+    public Builder setStorageConfig(File storageConfig) {
+      this.storageConfig = Optional.of(storageConfig);
+      return this;
+    }
+
+    public Builder setMountPath(String mountPath) {
+      this.mountPath = Optional.of(mountPath);
+      return this;
+    }
+
+    public Builder setNamespace(String namespace) {
+      this.namespace = Optional.of(namespace);
+      return this;
+    }
+
+    public Builder withProperties(Properties properties) throws ConfigException {
+      return withProperties(properties, "");
+    }
+
+    public Builder withProperties(Properties properties, String prefix) throws ConfigException {
+      {
+        String key = prefix + BackupSystemProperty.BACKUP_ENABLED;
+        String prop = properties.getProperty(key);
+        if (prop != null) {
+          this.enabled = Optional.of(parseBoolean(key, prop));
+        }
       }
-      if (_namespace == null) {
-        throw new IllegalArgumentException("Please specify a namespace for this host.");
+      {
+        String key = prefix + BackupSystemProperty.BACKUP_STATUS_DIR;
+        String prop = properties.getProperty(key);
+        if (prop != null) {
+          this.statusDir = Optional.of(vff.create(prop));
+        }
       }
-      if (_storageProviderClassName.equals(NFS_BACKUP_STORAGE) && _mountPath == null) {
-        throw new IllegalArgumentException("Please specify a mount path for NFS client.");
+      {
+        String key = prefix + BackupSystemProperty.BACKUP_TMP_DIR;
+        String prop = properties.getProperty(key);
+        if (prop != null) {
+          this.tmpDir = Optional.of(vff.create(prop));
+        }
+      }
+      {
+        String key = prefix + BackupSystemProperty.BACKUP_INTERVAL_MS;
+        String prop = properties.getProperty(key);
+        if (prop != null) {
+          long ms = parseLong(key, prop);
+          this.backupIntervalInMs = Optional.of(ms);
+        }
+      }
+      {
+        String key = prefix + BackupSystemProperty.BACKUP_STORAGE_CONFIG;
+        String prop = properties.getProperty(key);
+        if (prop != null) {
+          this.storageConfig = Optional.of(vff.create(prop));
+        }
+      }
+      {
+        String key = prefix + BackupSystemProperty.BACKUP_MOUNT_PATH;
+        String prop = properties.getProperty(key);
+        if (prop != null) {
+          this.mountPath = Optional.of(prop);
+        }
+      }
+      {
+        String key = prefix + BackupSystemProperty.BACKUP_RETENTION_DAYS;
+        String prop = properties.getProperty(key);
+        if (prop != null) {
+          this.retentionPeriodInDays = Optional.of(parseInt(key, prop));
+        }
+      }
+      {
+        String key = prefix + BackupSystemProperty.BACKUP_RETENTION_MAINTENANCE_INTERVAL_MS;
+        String prop = properties.getProperty(key);
+        if (prop != null) {
+          long ms = parseLong(key, prop);
+          this.retentionMaintenanceIntervalInMs = Optional.of(ms);
+        }
+      }
+      {
+        String key = prefix + BackupSystemProperty.BACKUP_STORAGE_PROVIDER_CLASS_NAME;
+        String prop = properties.getProperty(key);
+        if (prop != null) {
+          this.storageProviderClassName = Optional.of(prop);
+        }
+      }
+      {
+        String key = prefix + BackupSystemProperty.BACKUP_NAMESPACE;
+        String prop = properties.getProperty(key);
+        if (prop != null) {
+          this.namespace = Optional.of(prop);
+        }
+      }
+      return this;
+    }
+
+    protected Builder withProperty(String key, String val) throws ConfigException {
+      Properties properties = new Properties();
+      properties.setProperty(key, val);
+      return withProperties(properties);
+    }
+
+    private static long parseLong(String key, String value) throws ConfigException {
+      try {
+        return Long.parseLong(value);
+      } catch (NumberFormatException exc) {
+        throw new ConfigException(String.format("parsing %s", key), exc);
+      }
+    }
+
+    private static int parseInt(String key, String value) throws ConfigException {
+      try {
+        return Integer.parseInt(value);
+      } catch (NumberFormatException exc) {
+        throw new ConfigException(String.format("parsing %s", key), exc);
+      }
+    }
+
+    private static boolean parseBoolean(String key, String value) {
+      boolean result;
+      switch (value.toLowerCase()) {
+        case "yes":
+          result = true;
+          break;
+        case "no":
+          result = false;
+          break;
+        default:
+          result = Boolean.parseBoolean(value);
+          break;
+      }
+      return result;
+    }
+
+    public Optional<BackupConfig> build() throws ConfigException {
+      final Optional<BackupConfig> result;
+      if (enabled.orElse(DEFAULT_BACKUP_ENABLED)) {
+        validate();
+        result = Optional.of(new BackupConfig(this));
+      } else {
+        result = Optional.empty();
+      }
+      return result;
+    }
+
+    /**
+     * Validates the backup config. Makes sure that required fields are present.
+     * @throws ConfigException
+     */
+    private void validate() throws ConfigException {
+      if (!statusDir.isPresent()) {
+        throw new ConfigException("BackupConfig statusDir not specified");
+      }
+      if (!tmpDir.isPresent()) {
+        throw new ConfigException("BackupConfig tmpDir not specified");
+      }
+      if (!storageProviderClassName.isPresent() || storageProviderClassName.get().equals("")) {
+        throw new ConfigException("Please specify a valid storage provider class name.");
       }
     }
   }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupSystemProperty.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupSystemProperty.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup;
+
+/**
+ * System property Strings for ZooKeeper backup.
+ */
+public class BackupSystemProperty {
+  public static final String BACKUP_ENABLED = "backup.enabled";
+  public static final String BACKUP_STATUS_DIR = "backup.statusDir";
+  public static final String BACKUP_TMP_DIR = "backup.tmpDir";
+  public static final String BACKUP_INTERVAL_MS = "backup.intervalMs";
+  public static final String BACKUP_RETENTION_DAYS = "backup.retentionDays";
+  public static final String BACKUP_RETENTION_MAINTENANCE_INTERVAL_MS =
+      "backup.retentionMaintenanceIntervalMs";
+  public static final String BACKUP_STORAGE_PROVIDER_CLASS_NAME = "backup.storageProviderClassName";
+  public static final String BACKUP_STORAGE_CONFIG = "backup.storageConfig";
+  public static final String BACKUP_MOUNT_PATH = "backup.mountPath";
+  public static final String BACKUP_NAMESPACE = "backup.namespace";
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/BackupConfigTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/BackupConfigTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.zookeeper.server.backup;
+
+import java.io.File;
+
+import org.apache.zookeeper.common.ConfigException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BackupConfigTest {
+  private static final File DEFAULT_STATUS_DIR = new File("/backup/status");
+  private static final File DEFAULT_TMP_DIR = new File("/tmp/backup");
+  private static final File DEFAULT_STORAGE_CONFIG = new File("/storage/config");
+  private static final String DEFAULT_STORAGE_MOUNT_PATH = "/storage/path";
+  // Use LocalBackupStorage for testing
+  private static final String DEFAULT_STORAGE_PROVIDER_CLASS_NAME =
+      "org.apache.zookeeper.server.backup.storage.impl.LocalBackupStorage";
+
+  @Test
+  public void testEnabled() throws Exception {
+    assertFalse(new BackupConfig.Builder().build().isPresent());
+    assertTrue(builder().build().isPresent());
+    assertFalse(
+        builder().withProperty(BackupSystemProperty.BACKUP_ENABLED, "false").build().isPresent());
+    assertTrue(
+        builder().withProperty(BackupSystemProperty.BACKUP_ENABLED, "true").build().isPresent());
+  }
+
+  @Test
+  public void testStatusDir() throws Exception {
+    try {
+      new BackupConfig.Builder().setEnabled(true).setTmpDir(DEFAULT_TMP_DIR)
+          .setStorageConfig(DEFAULT_STORAGE_CONFIG).setMountPath(DEFAULT_STORAGE_MOUNT_PATH)
+          .build();
+      assertTrue(false);
+    } catch (ConfigException exc) {
+      assertTrue(true);
+    }
+
+    assertEquals(DEFAULT_STATUS_DIR, builder().build().get().getStatusDir());
+    File expected = new File("/expected");
+    assertEquals(expected, builder().setStatusDir(expected).build().get().getStatusDir());
+    assertEquals(expected,
+        builder().withProperty(BackupSystemProperty.BACKUP_STATUS_DIR, expected.getAbsolutePath())
+            .build().get().getStatusDir());
+  }
+
+  @Test
+  public void testTmpDir() throws Exception {
+    try {
+      new BackupConfig.Builder().setEnabled(true).setStatusDir(DEFAULT_STATUS_DIR)
+          .setStorageConfig(DEFAULT_STORAGE_CONFIG).setMountPath(DEFAULT_STORAGE_MOUNT_PATH)
+          .build();
+      assertTrue(false);
+    } catch (ConfigException exc) {
+      assertTrue(true);
+    }
+
+    assertEquals(DEFAULT_TMP_DIR, builder().build().get().getTmpDir());
+    File expected = new File("/expected");
+    assertEquals(expected, builder().setTmpDir(expected).build().get().getTmpDir());
+    assertEquals(expected,
+        builder().withProperty(BackupSystemProperty.BACKUP_TMP_DIR, expected.getAbsolutePath())
+            .build().get().getTmpDir());
+  }
+
+  @Test
+  public void testInterval() throws Exception {
+    assertEquals(BackupConfig.DEFAULT_BACKUP_INTERVAL_MS,
+        builder().build().get().getBackupInterval());
+    long expectedInterval = 3 * 60 * 1000L; // 3 minutes
+    assertEquals(expectedInterval,
+        builder().setBackupInterval(expectedInterval).build().get().getBackupInterval());
+    assertEquals(expectedInterval, builder()
+        .withProperty(BackupSystemProperty.BACKUP_INTERVAL_MS, "180000") // 180000 ms = 3 min
+        .build().get().getBackupInterval());
+  }
+
+  @Test
+  public void testStorageConfig() throws Exception {
+    try {
+      new BackupConfig.Builder().setEnabled(true).setStatusDir(DEFAULT_STATUS_DIR)
+          .setTmpDir(DEFAULT_TMP_DIR).setMountPath(DEFAULT_STORAGE_MOUNT_PATH).build();
+      assertTrue(false);
+    } catch (ConfigException exc) {
+      assertTrue(true);
+    }
+
+    assertEquals(DEFAULT_STORAGE_CONFIG, builder().build().get().getStorageConfig());
+    File expected = new File("/expected");
+    assertEquals(expected, builder().setStorageConfig(expected).build().get().getStorageConfig());
+    assertEquals(expected, builder()
+        .withProperty(BackupSystemProperty.BACKUP_STORAGE_CONFIG, expected.getAbsolutePath())
+        .build().get().getStorageConfig());
+  }
+
+  @Test
+  public void testMountPath() throws Exception {
+    try {
+      new BackupConfig.Builder().setEnabled(true).setStatusDir(DEFAULT_STATUS_DIR)
+          .setTmpDir(DEFAULT_TMP_DIR).setStorageConfig(DEFAULT_STORAGE_CONFIG).build();
+      assertTrue(false);
+    } catch (ConfigException exc) {
+      assertTrue(true);
+    }
+
+    assertEquals(DEFAULT_STORAGE_MOUNT_PATH, builder().build().get().getMountPath());
+    String expected = "/expected";
+    assertEquals(expected, builder().setMountPath(expected).build().get().getMountPath());
+    assertEquals(expected,
+        builder().withProperty(BackupSystemProperty.BACKUP_MOUNT_PATH, expected).build().get()
+            .getMountPath());
+  }
+
+  @Test
+  public void testRetentionPeriod() throws Exception {
+    assertEquals(BackupConfig.DEFAULT_RETENTION_DAYS, builder().build().get().getRetentionPeriod());
+    int expected = BackupConfig.DEFAULT_RETENTION_DAYS;
+    assertEquals(expected,
+        builder().setRetentionPeriodInDays(expected).build().get().getRetentionPeriod());
+    assertEquals(expected,
+        builder().withProperty(BackupSystemProperty.BACKUP_RETENTION_DAYS, "20").build().get()
+            .getRetentionPeriod());
+  }
+
+  @Test
+  public void testRetentionMaintenanceInterval() throws Exception {
+    assertEquals(BackupConfig.DEFAULT_RETENTION_MAINTENANCE_INTERVAL_MS,
+        builder().build().get().getRetentionMaintenanceInterval());
+    long expected = 3 * 60 * 60 * 1000L; // 3 hours
+    assertEquals(expected, builder().setRetentionMaintenanceInterval(expected).build().get()
+        .getRetentionMaintenanceInterval());
+    assertEquals(expected, builder()
+        .withProperty(BackupSystemProperty.BACKUP_RETENTION_MAINTENANCE_INTERVAL_MS, "10800000")
+        .build().get().getRetentionMaintenanceInterval());
+  }
+
+  private BackupConfig.Builder builder() {
+    return new BackupConfig.Builder().setEnabled(true).setStatusDir(DEFAULT_STATUS_DIR)
+        .setTmpDir(DEFAULT_TMP_DIR).setStorageConfig(DEFAULT_STORAGE_CONFIG)
+        .setMountPath(DEFAULT_STORAGE_MOUNT_PATH)
+        .setStorageProviderClassName(DEFAULT_STORAGE_PROVIDER_CLASS_NAME);
+  }
+}


### PR DESCRIPTION
In order to allow the zk server to read the necessary configs for backup, we need to create a POJO class that encapsulates such configs. This change implements such components in a generalized way, meaning it's not tied to a particular storage implementation. BackupConfigTest has been added as well.