### PR TITLE
Store snapshots and Txlogs in flat directory

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/storage/BackupStorageUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/storage/BackupStorageUtil.java
@@ -64,14 +64,15 @@ public class BackupStorageUtil {
    * @param fileName The name of the file
    * @param parentDir The path to the parent directory of the backup file.
    * @return The path of the backup file in the format of:
-   * 1. parentDir path is not supplied: log/{fileName} or snapshot/{fileName}
-   * 2. parentDir path is provided: {parentDir}/log/{fileName} or {parentDir}/snapshot/{fileName}
+   * 1. parentDir path is not supplied: {fileName} or {fileName}
+   * 2. parentDir path is provided: {parentDir}/{fileName} or {parentDir}/{fileName}
    */
   public static String constructBackupFilePath(String fileName, String parentDir) {
+    //TODO: store snapshots and Txlogs in different subfolders for better organization
     if (parentDir != null) {
-      return String.join(File.separator, parentDir, getFileTypePrefix(fileName), fileName);
+      return String.join(File.separator, parentDir, fileName);
     }
-    return String.join(File.separator, getFileTypePrefix(fileName), fileName);
+    return fileName;
   }
 
   /**

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/storage/impl/FileSystemBackupStorageTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/storage/impl/FileSystemBackupStorageTest.java
@@ -119,7 +119,7 @@ public class FileSystemBackupStorageTest {
 
   @Test
   public void test2_GetBackupFileInfos() throws IOException {
-    List<BackupFileInfo> fileInfos = backupStorage.getBackupFileInfos(new File("/log"), "log");
+    List<BackupFileInfo> fileInfos = backupStorage.getBackupFileInfos(new File(""), "log");
     Assert.assertEquals(2, fileInfos.size());
   }
 


### PR DESCRIPTION
In https://github.com/linkedin/zookeeper/pull/21 we found a difference between the existing HdfsBackupStorage implementation and our FileSystemBackupStorage implementation. In HdfsBackupStorage, backup TxLog and snapshot files are stored in a flat directory, while in FileSystemBackupStorage they are stored under different subfolders (/log and /snapshot).
After discussion, we agreed to store both snapshot and Txlog backups in a flat directory instead of subfolders for the time being to keep the logic consistent with the other open-source implementation. 
This commit is to change the backup file path from a subfolder path to a flat directory path.

Passed `FileSystemBackupStorageTest`.