### PR TITLE
Fix issues when remove invalid temporary backup files

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
@@ -278,9 +278,9 @@ public class BackupManager {
           }
         }
       } catch (InterruptedException e) {
-        logger.warn("Interrupted exception while waiting for backup interval.", e);
+        logger.warn("Interrupted exception while waiting for backup interval.", e.fillInStackTrace());
       } catch (Exception e) {
-        logger.error("Hit unexpected exception", e);
+        logger.error("Hit unexpected exception", e.fillInStackTrace());
       }
 
       logger.warn("BackupProcess thread exited loop!");
@@ -443,7 +443,7 @@ public class BackupManager {
         }
 
       } catch (IOException e) {
-        logger.warn("Hit exception after {} records.  Exception: {} ", txnCopied, e);
+        logger.warn("Hit exception after {} records.  Exception: {} ", txnCopied, e.fillInStackTrace());
 
         // If any records were copied return those and ignore the error.  Otherwise
         // rethrow the error to be handled by the caller as a failed backup iteration.

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/storage/BackupStorageUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/storage/BackupStorageUtil.java
@@ -34,6 +34,7 @@ import org.apache.zookeeper.server.persistence.Util;
  */
 public class BackupStorageUtil {
   public static final String TMP_FILE_PREFIX = "TMP_";
+  private static final File[] NO_FILE = new File[0];
 
   /**
    * Parse the prefix from a file name, also works for temporary file names in backup storage
@@ -140,11 +141,11 @@ public class BackupStorageUtil {
    */
   public static File[] getFilesWithPrefix(File directory, String prefix) {
     if (directory == null) {
-      return new File[0];
+      return NO_FILE;
     }
     FilenameFilter fileFilter = (dir, name) -> name.startsWith(prefix);
     File[] files = directory.listFiles(fileFilter);
-    return files == null ? new File[0] : files;
+    return files == null ? NO_FILE : files;
   }
 
   /**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/storage/BackupStorageUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/storage/BackupStorageUtil.java
@@ -143,7 +143,8 @@ public class BackupStorageUtil {
       return new File[0];
     }
     FilenameFilter fileFilter = (dir, name) -> name.startsWith(prefix);
-    return directory.listFiles(fileFilter);
+    File[] files = directory.listFiles(fileFilter);
+    return files == null ? new File[0] : files;
   }
 
   /**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/storage/impl/FileSystemBackupStorage.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/storage/impl/FileSystemBackupStorage.java
@@ -102,10 +102,8 @@ public class FileSystemBackupStorage implements BackupStorageProvider {
 
     // Read the file info and add to the list. If an exception is thrown, the entire operation will fail
     List<BackupFileInfo> backupFileInfos = new ArrayList<>();
-    if (files != null) {
-      for (File file : files) {
-        backupFileInfos.add(getBackupFileInfo(file));
-      }
+    for (File file : files) {
+      backupFileInfos.add(getBackupFileInfo(file));
     }
     return backupFileInfos;
   }


### PR DESCRIPTION
An IOException from FileSystemBackupStorage in copyToBackupStorage() is found during our testing.  The root cause is that currently when cleanupInvalidFiles() method is called, all the temporary backup files (both transaction logs and snapshots) will be deleted. And this caused an undesired situation where the snapshot backup thread deletes temporary transaction log backup files before they can be saved as formal backup files.
This commit fixes this bug from two aspects:
1. Add a read write lock to coordinate the temporary files' read and write access from multiple threads in FileSystemBackupStorage
2. Modify the way to log an exception in BackupManager to allow detailed exception stack trace to show in the logs, for easier debugging in the future

Tests passed:
FileSystemBackupStorageTest, BackupManagerTest, deployed zk server locally and test