### PR TITLE
Refactor NfsBackupStorage to FileSystemBackupStorage

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupConfig.java
@@ -63,11 +63,11 @@ public class BackupConfig {
   /*
    * The custom path under which the backup files will be stored in.
    */
-  private final String mountPath;
+  private final String backupStoragePath;
   /*
    * The custom namespace string under which the backup files will be stored in.
-   * E.g.) <mountPath>/<namespace>/snapshot/snapshot-123456
-   *       <mountPath>/<namespace>/translog/translog-123456
+   * E.g.) <backupStoragePath>/<namespace>/snapshot/snapshot-123456
+   *       <backupStoragePath>/<namespace>/translog/translog-123456
    */
   private final String namespace;
 
@@ -80,7 +80,7 @@ public class BackupConfig {
         builder.retentionMaintenanceIntervalInMs.orElse(DEFAULT_RETENTION_MAINTENANCE_INTERVAL_MS);
     this.storageProviderClassName = builder.storageProviderClassName.get();
     this.storageConfig = builder.storageConfig.orElse(null);
-    this.mountPath = builder.mountPath.orElse("");
+    this.backupStoragePath = builder.backupStoragePath.orElse("");
     this.namespace = builder.namespace.orElse("");
   }
 
@@ -112,8 +112,8 @@ public class BackupConfig {
     return storageConfig;
   }
 
-  public String getMountPath() {
-    return mountPath;
+  public String getBackupStoragePath() {
+    return backupStoragePath;
   }
 
   public String getNamespace() {
@@ -133,7 +133,7 @@ public class BackupConfig {
         Optional.of(DEFAULT_RETENTION_MAINTENANCE_INTERVAL_MS);
     private Optional<String> storageProviderClassName = Optional.empty();
     private Optional<File> storageConfig = Optional.empty();
-    private Optional<String> mountPath = Optional.empty();
+    private Optional<String> backupStoragePath = Optional.empty();
     private Optional<String> namespace = Optional.empty();
 
     public Builder setEnabled(boolean enabled) {
@@ -176,8 +176,8 @@ public class BackupConfig {
       return this;
     }
 
-    public Builder setMountPath(String mountPath) {
-      this.mountPath = Optional.of(mountPath);
+    public Builder setBackupStoragePath(String backupStoragePath) {
+      this.backupStoragePath = Optional.of(backupStoragePath);
       return this;
     }
 
@@ -231,7 +231,7 @@ public class BackupConfig {
         String key = prefix + BackupSystemProperty.BACKUP_MOUNT_PATH;
         String prop = properties.getProperty(key);
         if (prop != null) {
-          this.mountPath = Optional.of(prop);
+          this.backupStoragePath = Optional.of(prop);
         }
       }
       {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/BackupConfigTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/BackupConfigTest.java
@@ -51,7 +51,7 @@ public class BackupConfigTest {
   public void testStatusDir() throws Exception {
     try {
       new BackupConfig.Builder().setEnabled(true).setTmpDir(DEFAULT_TMP_DIR)
-          .setStorageConfig(DEFAULT_STORAGE_CONFIG).setMountPath(DEFAULT_STORAGE_MOUNT_PATH)
+          .setStorageConfig(DEFAULT_STORAGE_CONFIG).setBackupStoragePath(DEFAULT_STORAGE_MOUNT_PATH)
           .build();
       assertTrue(false);
     } catch (ConfigException exc) {
@@ -70,7 +70,7 @@ public class BackupConfigTest {
   public void testTmpDir() throws Exception {
     try {
       new BackupConfig.Builder().setEnabled(true).setStatusDir(DEFAULT_STATUS_DIR)
-          .setStorageConfig(DEFAULT_STORAGE_CONFIG).setMountPath(DEFAULT_STORAGE_MOUNT_PATH)
+          .setStorageConfig(DEFAULT_STORAGE_CONFIG).setBackupStoragePath(DEFAULT_STORAGE_MOUNT_PATH)
           .build();
       assertTrue(false);
     } catch (ConfigException exc) {
@@ -101,7 +101,7 @@ public class BackupConfigTest {
   public void testStorageConfig() throws Exception {
     try {
       new BackupConfig.Builder().setEnabled(true).setStatusDir(DEFAULT_STATUS_DIR)
-          .setTmpDir(DEFAULT_TMP_DIR).setMountPath(DEFAULT_STORAGE_MOUNT_PATH).build();
+          .setTmpDir(DEFAULT_TMP_DIR).setBackupStoragePath(DEFAULT_STORAGE_MOUNT_PATH).build();
       assertTrue(false);
     } catch (ConfigException exc) {
       assertTrue(true);
@@ -125,12 +125,12 @@ public class BackupConfigTest {
       assertTrue(true);
     }
 
-    assertEquals(DEFAULT_STORAGE_MOUNT_PATH, builder().build().get().getMountPath());
+    assertEquals(DEFAULT_STORAGE_MOUNT_PATH, builder().build().get().getBackupStoragePath());
     String expected = "/expected";
-    assertEquals(expected, builder().setMountPath(expected).build().get().getMountPath());
+    assertEquals(expected, builder().setBackupStoragePath(expected).build().get().getBackupStoragePath());
     assertEquals(expected,
         builder().withProperty(BackupSystemProperty.BACKUP_MOUNT_PATH, expected).build().get()
-            .getMountPath());
+            .getBackupStoragePath());
   }
 
   @Test
@@ -159,7 +159,7 @@ public class BackupConfigTest {
   private BackupConfig.Builder builder() {
     return new BackupConfig.Builder().setEnabled(true).setStatusDir(DEFAULT_STATUS_DIR)
         .setTmpDir(DEFAULT_TMP_DIR).setStorageConfig(DEFAULT_STORAGE_CONFIG)
-        .setMountPath(DEFAULT_STORAGE_MOUNT_PATH)
+        .setBackupStoragePath(DEFAULT_STORAGE_MOUNT_PATH)
         .setStorageProviderClassName(DEFAULT_STORAGE_PROVIDER_CLASS_NAME);
   }
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/storage/impl/FileSystemBackupStorageTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/storage/impl/FileSystemBackupStorageTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup.storage.impl;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.zookeeper.common.ConfigException;
+import org.apache.zookeeper.server.backup.BackupConfig;
+import org.apache.zookeeper.server.backup.BackupFileInfo;
+import org.apache.zookeeper.server.backup.storage.BackupStorageProvider;
+import org.apache.zookeeper.server.backup.storage.BackupStorageUtil;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class FileSystemBackupStorageTest {
+  private static String testFolderPath;
+  private static String testFileDirPath;
+  private static String backupFileDirPath;
+  private static List<String> testFileNames =
+      new ArrayList<>(Arrays.asList("log.testFile_0", "snapshot.testFile_1", "log.testFile_2"));
+  private static BackupStorageProvider backupStorage;
+  private static List<File> testFiles;
+  private static List<File> backupFiles;
+  private static final String NAMESPACE = "test";
+
+  @BeforeClass
+  public static void beforeClass() throws ConfigException, IOException {
+    // Build backup config that point the backup storage to a local directory
+    BackupConfig backupConfig = new BackupConfig.Builder().setEnabled(true)
+        .setStatusDir(new File("./localBackupStorageTest/backup/status")).
+            setTmpDir(new File("./localBackupStorageTest/tmp/backup"))
+        .setStorageProviderClassName(FileSystemBackupStorage.class.getName())
+        .setBackupStoragePath("./localBackupStorageTest").setNamespace(NAMESPACE).build().get();
+
+    backupStorage = new FileSystemBackupStorage(backupConfig);
+    // The path to the directory that contains all directories and files created for this test
+    testFolderPath =
+        Paths.get(Paths.get("").toAbsolutePath().toString(), backupConfig.getBackupStoragePath())
+            .toString();
+    // The path to the directory that backup files will be stored
+    backupFileDirPath = String.join(File.separator, testFolderPath, NAMESPACE);
+    // The path to the directory that contains the test files representing logs/snapshots in ZK dataDir
+    testFileDirPath = String.join(File.separator, testFolderPath, "testFiles");
+    testFiles = new ArrayList<>();
+    backupFiles = new ArrayList<>();
+
+    // Create the test files in the testFileDir, and add reference to testFiles list for easy reference
+    for (String testFileName : testFileNames) {
+      String testFilePath = String.join(File.separator, testFileDirPath, testFileName);
+      File testFile = new File(testFilePath);
+      testFiles.add(testFile);
+      BackupStorageUtil.createFile(testFile, false);
+      FileWriter fileWriter = new FileWriter(testFile);
+      for (int i = 0; i < 1000; i++) {
+        fileWriter.write(testFileName);
+        fileWriter.write('\n');
+      }
+      fileWriter.close();
+      Assert.assertTrue(testFile.exists());
+      Assert.assertTrue(sizeOf(testFile) > 0);
+    }
+  }
+
+  @AfterClass
+  public static void afterClass() throws IOException {
+    FileUtils.deleteDirectory(new File(testFolderPath));
+  }
+
+  @Test
+  public void test0_CopyToBackupStorage() throws IOException {
+    for (File testFile : testFiles) {
+      backupStorage.copyToBackupStorage(testFile, testFile);
+      String backupFilePath =
+          BackupStorageUtil.constructBackupFilePath(testFile.getName(), backupFileDirPath);
+      File backupFile = new File(backupFilePath);
+      backupFiles.add(backupFile);
+      Assert.assertEquals(sizeOf(testFile), sizeOf(backupFile));
+    }
+  }
+
+  @Test
+  public void test1_GetBackupFileInfo() throws IOException {
+    BackupFileInfo validFileInfo = backupStorage.getBackupFileInfo(testFiles.get(0));
+    BackupFileInfo invalidFileInfo =
+        backupStorage.getBackupFileInfo(new File("log.invalidBackupFile"));
+    Assert.assertEquals(validFileInfo.getSize(), sizeOf(testFiles.get(0)));
+    Assert.assertEquals(invalidFileInfo.getSize(), BackupFileInfo.NOT_SET);
+  }
+
+  @Test
+  public void test2_GetBackupFileInfos() throws IOException {
+    List<BackupFileInfo> fileInfos = backupStorage.getBackupFileInfos(new File("/log"), "log");
+    Assert.assertEquals(2, fileInfos.size());
+  }
+
+  @Test
+  public void test3_CopyToLocalStorage() throws IOException {
+    for (File testFile : testFiles) {
+      Files.delete(Paths.get(testFile.getPath()));
+      Assert.assertFalse(testFile.exists());
+      backupStorage.copyToLocalStorage(testFile,
+          new File(String.join(File.separator, testFileDirPath, testFile.getName())));
+      Assert.assertTrue(testFile.exists());
+    }
+  }
+
+  @Test
+  public void test4_Delete() throws IOException {
+    for (int i = 0; i < testFiles.size(); i++) {
+      backupStorage.delete(testFiles.get(i));
+      Assert.assertFalse(backupFiles.get(i).exists());
+    }
+  }
+
+  private static long sizeOf(File file) throws IOException {
+    return Files.readAttributes(Paths.get(file.getPath()), BasicFileAttributes.class).size();
+  }
+}


### PR DESCRIPTION
This PR renamed NfsBackupStorage to FileSystemBackupStorage, so it could be used for a broader usage, not only limited to NFS client, but also other file systems which works on a file path. One immediate usage is to use local storage as the backup storage for integration tests.
Changes made:
1. Rename file name `NfsBackupStorage` to `FileSystemBackupStorage`
2. Changed `mountPath` field name and its occurrences in `BackupConfig` to `backupStoragePath`
3. A fix in `getBackupFileInfos` method in `FileSystemBackupStorage` implementation
4. Added unit tests for FileSystemBackupStorage in `FileSystemBackupStorageTest`
<img width="317" alt="Screen Shot 2021-01-21 at 1 50 04 PM" src="https://user-images.githubusercontent.com/31704180/105416862-99c3f600-5bef-11eb-9b40-278bf5108022.png">