### PR TITLE
Do not throw exception in FileSystemBackupStorage when input path=null

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/storage/BackupStorageUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/storage/BackupStorageUtil.java
@@ -25,6 +25,7 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import org.apache.zookeeper.server.backup.BackupConfig;
 import org.apache.zookeeper.server.backup.exception.BackupException;
 import org.apache.zookeeper.server.persistence.Util;
 
@@ -70,7 +71,7 @@ public class BackupStorageUtil {
   public static String constructBackupFilePath(String fileName, String parentDir) {
     //TODO: store snapshots and Txlogs in different subfolders for better organization
     if (parentDir != null) {
-      return String.join(File.separator, parentDir, fileName);
+      return String.valueOf(Paths.get(parentDir, fileName));
     }
     return fileName;
   }
@@ -138,6 +139,9 @@ public class BackupStorageUtil {
    * @return
    */
   public static File[] getFilesWithPrefix(File directory, String prefix) {
+    if (directory == null) {
+      return new File[0];
+    }
     FilenameFilter fileFilter = (dir, name) -> name.startsWith(prefix);
     return directory.listFiles(fileFilter);
   }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/storage/impl/FileSystemBackupStorage.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/storage/impl/FileSystemBackupStorage.java
@@ -81,12 +81,12 @@ public class FileSystemBackupStorage implements BackupStorageProvider {
 
   @Override
   public List<BackupFileInfo> getBackupFileInfos(File path, String prefix) throws IOException {
-    String backupDirPath = Paths.get(fileRootPath, path.getPath()).toString();
+    String filePath = path == null ? "" : path.getPath();
+    String backupDirPath = Paths.get(fileRootPath, filePath).toString();
     File backupDir = new File(backupDirPath);
 
     if (!backupDir.exists()) {
-      throw new BackupException(
-          "Backup directory " + path.getPath() + " does not exist, could not get file info.");
+      return new ArrayList<>();
     }
 
     File[] files = BackupStorageUtil.getFilesWithPrefix(backupDir, prefix);
@@ -103,12 +103,13 @@ public class FileSystemBackupStorage implements BackupStorageProvider {
 
   @Override
   public List<File> getDirectories(File path) {
-    String backupDirPath = BackupStorageUtil.constructBackupFilePath(path.getName(), fileRootPath);
+    String filePath = path == null ? "" : path.getPath();
+    String backupDirPath = BackupStorageUtil.constructBackupFilePath(filePath, fileRootPath);
     File backupDir = new File(backupDirPath);
 
     if (!backupDir.exists()) {
       throw new BackupException(
-          "Backup directory " + path.getPath() + " does not exist, could not get directory list.");
+          "Backup directory " + filePath + " does not exist, could not get directory list.");
     }
 
     // Filter out all the files which are directories
@@ -116,8 +117,7 @@ public class FileSystemBackupStorage implements BackupStorageProvider {
     File[] dirs = backupDir.listFiles(fileFilter);
 
     if (dirs == null) {
-      throw new BackupException("The provided directory path " + path.getPath()
-          + " is invalid, could not get directory list.");
+      return new ArrayList<>();
     }
     return Arrays.asList(dirs);
   }
@@ -194,8 +194,9 @@ public class FileSystemBackupStorage implements BackupStorageProvider {
 
   @Override
   public void delete(File fileToDelete) throws IOException {
+    String fileName = fileToDelete == null ? "" : fileToDelete.getName();
     String backupFilePath =
-        BackupStorageUtil.constructBackupFilePath(fileToDelete.getName(), fileRootPath);
+        BackupStorageUtil.constructBackupFilePath(fileName, fileRootPath);
     Files.deleteIfExists(Paths.get(backupFilePath));
   }
 


### PR DESCRIPTION
Current FileSystemBackupStorage implementation has some inconsistencies with existing open source implementation for HdfsBackupStorage. FileSystemBackupStorage throws a backup exception when the input File path is null that saying the provided path is invalid, while HdfsBackupStorage does not throw exceptions. These inconsistencies result to the need of special handling in test cases. To ensure that all the implementations of BackupStorageProvider have same semantics, this commit will remove the exceptions thrown by FileSystemBackupStorage in the above described situations, and return empty list/array as how it is handled in HdfsBackupStorage.

Passed `FileSystemBackupStorageTest`