### PR TITLE
Enable backup in ZK server-side logic and update BackupConfig units

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupConfig.java
@@ -38,18 +38,18 @@ public class BackupConfig {
    */
   private static final boolean DEFAULT_BACKUP_ENABLED = false;
   public static final int DEFAULT_RETENTION_DAYS = 20;
-  public static final long DEFAULT_BACKUP_INTERVAL_MS = 30 * 60 * 1000L; // 30 minutes
+  public static final int DEFAULT_BACKUP_INTERVAL_MINUTES = 30; // 30 minutes
   /*
    * For retention maintenance, -1 indicates no maintenance by default.
    * Some storage backends support TTL natively.
    */
-  public static final long DEFAULT_RETENTION_MAINTENANCE_INTERVAL_MS = -1L;
+  public static final int DEFAULT_RETENTION_MAINTENANCE_INTERVAL_HOURS = -1;
 
   private final File statusDir;
   private final File tmpDir;
-  private final long backupIntervalInMs;
+  private final int backupIntervalInMinutes;
   private final int retentionPeriodInDays;
-  private final long retentionMaintenanceIntervalInMs;
+  private final int retentionMaintenanceIntervalInHours;
   /*
    * Fully-qualified Java class name for the storage implementation. See BackupStorageType.java
    * for example.
@@ -74,10 +74,12 @@ public class BackupConfig {
   public BackupConfig(Builder builder) {
     this.statusDir = builder.statusDir.get();
     this.tmpDir = builder.tmpDir.get();
-    this.backupIntervalInMs = builder.backupIntervalInMs.orElse(DEFAULT_BACKUP_INTERVAL_MS);
+    this.backupIntervalInMinutes = builder.backupIntervalInMinutes.orElse(
+        DEFAULT_BACKUP_INTERVAL_MINUTES);
     this.retentionPeriodInDays = builder.retentionPeriodInDays.orElse(DEFAULT_RETENTION_DAYS);
-    this.retentionMaintenanceIntervalInMs =
-        builder.retentionMaintenanceIntervalInMs.orElse(DEFAULT_RETENTION_MAINTENANCE_INTERVAL_MS);
+    this.retentionMaintenanceIntervalInHours =
+        builder.retentionMaintenanceIntervalInHours.orElse(
+            DEFAULT_RETENTION_MAINTENANCE_INTERVAL_HOURS);
     this.storageProviderClassName = builder.storageProviderClassName.get();
     this.storageConfig = builder.storageConfig.orElse(null);
     this.backupStoragePath = builder.backupStoragePath.orElse("");
@@ -92,8 +94,8 @@ public class BackupConfig {
     return tmpDir;
   }
 
-  public long getBackupInterval() {
-    return backupIntervalInMs;
+  public int getBackupIntervalInMinutes() {
+    return backupIntervalInMinutes;
   }
 
   public int getRetentionPeriod() {
@@ -101,7 +103,7 @@ public class BackupConfig {
   }
 
   public long getRetentionMaintenanceInterval() {
-    return retentionMaintenanceIntervalInMs;
+    return retentionMaintenanceIntervalInHours;
   }
 
   public String getStorageProviderClassName() {
@@ -127,10 +129,11 @@ public class BackupConfig {
     private Optional<Boolean> enabled = Optional.empty();
     private Optional<File> statusDir = Optional.empty();
     private Optional<File> tmpDir = Optional.empty();
-    private Optional<Long> backupIntervalInMs = Optional.of(DEFAULT_BACKUP_INTERVAL_MS);
+    private Optional<Integer> backupIntervalInMinutes =
+        Optional.of(DEFAULT_BACKUP_INTERVAL_MINUTES);
     private Optional<Integer> retentionPeriodInDays = Optional.of(DEFAULT_RETENTION_DAYS);
-    private Optional<Long> retentionMaintenanceIntervalInMs =
-        Optional.of(DEFAULT_RETENTION_MAINTENANCE_INTERVAL_MS);
+    private Optional<Integer> retentionMaintenanceIntervalInHours =
+        Optional.of(DEFAULT_RETENTION_MAINTENANCE_INTERVAL_HOURS);
     private Optional<String> storageProviderClassName = Optional.empty();
     private Optional<File> storageConfig = Optional.empty();
     private Optional<String> backupStoragePath = Optional.empty();
@@ -151,8 +154,8 @@ public class BackupConfig {
       return this;
     }
 
-    public Builder setBackupInterval(long intervalInMs) {
-      this.backupIntervalInMs = Optional.of(intervalInMs);
+    public Builder setBackupIntervalInMinutes(int intervalInMinutes) {
+      this.backupIntervalInMinutes = Optional.of(intervalInMinutes);
       return this;
     }
 
@@ -161,8 +164,8 @@ public class BackupConfig {
       return this;
     }
 
-    public Builder setRetentionMaintenanceInterval(long retentionMaintenanceInterval) {
-      this.retentionMaintenanceIntervalInMs = Optional.of(retentionMaintenanceInterval);
+    public Builder setRetentionMaintenanceIntervalInHours(int retentionMaintenanceIntervalInHours) {
+      this.retentionMaintenanceIntervalInHours = Optional.of(retentionMaintenanceIntervalInHours);
       return this;
     }
 
@@ -213,11 +216,11 @@ public class BackupConfig {
         }
       }
       {
-        String key = prefix + BackupSystemProperty.BACKUP_INTERVAL_MS;
+        String key = prefix + BackupSystemProperty.BACKUP_INTERVAL_MINUTES;
         String prop = properties.getProperty(key);
         if (prop != null) {
-          long ms = parseLong(key, prop);
-          this.backupIntervalInMs = Optional.of(ms);
+          int minutes = parseInt(key, prop);
+          this.backupIntervalInMinutes = Optional.of(minutes);
         }
       }
       {
@@ -228,7 +231,7 @@ public class BackupConfig {
         }
       }
       {
-        String key = prefix + BackupSystemProperty.BACKUP_MOUNT_PATH;
+        String key = prefix + BackupSystemProperty.BACKUP_STORAGE_PATH;
         String prop = properties.getProperty(key);
         if (prop != null) {
           this.backupStoragePath = Optional.of(prop);
@@ -242,11 +245,11 @@ public class BackupConfig {
         }
       }
       {
-        String key = prefix + BackupSystemProperty.BACKUP_RETENTION_MAINTENANCE_INTERVAL_MS;
+        String key = prefix + BackupSystemProperty.BACKUP_RETENTION_MAINTENANCE_INTERVAL_HOURS;
         String prop = properties.getProperty(key);
         if (prop != null) {
-          long ms = parseLong(key, prop);
-          this.retentionMaintenanceIntervalInMs = Optional.of(ms);
+          int hours = parseInt(key, prop);
+          this.retentionMaintenanceIntervalInHours = Optional.of(hours);
         }
       }
       {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupSystemProperty.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupSystemProperty.java
@@ -25,12 +25,12 @@ public class BackupSystemProperty {
   public static final String BACKUP_ENABLED = "backup.enabled";
   public static final String BACKUP_STATUS_DIR = "backup.statusDir";
   public static final String BACKUP_TMP_DIR = "backup.tmpDir";
-  public static final String BACKUP_INTERVAL_MS = "backup.intervalMs";
+  public static final String BACKUP_INTERVAL_MINUTES = "backup.intervalMinutes";
   public static final String BACKUP_RETENTION_DAYS = "backup.retentionDays";
-  public static final String BACKUP_RETENTION_MAINTENANCE_INTERVAL_MS =
-      "backup.retentionMaintenanceIntervalMs";
+  public static final String BACKUP_RETENTION_MAINTENANCE_INTERVAL_HOURS =
+      "backup.retentionMaintenanceIntervalHours";
   public static final String BACKUP_STORAGE_PROVIDER_CLASS_NAME = "backup.storageProviderClassName";
   public static final String BACKUP_STORAGE_CONFIG = "backup.storageConfig";
-  public static final String BACKUP_MOUNT_PATH = "backup.mountPath";
+  public static final String BACKUP_STORAGE_PATH = "backup.storagePath";
   public static final String BACKUP_NAMESPACE = "backup.namespace";
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/exception/BackupException.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/exception/BackupException.java
@@ -26,4 +26,8 @@ public class BackupException extends RuntimeException {
   public BackupException(String message) {
     super(message);
   }
+
+  public BackupException(String message, Exception e) {
+    super(message, e);
+  }
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/BackupConfigTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/BackupConfigTest.java
@@ -87,14 +87,14 @@ public class BackupConfigTest {
 
   @Test
   public void testInterval() throws Exception {
-    assertEquals(BackupConfig.DEFAULT_BACKUP_INTERVAL_MS,
-        builder().build().get().getBackupInterval());
-    long expectedInterval = 3 * 60 * 1000L; // 3 minutes
+    assertEquals(BackupConfig.DEFAULT_BACKUP_INTERVAL_MINUTES,
+        builder().build().get().getBackupIntervalInMinutes());
+    int expectedInterval = 3; // 3 minutes
     assertEquals(expectedInterval,
-        builder().setBackupInterval(expectedInterval).build().get().getBackupInterval());
+        builder().setBackupIntervalInMinutes(expectedInterval).build().get().getBackupIntervalInMinutes());
     assertEquals(expectedInterval, builder()
-        .withProperty(BackupSystemProperty.BACKUP_INTERVAL_MS, "180000") // 180000 ms = 3 min
-        .build().get().getBackupInterval());
+        .withProperty(BackupSystemProperty.BACKUP_INTERVAL_MINUTES, "3")
+        .build().get().getBackupIntervalInMinutes());
   }
 
   @Test
@@ -129,7 +129,7 @@ public class BackupConfigTest {
     String expected = "/expected";
     assertEquals(expected, builder().setBackupStoragePath(expected).build().get().getBackupStoragePath());
     assertEquals(expected,
-        builder().withProperty(BackupSystemProperty.BACKUP_MOUNT_PATH, expected).build().get()
+        builder().withProperty(BackupSystemProperty.BACKUP_STORAGE_PATH, expected).build().get()
             .getBackupStoragePath());
   }
 
@@ -146,13 +146,13 @@ public class BackupConfigTest {
 
   @Test
   public void testRetentionMaintenanceInterval() throws Exception {
-    assertEquals(BackupConfig.DEFAULT_RETENTION_MAINTENANCE_INTERVAL_MS,
+    assertEquals(BackupConfig.DEFAULT_RETENTION_MAINTENANCE_INTERVAL_HOURS,
         builder().build().get().getRetentionMaintenanceInterval());
-    long expected = 3 * 60 * 60 * 1000L; // 3 hours
-    assertEquals(expected, builder().setRetentionMaintenanceInterval(expected).build().get()
+    int expected = 3; // 3 hours
+    assertEquals(expected, builder().setRetentionMaintenanceIntervalInHours(expected).build().get()
         .getRetentionMaintenanceInterval());
     assertEquals(expected, builder()
-        .withProperty(BackupSystemProperty.BACKUP_RETENTION_MAINTENANCE_INTERVAL_MS, "10800000")
+        .withProperty(BackupSystemProperty.BACKUP_RETENTION_MAINTENANCE_INTERVAL_HOURS, "3")
         .build().get().getRetentionMaintenanceInterval());
   }
 


### PR DESCRIPTION
This commit contains changes that 1) allow QuorumPeerConfig to read BackupConfig, 2) enable QuorumPeerMain to start the backup thread, and 3) update the units used in BackupConfig for consistency.

Build:
```
[INFO] Reactor Summary for Apache ZooKeeper 3.6.2:
[INFO]
[INFO] Apache ZooKeeper ................................... SUCCESS [  2.287 s]
[INFO] Apache ZooKeeper - Documentation ................... SUCCESS [  1.167 s]
[INFO] Apache ZooKeeper - Jute ............................ SUCCESS [  6.005 s]
[INFO] Apache ZooKeeper - Server .......................... SUCCESS [ 12.472 s]
[INFO] Apache ZooKeeper - Metrics Providers ............... SUCCESS [  0.250 s]
[INFO] Apache ZooKeeper - Prometheus.io Metrics Provider .. SUCCESS [  1.201 s]
[INFO] Apache ZooKeeper - Client .......................... SUCCESS [  0.198 s]
[INFO] Apache ZooKeeper - Recipes ......................... SUCCESS [  0.236 s]
[INFO] Apache ZooKeeper - Recipes - Election .............. SUCCESS [  0.347 s]
[INFO] Apache ZooKeeper - Recipes - Lock .................. SUCCESS [  0.392 s]
[INFO] Apache ZooKeeper - Recipes - Queue ................. SUCCESS [  0.419 s]
[INFO] Apache ZooKeeper - Assembly ........................ SUCCESS [  3.817 s]
[INFO] Apache ZooKeeper - Compatibility Tests ............. SUCCESS [  0.213 s]
[INFO] Apache ZooKeeper - Compatibility Tests - Curator ... SUCCESS [  0.378 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  29.576 s
[INFO] Finished at: 2021-01-23T14:18:36-08:00
[INFO] ------------------------------------------------------------------------
```

Test:
```
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.zookeeper.server.backup.BackupConfigTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.09 s - in org.apache.zookeeper.server.backup.BackupConfigTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  9.504 s
[INFO] Finished at: 2021-01-23T14:20:29-08:00
[INFO] ------------------------------------------------------------------------
```