### PR TITLE
Add BackupBean and BackupStats

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
@@ -25,6 +25,11 @@ import org.apache.zookeeper.server.backup.storage.BackupStorageProvider;
 import org.apache.zookeeper.server.persistence.*;
 import org.apache.zookeeper.server.backup.BackupUtil.BackupFileType;
 import org.apache.zookeeper.server.backup.BackupUtil.ZxidPart;
+import org.apache.zookeeper.server.backup.monitoring.BackupBean;
+import org.apache.zookeeper.server.backup.monitoring.BackupStats;
+import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
+import javax.management.JMException;
+import org.apache.zookeeper.jmx.MBeanRegistry;
 import org.apache.zookeeper.server.util.ZxidUtils;
 import org.apache.zookeeper.txn.TxnHeader;
 import org.slf4j.Logger;
@@ -40,6 +45,8 @@ import java.util.*;
  * an ensemble server
  */
 public class BackupManager {
+  private static final Logger LOG = LoggerFactory.getLogger(BackupManager.class);
+
   private final Logger logger;
   private final File snapDir;
   private final File dataLogDir;
@@ -55,6 +62,10 @@ public class BackupManager {
   private long backedupSnapZxid;
 
   private final BackupStorageProvider backupStorage;
+  private final long serverId;
+  private final String namespace;
+  private BackupBean backupBean = null;
+  private BackupStats backupStats = null;
 
   /**
    * Tracks a file that needs to be backed up, including temporary copies of the file
@@ -623,14 +634,22 @@ public class BackupManager {
    * @param tmpDir temporary directory
    * @param backupIntervalInMinutes the interval backups should run at in minutes
    */
-  public BackupManager(File snapDir, File dataLogDir, File backupStatusDir, File tmpDir, int backupIntervalInMinutes,
-      BackupStorageProvider backupStorageProvider) throws IOException {
+  public BackupManager(File snapDir, File dataLogDir, File backupStatusDir, File tmpDir,
+      int backupIntervalInMinutes, BackupStorageProvider backupStorageProvider) throws IOException {
+    this(snapDir, dataLogDir, backupStatusDir, tmpDir, backupIntervalInMinutes,
+        backupStorageProvider, "UNKNOWN", QuorumPeerConfig.UNSET_SERVERID);
+  }
+
+  public BackupManager(File snapDir, File dataLogDir, File backupStatusDir, File tmpDir,
+      int backupIntervalInMinutes, BackupStorageProvider backupStorageProvider, String namespace,
+      long serverId) throws IOException {
     logger = LoggerFactory.getLogger(BackupManager.class);
     logger.info("snapDir={}", snapDir.getPath());
     logger.info("dataLogDir={}", dataLogDir.getPath());
     logger.info("backupStatusDir={}", backupStatusDir.getPath());
     logger.info("tmpDir={}", tmpDir.getPath());
     logger.info("backupIntervalInMinutes={}", backupIntervalInMinutes);
+    logger.info("serverId={}", serverId);
 
     this.snapDir = snapDir;
     this.dataLogDir = dataLogDir;
@@ -638,7 +657,8 @@ public class BackupManager {
     this.backupStatus = new BackupStatus(backupStatusDir);
     this.backupIntervalInMilliseconds = backupIntervalInMinutes * 60 * 1000;
     this.backupStorage = backupStorageProvider;
-
+    this.serverId = serverId;
+    this.namespace = namespace;
     initialize();
   }
 
@@ -666,6 +686,10 @@ public class BackupManager {
       snapBackup.shutdown();
       logBackup = null;
       snapBackup = null;
+      if (backupBean != null) {
+        MBeanRegistry.getInstance().unregister(backupBean);
+        backupBean = null;
+      }
     }
   }
 
@@ -685,6 +709,16 @@ public class BackupManager {
   }
 
   public synchronized void initialize() throws IOException {
+    try {
+      backupStats = new BackupStats();
+      backupBean = new BackupBean(backupStats, namespace, serverId);
+      MBeanRegistry.getInstance().register(backupBean, null);
+      LOG.info("Registered Backup bean {} with JMX.", backupBean.getName());
+    } catch (JMException e) {
+      LOG.warn("Failed to register with JMX", e);
+      backupBean = null;
+    }
+
     synchronized (backupStatus) {
       backupStatus.createIfNeeded();
       BackupPoint bp = backupStatus.read();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupBean.java
@@ -51,8 +51,8 @@ public class BackupBean implements ZKMBeanInfo, BackupMXBean {
 
   // Snapshot backup metrics
   @Override
-  public int getSuccessiveSnapshotIterationErrorCount() {
-    return backupStats.getSuccessiveSnapshotIterationErrorCount();
+  public int getNumConsecutiveFailedSnapshotIterations() {
+    return backupStats.getNumConsecutiveFailedSnapshotIterations();
   }
 
   @Override
@@ -77,8 +77,8 @@ public class BackupBean implements ZKMBeanInfo, BackupMXBean {
 
   // Transaction log backup metrics
   @Override
-  public int getSuccessiveTxnLogIterationErrorCount() {
-    return backupStats.getSuccessiveTxnLogIterationErrorCount();
+  public int getNumConsecutiveFailedTxnLogIterations() {
+    return backupStats.getNumConsecutiveFailedTxnLogIterations();
   }
 
   @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupBean.java
@@ -53,8 +53,8 @@ public class BackupBean implements ZKMBeanInfo, BackupMXBean {
   }
 
   @Override
-  public long getTimeElapsedSinceLastSuccessfulSnapshotIteration() {
-    return backupStats.getTimeElapsedSinceLastSuccessfulSnapshotIteration();
+  public long getMinutesSinceLastSuccessfulSnapshotIteration() {
+    return backupStats.getMinutesSinceLastSuccessfulSnapshotIteration();
   }
 
   @Override
@@ -62,11 +62,14 @@ public class BackupBean implements ZKMBeanInfo, BackupMXBean {
     return backupStats.getSnapshotBackupActiveStatus();
   }
 
-  /**
-   * @return How long it took to complete the last successful snapshot backup iteration
-   */
+  @Override
   public long getSnapshotIterationDuration() {
     return backupStats.getSnapshotIterationDuration();
+  }
+
+  @Override
+  public long getNumberOfSnapshotBackupFilesCreatedLastIteration() {
+    return backupStats.getNumberOfSnapshotBackupFilesCreatedLastIteration();
   }
 
   // Transaction log backup metrics
@@ -76,8 +79,8 @@ public class BackupBean implements ZKMBeanInfo, BackupMXBean {
   }
 
   @Override
-  public long getTimeSinceLastSuccessfulTxnLogIteration() {
-    return backupStats.getTimeSinceLastSuccessfulTxnLogIteration();
+  public long getMinutesSinceLastSuccessfulTxnLogIteration() {
+    return backupStats.getMinutesSinceLastSuccessfulTxnLogIteration();
   }
 
   @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupBean.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 /**
  * This class implements ZK backup MBean
  */
-public class BackupBean implements ZKMBeanInfo {
+public class BackupBean implements ZKMBeanInfo, BackupMXBean {
   private static final Logger LOG = LoggerFactory.getLogger(BackupBean.class);
 
   private final BackupStats backupStats;
@@ -47,74 +47,46 @@ public class BackupBean implements ZKMBeanInfo {
   }
 
   // Snapshot backup metrics
-  /**
-   * @return Number of snapshot backup errors occur since last successful snapshot backup iteration
-   */
+  @Override
   public int getSnapshotErrorCount() {
     return backupStats.getSnapshotErrorCount();
   }
 
-  /**
-   * @return Time passed since last successful snapshot backup iteration
-   */
-  public long getSnapshotTimeSinceLastSuccessfulIteration() {
-    return backupStats.getSnapshotTimeSinceLastSuccessfulIteration();
+  @Override
+  public long getTimeElapsedSinceLastSuccessfulSnapshotIteration() {
+    return backupStats.getTimeElapsedSinceLastSuccessfulSnapshotIteration();
   }
 
-  /**
-   * @return If snapshot backup is currently actively ongoing
-   */
+  @Override
   public boolean getSnapshotBackupActiveStatus() {
     return backupStats.getSnapshotBackupActiveStatus();
   }
 
   /**
-   * @return The elapsed time to complete a snapshot backup iteration
+   * @return How long it took to complete the last successful snapshot backup iteration
    */
   public long getSnapshotIterationDuration() {
     return backupStats.getSnapshotIterationDuration();
   }
 
-  /**
-   * @return Number of backup files created in a snapshot backup iteration
-   */
-  public long getSnapshotBackupFilesCreatedPerIteration() {
-    return backupStats.getSnapshotBackupFilesCreatedPerIteration();
-  }
-
   // Transaction log backup metrics
-  /**
-   * @return Number of txn log backup errors occur after last successful txn log backup iteration
-   */
+  @Override
   public int getTxnLogErrorCount() {
     return backupStats.getTxnLogErrorCount();
   }
 
-  /**
-   * @return Time passed since last successful txn log backup iteration
-   */
-  public long getTxnLogTimeSinceLastSuccessfulIteration() {
-    return backupStats.getTxnLogTimeSinceLastSuccessfulIteration();
+  @Override
+  public long getTimeSinceLastSuccessfulTxnLogIteration() {
+    return backupStats.getTimeSinceLastSuccessfulTxnLogIteration();
   }
 
-  /**
-   * @return If txn log backup is currently actively ongoing
-   */
+  @Override
   public boolean getTxnLogBackupActiveStatus() {
     return backupStats.getTxnLogBackupActiveStatus();
   }
 
-  /**
-   * @return The elapsed time to complete a txn log backup iteration
-   */
+  @Override
   public long getTxnLogIterationDuration() {
     return backupStats.getTxnLogIterationDuration();
-  }
-
-  /**
-   * @return Number of backup files created in a txn log backup iteration
-   */
-  public long getTxnLogBackupFilesCreatedPerIteration() {
-    return backupStats.getTxnLogBackupFilesCreatedPerIteration();
   }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupBean.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup.monitoring;
+
+import org.apache.zookeeper.jmx.ZKMBeanInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class implements ZK backup MBean
+ */
+public class BackupBean implements ZKMBeanInfo {
+  private static final Logger LOG = LoggerFactory.getLogger(BackupBean.class);
+
+  private final BackupStats backupStats;
+  private final String name;
+
+  public BackupBean(BackupStats backupStats, String namespace, long serverId) {
+    this.backupStats = backupStats;
+    name = "Backup_" + namespace + ".server" + serverId;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public boolean isHidden() {
+    return false;
+  }
+
+  // Snapshot backup metrics
+  /**
+   * @return Number of snapshot backup errors occur since last successful snapshot backup iteration
+   */
+  public int getSnapshotErrorCount() {
+    return backupStats.getSnapshotErrorCount();
+  }
+
+  /**
+   * @return Time passed since last successful snapshot backup iteration
+   */
+  public long getSnapshotTimeSinceLastSuccessfulIteration() {
+    return backupStats.getSnapshotTimeSinceLastSuccessfulIteration();
+  }
+
+  /**
+   * @return If snapshot backup is currently actively ongoing
+   */
+  public boolean getSnapshotBackupActiveStatus() {
+    return backupStats.getSnapshotBackupActiveStatus();
+  }
+
+  /**
+   * @return The elapsed time to complete a snapshot backup iteration
+   */
+  public long getSnapshotIterationDuration() {
+    return backupStats.getSnapshotIterationDuration();
+  }
+
+  /**
+   * @return Number of backup files created in a snapshot backup iteration
+   */
+  public long getSnapshotBackupFilesCreatedPerIteration() {
+    return backupStats.getSnapshotBackupFilesCreatedPerIteration();
+  }
+
+  // Transaction log backup metrics
+  /**
+   * @return Number of txn log backup errors occur after last successful txn log backup iteration
+   */
+  public int getTxnLogErrorCount() {
+    return backupStats.getTxnLogErrorCount();
+  }
+
+  /**
+   * @return Time passed since last successful txn log backup iteration
+   */
+  public long getTxnLogTimeSinceLastSuccessfulIteration() {
+    return backupStats.getTxnLogTimeSinceLastSuccessfulIteration();
+  }
+
+  /**
+   * @return If txn log backup is currently actively ongoing
+   */
+  public boolean getTxnLogBackupActiveStatus() {
+    return backupStats.getTxnLogBackupActiveStatus();
+  }
+
+  /**
+   * @return The elapsed time to complete a txn log backup iteration
+   */
+  public long getTxnLogIterationDuration() {
+    return backupStats.getTxnLogIterationDuration();
+  }
+
+  /**
+   * @return Number of backup files created in a txn log backup iteration
+   */
+  public long getTxnLogBackupFilesCreatedPerIteration() {
+    return backupStats.getTxnLogBackupFilesCreatedPerIteration();
+  }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupBean.java
@@ -33,6 +33,9 @@ public class BackupBean implements ZKMBeanInfo, BackupMXBean {
 
   public BackupBean(BackupStats backupStats, String namespace, long serverId) {
     this.backupStats = backupStats;
+    if (namespace == null || namespace.isEmpty()) {
+      namespace = "UNKNOWN";
+    }
     name = "Backup_" + namespace + ".server" + serverId;
   }
 
@@ -48,8 +51,8 @@ public class BackupBean implements ZKMBeanInfo, BackupMXBean {
 
   // Snapshot backup metrics
   @Override
-  public int getSnapshotErrorCount() {
-    return backupStats.getSnapshotErrorCount();
+  public int getSuccessiveSnapshotIterationErrorCount() {
+    return backupStats.getSuccessiveSnapshotIterationErrorCount();
   }
 
   @Override
@@ -63,19 +66,19 @@ public class BackupBean implements ZKMBeanInfo, BackupMXBean {
   }
 
   @Override
-  public long getSnapshotIterationDuration() {
+  public long getLastSnapshotIterationDuration() {
     return backupStats.getSnapshotIterationDuration();
   }
 
   @Override
-  public long getNumberOfSnapshotBackupFilesCreatedLastIteration() {
-    return backupStats.getNumberOfSnapshotBackupFilesCreatedLastIteration();
+  public long getNumberOfSnapshotFilesBackedUpLastIteration() {
+    return backupStats.getNumberOfSnapshotFilesBackedUpLastIteration();
   }
 
   // Transaction log backup metrics
   @Override
-  public int getTxnLogErrorCount() {
-    return backupStats.getTxnLogErrorCount();
+  public int getSuccessiveTxnLogIterationErrorCount() {
+    return backupStats.getSuccessiveTxnLogIterationErrorCount();
   }
 
   @Override
@@ -89,7 +92,7 @@ public class BackupBean implements ZKMBeanInfo, BackupMXBean {
   }
 
   @Override
-  public long getTxnLogIterationDuration() {
+  public long getLastTxnLogIterationDuration() {
     return backupStats.getTxnLogIterationDuration();
   }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupMXBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupMXBean.java
@@ -26,9 +26,11 @@ public interface BackupMXBean {
 
   /**
    * Counter
-   * @return Number of snapshot backup errors since last successful snapshot backup iteration
+   * For example: if backup iteration A fails, the number is 1; if next backup iteration B succeeds, the number is reset to 0.
+   * If A fails, the number is 1; if then B fails too, the number is incremented to 2.
+   * @return Number of consecutive snapshot backup errors since last successful snapshot backup iteration
    */
-  int getSuccessiveSnapshotIterationErrorCount();
+  int getNumConsecutiveFailedSnapshotIterations();
 
   /**
    * Counter
@@ -58,9 +60,11 @@ public interface BackupMXBean {
 
   /**
    * Counter
-   * @return Number of txn log backup errors occur after last successful txn log backup iteration
+   * For example: if backup iteration A fails, the number is 1; if next backup iteration B succeeds, the number is reset to 0.
+   * If A fails, the number is 1; if then B fails too, the number is incremented to 2.
+   * @return Number of consecutive txn log backup errors since last successful txn log backup iteration
    */
-  int getSuccessiveTxnLogIterationErrorCount();
+  int getNumConsecutiveFailedTxnLogIterations();
 
   /**
    * Counter

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupMXBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupMXBean.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup.monitoring;
+
+public interface BackupMXBean {
+  // Snapshot backup metrics
+
+  /**
+   * @return Number of snapshot backup errors since last successful snapshot backup iteration
+   */
+  int getSnapshotErrorCount();
+
+  /**
+   * @return Time passed since last successful snapshot backup iteration
+   */
+  long getTimeElapsedSinceLastSuccessfulSnapshotIteration();
+
+  /**
+   * @return If snapshot backup is currently actively ongoing
+   */
+  boolean getSnapshotBackupActiveStatus();
+
+  /**
+   * @return How long it took to complete the last successful snapshot backup iteration
+   */
+  long getSnapshotIterationDuration();
+
+  // Transaction log backup metrics
+
+  /**
+   * @return Number of txn log backup errors occur after last successful txn log backup iteration
+   */
+  int getTxnLogErrorCount();
+
+  /**
+   * @return Time passed since last successful txn log backup iteration
+   */
+  long getTimeSinceLastSuccessfulTxnLogIteration();
+
+  /**
+   * @return If txn log backup is currently actively ongoing
+   */
+  boolean getTxnLogBackupActiveStatus();
+
+  /**
+   * @return How long it took to complete the last successful txn log backup iteration
+   */
+  long getTxnLogIterationDuration();
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupMXBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupMXBean.java
@@ -18,53 +18,65 @@
 
 package org.apache.zookeeper.server.backup.monitoring;
 
+/**
+ * ZK backup MBean
+ */
 public interface BackupMXBean {
   // Snapshot backup metrics
 
   /**
+   * Counter
    * @return Number of snapshot backup errors since last successful snapshot backup iteration
    */
-  int getSnapshotErrorCount();
+  int getSuccessiveSnapshotIterationErrorCount();
 
   /**
+   * Counter
    * @return Time passed (minutes) since last successful snapshot backup iteration
    */
   long getMinutesSinceLastSuccessfulSnapshotIteration();
 
   /**
+   * Gauge
    * @return If snapshot backup is currently actively ongoing
    */
   boolean getSnapshotBackupActiveStatus();
 
   /**
-   * @return How long it took to complete the last successful snapshot backup iteration
+   * Gauge
+   * @return How long it took to complete the last snapshot backup iteration
    */
-  long getSnapshotIterationDuration();
+  long getLastSnapshotIterationDuration();
 
   /**
-   * @return Number of backup files created in last snapshot backup iteration
+   * Gauge
+   * @return Number of snapshot files that were backed up to backup storage in last snapshot backup iteration
    */
-  long getNumberOfSnapshotBackupFilesCreatedLastIteration();
+  long getNumberOfSnapshotFilesBackedUpLastIteration();
 
   // Transaction log backup metrics
 
   /**
+   * Counter
    * @return Number of txn log backup errors occur after last successful txn log backup iteration
    */
-  int getTxnLogErrorCount();
+  int getSuccessiveTxnLogIterationErrorCount();
 
   /**
+   * Counter
    * @return Time passed (minutes) since last successful txn log backup iteration
    */
   long getMinutesSinceLastSuccessfulTxnLogIteration();
 
   /**
+   * Gauge
    * @return If txn log backup is currently actively ongoing
    */
   boolean getTxnLogBackupActiveStatus();
 
   /**
-   * @return How long it took to complete the last successful txn log backup iteration
+   * Gauge
+   * @return How long it took to complete the last txn log backup iteration
    */
-  long getTxnLogIterationDuration();
+  long getLastTxnLogIterationDuration();
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupMXBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupMXBean.java
@@ -25,15 +25,17 @@ public interface BackupMXBean {
   // Snapshot backup metrics
 
   /**
-   * Counter
+   * Counter, reset when a successful backup iteration is completed
    * For example: if backup iteration A fails, the number is 1; if next backup iteration B succeeds, the number is reset to 0.
    * If A fails, the number is 1; if then B fails too, the number is incremented to 2.
+   * This metric can be used for alerts.
    * @return Number of consecutive snapshot backup errors since last successful snapshot backup iteration
    */
   int getNumConsecutiveFailedSnapshotIterations();
 
   /**
-   * Counter
+   * Counter, reset when a successful backup iteration is completed
+   * This metric can be used for alerts.
    * @return Time passed (minutes) since last successful snapshot backup iteration
    */
   long getMinutesSinceLastSuccessfulSnapshotIteration();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupMXBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupMXBean.java
@@ -27,9 +27,9 @@ public interface BackupMXBean {
   int getSnapshotErrorCount();
 
   /**
-   * @return Time passed since last successful snapshot backup iteration
+   * @return Time passed (minutes) since last successful snapshot backup iteration
    */
-  long getTimeElapsedSinceLastSuccessfulSnapshotIteration();
+  long getMinutesSinceLastSuccessfulSnapshotIteration();
 
   /**
    * @return If snapshot backup is currently actively ongoing
@@ -41,6 +41,11 @@ public interface BackupMXBean {
    */
   long getSnapshotIterationDuration();
 
+  /**
+   * @return Number of backup files created in last snapshot backup iteration
+   */
+  long getNumberOfSnapshotBackupFilesCreatedLastIteration();
+
   // Transaction log backup metrics
 
   /**
@@ -49,9 +54,9 @@ public interface BackupMXBean {
   int getTxnLogErrorCount();
 
   /**
-   * @return Time passed since last successful txn log backup iteration
+   * @return Time passed (minutes) since last successful txn log backup iteration
    */
-  long getTimeSinceLastSuccessfulTxnLogIteration();
+  long getMinutesSinceLastSuccessfulTxnLogIteration();
 
   /**
    * @return If txn log backup is currently actively ongoing

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupStats.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupStats.java
@@ -28,15 +28,17 @@ public class BackupStats {
   private static final Logger LOG = LoggerFactory.getLogger(BackupStats.class);
 
   private int snapshotErrorCount = 0;
-  private long timeSinceLastSuccessfulSnapshotIteration = Long.MAX_VALUE;
+  private long lastSuccessfulSnapshotBackupIterationFinishTime = System.currentTimeMillis();
   private boolean snapshotBackupActive = false;
   private long snapshotIterationDuration = 0L;
+  private int numberOfSnapshotBackupFilesCreatedLastIteration = 0;
   private int txnLogErrorCount = 0;
-  private long timeSinceLastSuccessfulTxnLogIteration = Long.MAX_VALUE;
+  private long lastSuccessfulTxnLogBackupIterationFinishTime = System.currentTimeMillis();
   private boolean txnLogBackupActive = false;
   private long txnLogIterationDuration = 0L;
 
   // Snapshot backup metrics
+
   /**
    * @return Number of snapshot backup errors occur since last successful snapshot backup iteration
    */
@@ -45,10 +47,10 @@ public class BackupStats {
   }
 
   /**
-   * @return Time passed since last successful snapshot backup iteration
+   * @return Time passed (minutes) since last successful snapshot backup iteration
    */
-  public long getTimeElapsedSinceLastSuccessfulSnapshotIteration() {
-    return timeSinceLastSuccessfulSnapshotIteration;
+  public long getMinutesSinceLastSuccessfulSnapshotIteration() {
+    return (System.currentTimeMillis() - lastSuccessfulSnapshotBackupIterationFinishTime) / (60 * 1000);
   }
 
   /**
@@ -65,7 +67,15 @@ public class BackupStats {
     return snapshotIterationDuration;
   }
 
+  /**
+   * @return Number of backup files created in last snapshot backup iteration
+   */
+  public long getNumberOfSnapshotBackupFilesCreatedLastIteration() {
+    return numberOfSnapshotBackupFilesCreatedLastIteration;
+  }
+
   // Transaction log backup metrics
+
   /**
    * @return Number of txn log backup errors after last successful txn log backup iteration
    */
@@ -74,10 +84,10 @@ public class BackupStats {
   }
 
   /**
-   * @return Time passed since last successful txn log backup iteration
+   * @return Time passed (minutes) since last successful txn log backup iteration
    */
-  public long getTimeSinceLastSuccessfulTxnLogIteration() {
-    return timeSinceLastSuccessfulTxnLogIteration;
+  public long getMinutesSinceLastSuccessfulTxnLogIteration() {
+    return (System.currentTimeMillis() - lastSuccessfulTxnLogBackupIterationFinishTime) / (60 * 1000);
   }
 
   /**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupStats.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupStats.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup.monitoring;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class contains ZK backup related statistics
+ */
+public class BackupStats {
+  private static final Logger LOG = LoggerFactory.getLogger(BackupStats.class);
+
+  private int snapshotErrorCount = 0;
+  private long snapshotTimeSinceLastSuccessfulIteration = Long.MAX_VALUE;
+  private boolean snapshotBackupActive = false;
+  private long snapshotIterationDuration = 0;
+  private int snapshotBackupFilesCreatedPerIteration = 0;
+  private int txnLogErrorCount = 0;
+  private long txnLogTimeSinceLastSuccessfulIteration = Long.MAX_VALUE;
+  private boolean txnLogBackupActive = false;
+  private long txnLogIterationDuration = 0;
+  private int txnLogBackupFilesCreatedPerIteration = 0;
+
+  // Snapshot backup metrics
+  /**
+   * @return Number of snapshot backup errors occur since last successful snapshot backup iteration
+   */
+  public int getSnapshotErrorCount() {
+    return snapshotErrorCount;
+  }
+
+  /**
+   * @return Time passed since last successful snapshot backup iteration
+   */
+  public long getSnapshotTimeSinceLastSuccessfulIteration() {
+    return snapshotTimeSinceLastSuccessfulIteration;
+  }
+
+  /**
+   * @return If snapshot backup is currently actively ongoing
+   */
+  public boolean getSnapshotBackupActiveStatus() {
+    return snapshotBackupActive;
+  }
+
+  /**
+   * @return The elapsed time to complete a snapshot backup iteration
+   */
+  public long getSnapshotIterationDuration() {
+    return snapshotIterationDuration;
+  }
+
+  /**
+   * @return Number of backup files created in a snapshot backup iteration
+   */
+  public long getSnapshotBackupFilesCreatedPerIteration() {
+    return snapshotBackupFilesCreatedPerIteration;
+  }
+
+  // Transaction log backup metrics
+  /**
+   * @return Number of txn log backup errors occur after last successful txn log backup iteration
+   */
+  public int getTxnLogErrorCount() {
+    return txnLogErrorCount;
+  }
+
+  /**
+   * @return Time passed since last successful txn log backup iteration
+   */
+  public long getTxnLogTimeSinceLastSuccessfulIteration() {
+    return txnLogTimeSinceLastSuccessfulIteration;
+  }
+
+  /**
+   * @return If txn log backup is currently actively ongoing
+   */
+  public boolean getTxnLogBackupActiveStatus() {
+    return txnLogBackupActive;
+  }
+
+  /**
+   * @return The elapsed time to complete a txn log backup iteration
+   */
+  public long getTxnLogIterationDuration() {
+    return txnLogIterationDuration;
+  }
+
+  /**
+   * @return Number of backup files created in a txn log backup iteration
+   */
+  public int getTxnLogBackupFilesCreatedPerIteration() {
+    return txnLogBackupFilesCreatedPerIteration;
+  }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupStats.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupStats.java
@@ -27,12 +27,12 @@ import org.slf4j.LoggerFactory;
 public class BackupStats {
   private static final Logger LOG = LoggerFactory.getLogger(BackupStats.class);
 
-  private int snapshotErrorCount = 0;
+  private int failedSnapshotIterationCount = 0;
   private long lastSuccessfulSnapshotBackupIterationFinishTime = System.currentTimeMillis();
   private boolean snapshotBackupActive = false;
   private long snapshotIterationDuration = 0L;
   private int numberOfSnapshotFilesBackedUpLastIteration = 0;
-  private int txnLogErrorCount = 0;
+  private int failedTxnLogIterationCount = 0;
   private long lastSuccessfulTxnLogBackupIterationFinishTime = System.currentTimeMillis();
   private boolean txnLogBackupActive = false;
   private long txnLogIterationDuration = 0L;
@@ -41,10 +41,12 @@ public class BackupStats {
 
   /**
    * Counter
-   * @return Number of snapshot backup errors occur since last successful snapshot backup iteration
+   * For example: if backup iteration A fails, the number is 1; if next backup iteration B succeeds, the number is reset to 0.
+   * If A fails, the number is 1; if then B fails too, the number is incremented to 2.
+   * @return Number of consecutive snapshot backup errors since last successful snapshot backup iteration
    */
-  public int getSuccessiveSnapshotIterationErrorCount() {
-    return snapshotErrorCount;
+  public int getNumConsecutiveFailedSnapshotIterations() {
+    return failedSnapshotIterationCount;
   }
 
   /**
@@ -84,10 +86,12 @@ public class BackupStats {
 
   /**
    * Counter
-   * @return Number of txn log backup errors after last successful txn log backup iteration
+   * For example: if backup iteration A fails, the number is 1; if next backup iteration B succeeds, the number is reset to 0.
+   * If A fails, the number is 1; if then B fails too, the number is incremented to 2.
+   * @return Number of consecutive txn log backup errors since last successful txn log backup iteration
    */
-  public int getSuccessiveTxnLogIterationErrorCount() {
-    return txnLogErrorCount;
+  public int getNumConsecutiveFailedTxnLogIterations() {
+    return failedTxnLogIterationCount;
   }
 
   /**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupStats.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupStats.java
@@ -31,7 +31,7 @@ public class BackupStats {
   private long lastSuccessfulSnapshotBackupIterationFinishTime = System.currentTimeMillis();
   private boolean snapshotBackupActive = false;
   private long snapshotIterationDuration = 0L;
-  private int numberOfSnapshotBackupFilesCreatedLastIteration = 0;
+  private int numberOfSnapshotFilesBackedUpLastIteration = 0;
   private int txnLogErrorCount = 0;
   private long lastSuccessfulTxnLogBackupIterationFinishTime = System.currentTimeMillis();
   private boolean txnLogBackupActive = false;
@@ -40,20 +40,24 @@ public class BackupStats {
   // Snapshot backup metrics
 
   /**
+   * Counter
    * @return Number of snapshot backup errors occur since last successful snapshot backup iteration
    */
-  public int getSnapshotErrorCount() {
+  public int getSuccessiveSnapshotIterationErrorCount() {
     return snapshotErrorCount;
   }
 
   /**
+   * Counter
    * @return Time passed (minutes) since last successful snapshot backup iteration
    */
   public long getMinutesSinceLastSuccessfulSnapshotIteration() {
-    return (System.currentTimeMillis() - lastSuccessfulSnapshotBackupIterationFinishTime) / (60 * 1000);
+    return (System.currentTimeMillis() - lastSuccessfulSnapshotBackupIterationFinishTime) / (60
+        * 1000);
   }
 
   /**
+   * Gauge
    * @return If snapshot backup is currently actively ongoing
    */
   public boolean getSnapshotBackupActiveStatus() {
@@ -61,36 +65,42 @@ public class BackupStats {
   }
 
   /**
-   * @return How long it took to complete the last successful snapshot backup iteration
+   * Gauge
+   * @return How long it took to complete the last snapshot backup iteration
    */
   public long getSnapshotIterationDuration() {
     return snapshotIterationDuration;
   }
 
   /**
-   * @return Number of backup files created in last snapshot backup iteration
+   * Gauge
+   * @return Number of snapshot files that were backed up to backup storage in last snapshot backup iteration
    */
-  public long getNumberOfSnapshotBackupFilesCreatedLastIteration() {
-    return numberOfSnapshotBackupFilesCreatedLastIteration;
+  public long getNumberOfSnapshotFilesBackedUpLastIteration() {
+    return numberOfSnapshotFilesBackedUpLastIteration;
   }
 
   // Transaction log backup metrics
 
   /**
+   * Counter
    * @return Number of txn log backup errors after last successful txn log backup iteration
    */
-  public int getTxnLogErrorCount() {
+  public int getSuccessiveTxnLogIterationErrorCount() {
     return txnLogErrorCount;
   }
 
   /**
+   * Counter
    * @return Time passed (minutes) since last successful txn log backup iteration
    */
   public long getMinutesSinceLastSuccessfulTxnLogIteration() {
-    return (System.currentTimeMillis() - lastSuccessfulTxnLogBackupIterationFinishTime) / (60 * 1000);
+    return (System.currentTimeMillis() - lastSuccessfulTxnLogBackupIterationFinishTime) / (60
+        * 1000);
   }
 
   /**
+   * Gauge
    * @return If txn log backup is currently actively ongoing
    */
   public boolean getTxnLogBackupActiveStatus() {
@@ -98,7 +108,8 @@ public class BackupStats {
   }
 
   /**
-   * @return How long it took to complete the last successful txn log backup iteration
+   * Gauge
+   * @return How long it took to complete the last txn log backup iteration
    */
   public long getTxnLogIterationDuration() {
     return txnLogIterationDuration;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupStats.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupStats.java
@@ -28,15 +28,13 @@ public class BackupStats {
   private static final Logger LOG = LoggerFactory.getLogger(BackupStats.class);
 
   private int snapshotErrorCount = 0;
-  private long snapshotTimeSinceLastSuccessfulIteration = Long.MAX_VALUE;
+  private long timeSinceLastSuccessfulSnapshotIteration = Long.MAX_VALUE;
   private boolean snapshotBackupActive = false;
-  private long snapshotIterationDuration = 0;
-  private int snapshotBackupFilesCreatedPerIteration = 0;
+  private long snapshotIterationDuration = 0L;
   private int txnLogErrorCount = 0;
-  private long txnLogTimeSinceLastSuccessfulIteration = Long.MAX_VALUE;
+  private long timeSinceLastSuccessfulTxnLogIteration = Long.MAX_VALUE;
   private boolean txnLogBackupActive = false;
-  private long txnLogIterationDuration = 0;
-  private int txnLogBackupFilesCreatedPerIteration = 0;
+  private long txnLogIterationDuration = 0L;
 
   // Snapshot backup metrics
   /**
@@ -49,8 +47,8 @@ public class BackupStats {
   /**
    * @return Time passed since last successful snapshot backup iteration
    */
-  public long getSnapshotTimeSinceLastSuccessfulIteration() {
-    return snapshotTimeSinceLastSuccessfulIteration;
+  public long getTimeElapsedSinceLastSuccessfulSnapshotIteration() {
+    return timeSinceLastSuccessfulSnapshotIteration;
   }
 
   /**
@@ -61,22 +59,15 @@ public class BackupStats {
   }
 
   /**
-   * @return The elapsed time to complete a snapshot backup iteration
+   * @return How long it took to complete the last successful snapshot backup iteration
    */
   public long getSnapshotIterationDuration() {
     return snapshotIterationDuration;
   }
 
-  /**
-   * @return Number of backup files created in a snapshot backup iteration
-   */
-  public long getSnapshotBackupFilesCreatedPerIteration() {
-    return snapshotBackupFilesCreatedPerIteration;
-  }
-
   // Transaction log backup metrics
   /**
-   * @return Number of txn log backup errors occur after last successful txn log backup iteration
+   * @return Number of txn log backup errors after last successful txn log backup iteration
    */
   public int getTxnLogErrorCount() {
     return txnLogErrorCount;
@@ -85,8 +76,8 @@ public class BackupStats {
   /**
    * @return Time passed since last successful txn log backup iteration
    */
-  public long getTxnLogTimeSinceLastSuccessfulIteration() {
-    return txnLogTimeSinceLastSuccessfulIteration;
+  public long getTimeSinceLastSuccessfulTxnLogIteration() {
+    return timeSinceLastSuccessfulTxnLogIteration;
   }
 
   /**
@@ -97,16 +88,9 @@ public class BackupStats {
   }
 
   /**
-   * @return The elapsed time to complete a txn log backup iteration
+   * @return How long it took to complete the last successful txn log backup iteration
    */
   public long getTxnLogIterationDuration() {
     return txnLogIterationDuration;
-  }
-
-  /**
-   * @return Number of backup files created in a txn log backup iteration
-   */
-  public int getTxnLogBackupFilesCreatedPerIteration() {
-    return txnLogBackupFilesCreatedPerIteration;
   }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -65,7 +65,7 @@ import org.slf4j.MDC;
 public class QuorumPeerConfig {
 
     private static final Logger LOG = LoggerFactory.getLogger(QuorumPeerConfig.class);
-    private static final int UNSET_SERVERID = -1;
+    public static final int UNSET_SERVERID = -1;
     public static final String nextDynamicConfigFileSuffix = ".dynamic.next";
 
     private static boolean standaloneEnabled = true;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -65,7 +65,7 @@ import org.slf4j.MDC;
 public class QuorumPeerConfig {
 
     private static final Logger LOG = LoggerFactory.getLogger(QuorumPeerConfig.class);
-    public static final int UNSET_SERVERID = -1;
+    private static final int UNSET_SERVERID = -1;
     public static final String nextDynamicConfigFileSuffix = ".dynamic.next";
 
     private static boolean standaloneEnabled = true;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerMain.java
@@ -148,7 +148,8 @@ public class QuorumPeerMain {
             }
             BackupManager backupManager = new BackupManager(config.dataDir, config.dataLogDir,
                 config.getBackupConfig().getStatusDir(), config.getBackupConfig().getTmpDir(),
-                config.getBackupConfig().getBackupIntervalInMinutes(), storageProvider);
+                config.getBackupConfig().getBackupIntervalInMinutes(), storageProvider,
+                config.getBackupConfig().getNamespace(), config.getServerId());
             backupManager.start();
         }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/BackupBeanTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/BackupBeanTest.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.zookeeper.DummyWatcher;
+import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.ZKTestCase;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.jmx.MBeanRegistry;
+import org.apache.zookeeper.jmx.ZKMBeanInfo;
+import org.apache.zookeeper.server.ServerCnxn;
+import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.apache.zookeeper.server.SyncRequestProcessor;
+import org.apache.zookeeper.server.ZooKeeperServer;
+import org.apache.zookeeper.server.backup.storage.BackupStorageProvider;
+import org.apache.zookeeper.server.backup.storage.impl.FileSystemBackupStorage;
+import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
+import org.apache.zookeeper.test.ClientBase;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BackupBeanTest extends ZKTestCase {
+  private static final Logger LOG = LoggerFactory.getLogger(BackupBeanTest.class);
+  private static String HOSTPORT = "127.0.0.1:" + PortAssignment.unique();
+  private static final int CONNECTION_TIMEOUT = 300000;
+  private static final String TEST_NAMESPACE = "TEST_NAMESPACE";
+
+  private ZooKeeper connection;
+  private File dataDir;
+  private File backupStatusDir;
+  private File backupTmpDir;
+  private File backupDir;
+  private ZooKeeperServer zks;
+  private ServerCnxnFactory serverCnxnFactory;
+  private BackupStorageProvider backupStorage;
+  private BackupManager backupManager;
+  private BackupStatus backupStatus;
+  private FileTxnSnapLog snapLog;
+  private BackupConfig backupConfig;
+
+  @Before
+  public void setup() throws Exception {
+    dataDir = ClientBase.createTmpDir();
+    backupStatusDir = ClientBase.createTmpDir();
+    backupTmpDir = ClientBase.createTmpDir();
+    backupDir = ClientBase.createTmpDir();
+
+    backupConfig = new BackupConfig.Builder().
+        setEnabled(true).
+        setStatusDir(testBaseDir).
+        setTmpDir(testBaseDir).
+        setBackupStoragePath(backupDir.getAbsolutePath()).
+        setNamespace(TEST_NAMESPACE).
+            setStorageProviderClassName(FileSystemBackupStorage.class.getName()).
+            build().get();
+    backupStorage = new FileSystemBackupStorage(backupConfig);
+
+    ClientBase.setupTestEnv();
+
+    LOG.info("Starting Zk");
+
+    zks = new ZooKeeperServer(dataDir, dataDir, 3000);
+    SyncRequestProcessor.setSnapCount(100);
+    final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
+    serverCnxnFactory = ServerCnxnFactory.createFactory(PORT, -1);
+    serverCnxnFactory.startup(zks);
+
+    LOG.info("Waiting for server startup");
+
+    Assert.assertTrue("waiting for server being up ",
+        ClientBase.waitForServerUp(HOSTPORT, CONNECTION_TIMEOUT));
+
+    backupStatus = new BackupStatus(backupStatusDir);
+
+    snapLog = new FileTxnSnapLog(dataDir, dataDir);
+
+    connection = new ZooKeeper(HOSTPORT, CONNECTION_TIMEOUT, DummyWatcher.INSTANCE);
+  }
+
+  @After
+  public void teardown() throws Exception {
+    if (connection != null) {
+      connection.close();
+    }
+    connection = null;
+
+    LOG.info("Closing and cleaning up Zk");
+
+    LOG.info("Closing Zk");
+
+    if (serverCnxnFactory != null) {
+      serverCnxnFactory.closeAll(ServerCnxn.DisconnectReason.SERVER_SHUTDOWN);
+      serverCnxnFactory.shutdown();
+      serverCnxnFactory = null;
+    }
+
+    if (zks != null) {
+      zks.getZKDatabase().close();
+      zks.shutdown();
+      zks = null;
+    }
+
+    Assert.assertTrue("waiting for server to shutdown",
+        ClientBase.waitForServerDown(HOSTPORT, CONNECTION_TIMEOUT));
+
+    backupManager = null;
+    backupStatus = null;
+    serverCnxnFactory = null;
+    zks = null;
+    snapLog = null;
+    backupStorage = null;
+  }
+
+  @Test
+  public void testMBeanRegistration() throws IOException {
+    // Register MBean when initializing backup manager
+    BackupManager bm = new BackupManager(dataDir, dataDir, dataDir, backupTmpDir, 15,
+        new FileSystemBackupStorage(backupConfig), TEST_NAMESPACE, 0);
+    String expectedMBeanName = "Backup_" + TEST_NAMESPACE + ".server0";
+    Set<ZKMBeanInfo> mbeans = MBeanRegistry.getInstance().getRegisteredBeans();
+    Assert.assertTrue(containsMBean(mbeans, expectedMBeanName, false));
+
+    // Unregister MBean when stopping backup manager
+    bm.stop();
+    mbeans = MBeanRegistry.getInstance().getRegisteredBeans();
+    Assert.assertFalse(containsMBean(mbeans, expectedMBeanName, false));
+  }
+
+  private boolean containsMBean(Set<ZKMBeanInfo> mbeanSet, String mbeanName, boolean isHidden) {
+    Optional<ZKMBeanInfo> foundMBean = mbeanSet.stream()
+        .filter(mbean -> mbean.getName().equals(mbeanName) && mbean.isHidden() == isHidden)
+        .findAny();
+    return foundMBean.isPresent();
+  }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/BackupBeanTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/BackupBeanTest.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
 
 public class BackupBeanTest extends ZKTestCase {
   private static final Logger LOG = LoggerFactory.getLogger(BackupBeanTest.class);
-  private static String HOSTPORT = "127.0.0.1:" + PortAssignment.unique();
+  private static final String HOSTPORT = "127.0.0.1:" + PortAssignment.unique();
   private static final int CONNECTION_TIMEOUT = 300000;
   private static final String TEST_NAMESPACE = "TEST_NAMESPACE";
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/BackupManagerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/BackupManagerTest.java
@@ -120,7 +120,7 @@ public class BackupManagerTest extends ZKTestCase implements Watcher {
     File backupDir = ClientBase.createTmpDir();
 
     BackupManager bm = new BackupManager(dataDir, dataDir, dataDir, backupTmpDir, 15,
-        new FileSystemBackupStorage(backupConfig));
+        new FileSystemBackupStorage(backupConfig), null, -1);
     bm.initialize();
 
     bm.getLogBackup().run(1);
@@ -523,7 +523,7 @@ public class BackupManagerTest extends ZKTestCase implements Watcher {
         ClientBase.waitForServerUp(HOSTPORT, CONNECTION_TIMEOUT));
 
     backupManager = new BackupManager(dataDir, dataDir, backupStatusDir, backupTmpDir, 15,
-        backupStorage);
+        backupStorage, null, -1);
     backupManager.initialize();
     backupStatus = new BackupStatus(backupStatusDir);
   }


### PR DESCRIPTION
This PR is first commit of zk backup monitoring implementation. This commit adds two new class: BackupBean and BackupStats.
Key logics involved:
1. Metric definitions in BackupBean and BackupStats
2. Pass information from QuorumPeerMain to instantiate and register BackupBean in BackupManager
Test: BackupBeanTest
More unit tests to be added once the entire implementation is completed.