### PR TITLE
Add timetable support for ZooKeeper backup and restore

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
@@ -20,12 +20,12 @@ package org.apache.zookeeper.server.backup;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import org.apache.commons.lang.NullArgumentException;
-import org.apache.commons.lang.time.StopWatch;
 import org.apache.zookeeper.jmx.MBeanRegistry;
+import org.apache.zookeeper.server.backup.exception.BackupException;
 import org.apache.zookeeper.server.backup.monitoring.BackupBean;
 import org.apache.zookeeper.server.backup.monitoring.BackupStats;
 import org.apache.zookeeper.server.backup.storage.BackupStorageProvider;
+import org.apache.zookeeper.server.backup.timetable.TimetableBackup;
 import org.apache.zookeeper.server.persistence.*;
 import org.apache.zookeeper.server.backup.BackupUtil.BackupFileType;
 import org.apache.zookeeper.server.backup.BackupUtil.ZxidPart;
@@ -36,7 +36,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import javax.management.JMException;
 
 /**
@@ -51,7 +54,8 @@ public class BackupManager {
   private final File snapDir;
   private final File dataLogDir;
   private final File tmpDir;
-  private final int backupIntervalInMilliseconds;
+  private final BackupConfig backupConfig;
+  private final long backupIntervalInMilliseconds;
   private BackupProcess logBackup = null;
   private BackupProcess snapBackup = null;
 
@@ -60,6 +64,7 @@ public class BackupManager {
   private final BackupStatus backupStatus;
   private long backedupLogZxid;
   private long backedupSnapZxid;
+  private long backedupTimestamp;
 
   private final BackupStorageProvider backupStorage;
   private final long serverId;
@@ -68,10 +73,13 @@ public class BackupManager {
   protected BackupBean backupBean = null;
   private BackupStats backupStats = null;
 
+  // Optional timetable backup
+  private BackupProcess timetableBackup = null;
+
   /**
    * Tracks a file that needs to be backed up, including temporary copies of the file
    */
-  protected static class BackupFile {
+  public static class BackupFile {
     private final File file;
     private final boolean isTemporary;
     private final ZxidRange zxidRange;
@@ -159,174 +167,6 @@ public class BackupManager {
   }
 
   /**
-   * Base class for the txnlog and snap back processes.
-   * Provides the main backup loop and copying to remote storage (via HDFS APIs)
-   */
-  public abstract class BackupProcess implements Runnable {
-    protected final Logger logger;
-    private volatile boolean isRunning = true;
-
-    /**
-     * Initialize starting backup point based on remote storage and backupStatus file
-     */
-    protected abstract void initialize() throws IOException;
-
-    /**
-     * Marks the start of a backup iteration.  A backup iteration is run every
-     * backup.interval.  This is called at the start of the iteration and before
-     * any calls to getNextFileToBackup
-     * @throws IOException
-     */
-    protected abstract void startIteration() throws IOException;
-
-    /**
-     * Marks the end of a backup iteration.  After this call there will be no more
-     * calls to getNextFileToBackup or backupComplete until startIteration is
-     * called again.
-     * @param errorFree whether the iteration was error free
-     * @throws IOException
-     */
-    protected abstract void endIteration(boolean errorFree);
-
-    /**
-     * Get the next file to backup
-     * @return the next file to copy to backup storage.
-     * @throws IOException
-     */
-    protected abstract BackupFile getNextFileToBackup() throws IOException;
-
-    /**
-     * Marks that the copy of the specified file to backup storage has completed
-     * @param file the file to backup
-     * @throws IOException
-     */
-    protected abstract void backupComplete(BackupFile file) throws IOException;
-
-    /**
-     * Create an instance of the backup process
-     * @param logger the logger to use for this process.
-     */
-    public BackupProcess(Logger logger) {
-      if (logger == null) {
-        throw new NullArgumentException("logger");
-      }
-
-      this.logger = logger;
-    }
-
-    /**
-     * Runs the main file based backup loop indefinitely.
-     */
-    public void run() {
-      run(0);
-    }
-
-    /**
-     * Runs the main file based backup loop the specified number of time.
-     * Calls methods implemented by derived classes to get the next file to copy.
-     */
-    public void run(int iterations) {
-      try {
-        boolean errorFree = true;
-        logger.debug("Thread starting.");
-
-        while (isRunning) {
-          BackupFile fileToCopy;
-          StopWatch sw = new StopWatch();
-
-          sw.start();
-
-          try {
-            if (logger.isDebugEnabled()) {
-              logger.debug("Starting iteration");
-            }
-
-            // Cleanup any invalid backups that may have been left behind by the
-            // previous failed iteration.
-            // NOTE: Not done on first iteration (errorFree initialized to true) since
-            //       initialize already does this.
-            if (!errorFree) {
-              backupStorage.cleanupInvalidFiles(null);
-            }
-
-            startIteration();
-
-            while ((fileToCopy = getNextFileToBackup()) != null) {
-              // Consider: compress file before sending to remote storage
-              copyToRemoteStorage(fileToCopy);
-              backupComplete(fileToCopy);
-              fileToCopy.cleanup();
-            }
-
-            errorFree = true;
-          } catch (IOException e) {
-            errorFree = false;
-            logger.warn("Exception hit during backup", e);
-          }
-
-          endIteration(errorFree);
-
-          sw.stop();
-          long elapsedTime = sw.getTime();
-
-          logger.info("Completed backup iteration in {} milliseconds.  ErrorFree: {}.",
-              elapsedTime, errorFree);
-
-          if (iterations != 0) {
-            iterations--;
-
-            if (iterations < 1) {
-              break;
-            }
-          }
-
-          // Count elapsed time towards the backup interval
-          long waitTime = backupIntervalInMilliseconds - elapsedTime;
-
-          synchronized (this) {  // synchronized to get notification of termination
-            if (waitTime > 0) {
-              wait(waitTime);
-            }
-          }
-        }
-      } catch (InterruptedException e) {
-        logger.warn("Interrupted exception while waiting for backup interval.", e.fillInStackTrace());
-      } catch (Exception e) {
-        logger.error("Hit unexpected exception", e.fillInStackTrace());
-      }
-
-      logger.warn("BackupProcess thread exited loop!");
-    }
-
-    /**
-     * Copy given file to remote storage via HDFS APIs.
-     * @param fileToCopy the file to copy
-     * @throws IOException
-     */
-    private void copyToRemoteStorage(BackupFile fileToCopy) throws IOException {
-      if (fileToCopy.getFile() == null) {
-        return;
-      }
-
-      // Use the file name to encode the max included zxid
-      String backedupName = BackupUtil.makeBackupName(
-          fileToCopy.getFile().getName(), fileToCopy.getMaxZxid());
-
-      backupStorage.copyToBackupStorage(fileToCopy.getFile(), new File(backedupName));
-    }
-
-    /**
-     * Shutdown the backup process
-     */
-    public void shutdown() {
-      synchronized (this) {
-        isRunning = false;
-        notifyAll();
-      }
-    }
-  }
-
-  /**
    * Implements txnlog specific logic for BackupProcess
    */
   protected class TxnLogBackup extends BackupProcess {
@@ -338,7 +178,8 @@ public class BackupManager {
      * @param snapLog the FileTxnSnapLog object to use
      */
     public TxnLogBackup(FileTxnSnapLog snapLog) {
-      super(LoggerFactory.getLogger(TxnLogBackup.class));
+      super(LoggerFactory.getLogger(TxnLogBackup.class), backupStorage,
+          backupIntervalInMilliseconds);
       this.snapLog = snapLog;
     }
 
@@ -523,7 +364,7 @@ public class BackupManager {
      * @param snapLog the FileTxnSnapLog object to use
      */
     public SnapBackup(FileTxnSnapLog snapLog) {
-      super(LoggerFactory.getLogger(SnapBackup.class));
+      super(LoggerFactory.getLogger(SnapBackup.class), backupStorage, backupIntervalInMilliseconds);
       this.snapLog = snapLog;
     }
 
@@ -636,33 +477,35 @@ public class BackupManager {
    * Constructor for the BackupManager.
    * @param snapDir the snapshot directory
    * @param dataLogDir the txnlog directory
-   * @param backupStatusDir the backup status directory
-   * @param tmpDir temporary directory
-   * @param backupIntervalInMinutes the interval backups should run at in minutes
-   * @param namespace the namespace of zk cluster to be backed up
    * @param serverId the id of the zk server
+   * @param backupConfig the backup config object
    * @throws IOException
    */
-  public BackupManager(File snapDir, File dataLogDir, File backupStatusDir, File tmpDir,
-      int backupIntervalInMinutes, BackupStorageProvider backupStorageProvider, String namespace,
-      long serverId) throws IOException {
+  public BackupManager(File snapDir, File dataLogDir, long serverId, BackupConfig backupConfig)
+      throws IOException {
     logger = LoggerFactory.getLogger(BackupManager.class);
     logger.info("snapDir={}", snapDir.getPath());
     logger.info("dataLogDir={}", dataLogDir.getPath());
-    logger.info("backupStatusDir={}", backupStatusDir.getPath());
-    logger.info("tmpDir={}", tmpDir.getPath());
-    logger.info("backupIntervalInMinutes={}", backupIntervalInMinutes);
+    logger.info("backupStatusDir={}", backupConfig.getStatusDir().getPath());
+    logger.info("tmpDir={}", backupConfig.getTmpDir().getPath());
+    logger.info("backupIntervalInMinutes={}", backupConfig.getBackupIntervalInMinutes());
     logger.info("serverId={}", serverId);
-    logger.info("namespace={}", namespace);
+    logger.info("namespace={}", backupConfig.getNamespace());
 
     this.snapDir = snapDir;
     this.dataLogDir = dataLogDir;
-    this.tmpDir = tmpDir;
-    this.backupStatus = new BackupStatus(backupStatusDir);
-    this.backupIntervalInMilliseconds = backupIntervalInMinutes * 60 * 1000;
-    this.backupStorage = backupStorageProvider;
+    this.backupConfig = backupConfig;
+    this.tmpDir = backupConfig.getTmpDir();
+    this.backupStatus = new BackupStatus(backupConfig.getStatusDir());
+    this.backupIntervalInMilliseconds =
+        TimeUnit.MINUTES.toMillis(backupConfig.getBackupIntervalInMinutes());
     this.serverId = serverId;
-    this.namespace = namespace == null ? "UNKNOWN" : namespace;
+    this.namespace = backupConfig.getNamespace() == null ? "UNKNOWN" : backupConfig.getNamespace();
+    try {
+      backupStorage = createStorageProviderImpl(backupConfig);
+    } catch (ReflectiveOperationException e) {
+      throw new BackupException(e.getMessage(), e);
+    }
     initialize();
   }
 
@@ -675,6 +518,9 @@ public class BackupManager {
 
     (new Thread(logBackup)).start();
     (new Thread(snapBackup)).start();
+    if (timetableBackup != null) {
+      (new Thread(timetableBackup)).start();
+    }
   }
 
   /**
@@ -697,6 +543,7 @@ public class BackupManager {
 
   public BackupProcess getLogBackup() { return logBackup; }
   public BackupProcess getSnapBackup() { return snapBackup; }
+  public BackupProcess getTimetableBackup() { return timetableBackup; }
 
   public long getBackedupLogZxid() {
     synchronized (backupStatus) {
@@ -727,6 +574,9 @@ public class BackupManager {
       BackupPoint bp = backupStatus.read();
       backedupLogZxid = bp.getLogZxid();
       backedupSnapZxid = bp.getSnapZxid();
+      if (backupConfig.isTimetableEnabled()) {
+        backedupTimestamp = bp.getTimestamp();
+      }
     }
 
     if (!tmpDir.exists()) {
@@ -742,5 +592,44 @@ public class BackupManager {
 
     logBackup.initialize();
     snapBackup.initialize();
+
+    // if timetable backup is enabled, initialize it as well
+    if (backupConfig.isTimetableEnabled()) {
+      // Create a separate instance of BackupStorageProvider for timetable backup
+      // This is because we want the timetable backup to be stored in a different storage path
+      BackupStorageProvider timetableBackupStorage;
+      try {
+        timetableBackupStorage = createStorageProviderImpl(
+            backupConfig.getBuilder().setBackupStoragePath(backupConfig.getTimetableStoragePath())
+                .build().get());
+      } catch (Exception e) {
+        throw new BackupException(e.getMessage(), e);
+      }
+      timetableBackup = new TimetableBackup(new FileTxnSnapLog(dataLogDir, snapDir), tmpDir,
+          timetableBackupStorage, backupIntervalInMilliseconds,
+          backupConfig.getTimetableBackupIntervalInMs());
+      timetableBackup.initialize();
+    }
+  }
+
+  /**
+   * Instantiates the storage provider implementation by reflection. This allows the user to
+   * choose which BackupStorageProvider implementation to use by specifying the fully-qualified
+   * class name in BackupConfig (read from Properties).
+   * @param backupConfig
+   * @return
+   * @throws ClassNotFoundException
+   * @throws NoSuchMethodException
+   * @throws IllegalAccessException
+   * @throws InvocationTargetException
+   * @throws InstantiationException
+   */
+  private BackupStorageProvider createStorageProviderImpl(BackupConfig backupConfig)
+      throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException,
+             InvocationTargetException, InstantiationException {
+    Class<?> clazz = Class.forName(backupConfig.getStorageProviderClassName());
+    Constructor<?> constructor = clazz.getConstructor(BackupConfig.class);
+    Object storageProvider = constructor.newInstance(backupConfig);
+    return (BackupStorageProvider) storageProvider;
   }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
@@ -595,6 +595,7 @@ public class BackupManager {
 
     // if timetable backup is enabled, initialize it as well
     if (backupConfig.isTimetableEnabled()) {
+      LOG.info("BackupManager::initialize(): timetable is enabled!");
       // Create a separate instance of BackupStorageProvider for timetable backup
       // This is because we want the timetable backup to be stored in a different storage path
       BackupStorageProvider timetableBackupStorage;
@@ -602,6 +603,9 @@ public class BackupManager {
         timetableBackupStorage = createStorageProviderImpl(
             backupConfig.getBuilder().setBackupStoragePath(backupConfig.getTimetableStoragePath())
                 .build().get());
+        LOG.info(
+            "BackupManager::initialize(): timetable backup storage initialized! Timetable storage path: "
+                + backupConfig.getTimetableStoragePath());
       } catch (Exception e) {
         throw new BackupException(e.getMessage(), e);
       }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupPoint.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupPoint.java
@@ -24,6 +24,7 @@ package org.apache.zookeeper.server.backup;
 public class BackupPoint {
   private final long logZxid;
   private final long snapZxid;
+  private long timestamp; // backup timetable is optional
 
   /**
    * Create an instance of a BackupPoint
@@ -46,4 +47,21 @@ public class BackupPoint {
    * @return the starting zxid of the latest backed up snap
    */
   public long getSnapZxid() { return snapZxid; }
+
+  /**
+   * Get the starting timestamp of the latest backed up timetable backup file
+   * @return the starting timestamp of the latest backed up timetable backup file
+   */
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  /**
+   * Set the starting timestamp of the latest backed up timetable backup file
+   * @param timestamp
+   * @return
+   */
+  public void setTimestamp(long timestamp) {
+    this.timestamp = timestamp;
+  }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupProcess.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupProcess.java
@@ -1,0 +1,182 @@
+package org.apache.zookeeper.server.backup;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.lang.NullArgumentException;
+import org.apache.commons.lang.time.StopWatch;
+import org.apache.zookeeper.server.backup.storage.BackupStorageProvider;
+import org.slf4j.Logger;
+
+/**
+ * Base class for the txnlog and snap back processes.
+ * Provides the main backup loop and copying to remote storage (via HDFS APIs)
+ */
+public abstract class BackupProcess implements Runnable {
+  protected final Logger logger;
+  private BackupStorageProvider backupStorage;
+  private final long backupIntervalInMilliseconds;
+  protected volatile boolean isRunning = true;
+
+  /**
+   * Initialize starting backup point based on remote storage and backupStatus file
+   */
+  protected abstract void initialize() throws IOException;
+
+  /**
+   * Marks the start of a backup iteration.  A backup iteration is run every
+   * backup.interval.  This is called at the start of the iteration and before
+   * any calls to getNextFileToBackup
+   * @throws IOException
+   */
+  protected abstract void startIteration() throws IOException;
+
+  /**
+   * Marks the end of a backup iteration.  After this call there will be no more
+   * calls to getNextFileToBackup or backupComplete until startIteration is
+   * called again.
+   * @param errorFree whether the iteration was error free
+   * @throws IOException
+   */
+  protected abstract void endIteration(boolean errorFree);
+
+  /**
+   * Get the next file to backup
+   * @return the next file to copy to backup storage.
+   * @throws IOException
+   */
+  protected abstract BackupManager.BackupFile getNextFileToBackup() throws IOException;
+
+  /**
+   * Marks that the copy of the specified file to backup storage has completed
+   * @param file the file to backup
+   * @throws IOException
+   */
+  protected abstract void backupComplete(BackupManager.BackupFile file) throws IOException;
+
+  /**
+   * Create an instance of the backup process
+   * @param logger the logger to use for this process.
+   */
+  public BackupProcess(Logger logger, BackupStorageProvider backupStorage,
+      long backupIntervalInMilliseconds) {
+    if (logger == null) {
+      throw new NullArgumentException("BackupProcess: logger is null!");
+    }
+
+    this.logger = logger;
+    this.backupStorage = backupStorage;
+    this.backupIntervalInMilliseconds = backupIntervalInMilliseconds;
+  }
+
+  /**
+   * Runs the main file based backup loop indefinitely.
+   */
+  public void run() {
+    run(0);
+  }
+
+  /**
+   * Runs the main file based backup loop the specified number of time.
+   * Calls methods implemented by derived classes to get the next file to copy.
+   */
+  public void run(int iterations) {
+    try {
+      boolean errorFree = true;
+      logger.debug("Thread starting.");
+
+      while (isRunning) {
+        BackupManager.BackupFile fileToCopy;
+        StopWatch sw = new StopWatch();
+
+        sw.start();
+
+        try {
+          if (logger.isDebugEnabled()) {
+            logger.debug("Starting iteration");
+          }
+
+          // Cleanup any invalid backups that may have been left behind by the
+          // previous failed iteration.
+          // NOTE: Not done on first iteration (errorFree initialized to true) since
+          //       initialize already does this.
+          if (!errorFree) {
+            backupStorage.cleanupInvalidFiles(null);
+          }
+
+          startIteration();
+
+          while ((fileToCopy = getNextFileToBackup()) != null) {
+            // Consider: compress file before sending to remote storage
+            copyToRemoteStorage(fileToCopy);
+            backupComplete(fileToCopy);
+            fileToCopy.cleanup();
+          }
+
+          errorFree = true;
+        } catch (IOException e) {
+          errorFree = false;
+          logger.warn("Exception hit during backup", e);
+        }
+
+        endIteration(errorFree);
+
+        sw.stop();
+        long elapsedTime = sw.getTime();
+
+        logger.info("Completed backup iteration in {} milliseconds.  ErrorFree: {}.",
+            elapsedTime, errorFree);
+
+        if (iterations != 0) {
+          iterations--;
+
+          if (iterations < 1) {
+            break;
+          }
+        }
+
+        // Count elapsed time towards the backup interval
+        long waitTime = backupIntervalInMilliseconds - elapsedTime;
+
+        synchronized (this) {  // synchronized to get notification of termination
+          if (waitTime > 0) {
+            wait(waitTime);
+          }
+        }
+      }
+    } catch (InterruptedException e) {
+      logger.warn("Interrupted exception while waiting for backup interval.", e.fillInStackTrace());
+    } catch (Exception e) {
+      logger.error("Hit unexpected exception", e.fillInStackTrace());
+    }
+
+    logger.warn("BackupProcess thread exited loop!");
+  }
+
+  /**
+   * Copy given file to remote storage via Backup Storage (HDFS, NFS, etc.) APIs.
+   * @param fileToCopy the file to copy
+   * @throws IOException
+   */
+  private void copyToRemoteStorage(BackupManager.BackupFile fileToCopy) throws IOException {
+    if (fileToCopy.getFile() == null) {
+      return;
+    }
+
+    // Use the file name to encode the max included zxid
+    String backupName = BackupUtil.makeBackupName(
+        fileToCopy.getFile().getName(), fileToCopy.getMaxZxid());
+
+    backupStorage.copyToBackupStorage(fileToCopy.getFile(), new File(backupName));
+  }
+
+  /**
+   * Shutdown the backup process
+   */
+  public void shutdown() {
+    synchronized (this) {
+      isRunning = false;
+      notifyAll();
+    }
+  }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupStatus.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupStatus.java
@@ -28,6 +28,8 @@ import org.apache.jute.BinaryInputArchive;
 import org.apache.jute.BinaryOutputArchive;
 import org.apache.jute.InputArchive;
 import org.apache.jute.OutputArchive;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Coordinate the backup status among processes local to a server;
@@ -35,6 +37,8 @@ import org.apache.jute.OutputArchive;
  * to the ZAB protocol or by some external mechanism.
  */
 public class BackupStatus {
+  private static final Logger LOG = LoggerFactory.getLogger(BackupStatus.class);
+
   /**
    * The name for the backup status file.
    */
@@ -123,6 +127,7 @@ public class BackupStatus {
 
   /**
    * Update the backup point in the status file, Creates the status file if needed.
+   * TODO: consider adding timestamp backup status here
    * @param logZxid the latest backed up txn log zxid
    * @param snapZxid the starting zxid of the latest backed up snapshot
    * @throws IOException
@@ -133,7 +138,8 @@ public class BackupStatus {
     }
 
     if (!statusFile.exists()) {
-      System.out.println("Creating file " + statusFile.getAbsolutePath());
+      LOG.info("BackupStatus::update(): BackupStatus file doesn't exist. Creating file at path: "
+          + statusFile.getAbsolutePath());
       statusFile.createNewFile();
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupSystemProperty.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupSystemProperty.java
@@ -33,4 +33,10 @@ public class BackupSystemProperty {
   public static final String BACKUP_STORAGE_CONFIG = "backup.storageConfig";
   public static final String BACKUP_STORAGE_PATH = "backup.storagePath";
   public static final String BACKUP_NAMESPACE = "backup.namespace";
+
+  // Backup timetable properties
+  public static final String BACKUP_TIMETABLE_ENABLED = "backup.timetable.enabled";
+  public static final String BACKUP_TIMETABLE_STORAGE_PATH = "backup.timetable.storagePath";
+  public static final String BACKUP_TIMETABLE_BACKUP_INTERVAL_MS =
+      "backup.timetable.backupIntervalInMs";
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupUtil.java
@@ -141,6 +141,13 @@ public class BackupUtil {
         }
       };
 
+  /**
+   * Creates a file name string for a backup file by appending a high zxid/long in Hex if it
+   * doesn't already.
+   * @param standardName
+   * @param highZxid
+   * @return
+   */
   public static String makeBackupName(String standardName, long highZxid) {
     return standardName.indexOf('-') >= 0
         ? standardName

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/storage/impl/FileSystemBackupStorage.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/storage/impl/FileSystemBackupStorage.java
@@ -54,7 +54,6 @@ import org.slf4j.LoggerFactory;
  */
 public class FileSystemBackupStorage implements BackupStorageProvider {
   private static final Logger LOG = LoggerFactory.getLogger(FileSystemBackupStorage.class);
-  private final BackupConfig backupConfig;
   private final String fileRootPath;
   private final ReadWriteLock rwLock;
   private final Lock sharedLock;
@@ -70,9 +69,8 @@ public class FileSystemBackupStorage implements BackupStorageProvider {
           "The backup storage is not ready, please check the path: " + backupConfig
               .getBackupStoragePath());
     }
-    this.backupConfig = backupConfig;
-    fileRootPath = String.join(File.separator, this.backupConfig.getBackupStoragePath(),
-        this.backupConfig.getNamespace());
+    fileRootPath = String
+        .join(File.separator, backupConfig.getBackupStoragePath(), backupConfig.getNamespace());
     rwLock = new ReentrantReadWriteLock();
     sharedLock = rwLock.readLock();
     exclusiveLock = rwLock.writeLock();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/timetable/TimetableBackup.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/timetable/TimetableBackup.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup.timetable;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.util.TreeMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.apache.zookeeper.server.backup.BackupManager;
+import org.apache.zookeeper.server.backup.BackupProcess;
+import org.apache.zookeeper.server.backup.exception.BackupException;
+import org.apache.zookeeper.server.backup.storage.BackupStorageProvider;
+import org.apache.zookeeper.server.persistence.FileTxnLog;
+import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
+import org.apache.zookeeper.server.persistence.TxnLog;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implements Timetable-specific logic for BackupProcess.
+ *
+ * Backup timetable encodes data of the format <timestamp>:<zxid>. This is used to locate the
+ * closest zxid backup point given the timestamp. The use case is for users who wish to restore
+ * from backup at a specific time recorded in the backup timetable.
+ */
+public class TimetableBackup extends BackupProcess {
+  public static final String TIMETABLE_PREFIX = "timetable";
+  // Use an ordered map of <timestamp>:<zxid>
+  private final TreeMap<Long, String> timetableRecordMap = new TreeMap<>();
+  private final File tmpDir;
+  // Lock is used to keep access to timetableRecordMap exclusive
+  private final Lock lock = new ReentrantLock(true);
+
+  // File to be backed up each iteration
+  private BackupManager.BackupFile timetableBackupFile;
+
+  /**
+   * Create an instance of TimetableBackup.
+   * @param snapLog
+   * @param tmpDir
+   * @param backupStorageProvider
+   * @param backupIntervalInMilliseconds
+   * @param timetableBackupIntervalInMs
+   */
+  public TimetableBackup(FileTxnSnapLog snapLog, File tmpDir,
+      BackupStorageProvider backupStorageProvider, long backupIntervalInMilliseconds,
+      long timetableBackupIntervalInMs) {
+    super(LoggerFactory.getLogger(TimetableBackup.class), backupStorageProvider,
+        backupIntervalInMilliseconds);
+    this.tmpDir = tmpDir;
+    // Start creating records
+    (new Thread(new TimetableRecorder(snapLog, timetableBackupIntervalInMs))).start();
+    logger.info(
+        "Starting TimetableBackup Process with backup interval: " + backupIntervalInMilliseconds
+            + " ms and timetable backup interval: " + timetableBackupIntervalInMs + " ms.");
+  }
+
+  @Override
+  protected void initialize() throws IOException {
+  }
+
+  @Override
+  protected void startIteration() throws IOException {
+    // Create a timetable backup file from the cached records (timetableRecordMap)
+    lock.lock();
+    try {
+      if (!timetableRecordMap.isEmpty()) {
+        // Create a temp timetable backup file
+        // Putting the zxid values here is okay; the actual backup file name will contain the
+        // starting and ending timestamps, not zxids
+        long lowestZxid = Long.valueOf(timetableRecordMap.firstEntry().getValue(), 16);
+        long highestZxid = Long.valueOf(timetableRecordMap.lastEntry().getValue(), 16);
+        timetableBackupFile =
+            new BackupManager.BackupFile(createTimetableBackupFile(), true, lowestZxid,
+                highestZxid); // make it temporary so that it will be deleted after iteration
+        timetableRecordMap.clear(); // Clear the map
+      }
+    } catch (Exception e) {
+      logger.error(
+          "TimetableBackup::getNextFileToBackup(): failed to get next timetable file to back up!",
+          e);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  protected void endIteration(boolean errorFree) {
+    // timetableRecordMap is cleared in startIteration() already, so no need to clear it here
+  }
+
+  @Override
+  protected BackupManager.BackupFile getNextFileToBackup() throws IOException {
+    BackupManager.BackupFile nextFile = timetableBackupFile;
+    timetableBackupFile = null;
+    return nextFile;
+  }
+
+  @Override
+  protected void backupComplete(BackupManager.BackupFile file) throws IOException {
+    // TODO: consider updating BackupStatus if necessary
+  }
+
+  /**
+   * Create a file name for timetable backup.
+   * E.g.) timetable.<lowest timestamp>-<highest timestamp>
+   * @return
+   */
+  private String makeTimetableBackupFileName() {
+    return String.format("%s.%d-%d", TIMETABLE_PREFIX, timetableRecordMap.firstKey(),
+        timetableRecordMap.lastKey());
+  }
+
+  /**
+   * Write the content of timetableRecordMap to a file using a tmpDir.
+   * @return
+   * @throws IOException
+   */
+  private File createTimetableBackupFile() throws IOException {
+    File tempTimetableBackupFile = new File(tmpDir, makeTimetableBackupFileName());
+    FileOutputStream fos = new FileOutputStream(tempTimetableBackupFile);
+    ObjectOutputStream oos = new ObjectOutputStream(fos);
+    oos.writeObject(timetableRecordMap);
+    oos.flush();
+    oos.close();
+    fos.close();
+    return tempTimetableBackupFile;
+  }
+
+  /**
+   * Child thread that records timetable records (<timestamp>:<zxid>) at the given interval.
+   *
+   * TimetableBackup: parent thread responsible for creating timetable backup files from
+   * cached record (map) and writing to backup storage
+   * TimetableRecorder: child thread responsible for adding timetable-zxid mappings to the cached
+   * map at every timetable backup interval.
+   */
+  class TimetableRecorder implements Runnable {
+    private final FileTxnSnapLog snapLog;
+    private final long timetableBackupIntervalInMs;
+    private long lastLoggedZxidFromLastRun;
+
+    public TimetableRecorder(FileTxnSnapLog snapLog, long timetableBackupIntervalInMs) {
+      this.snapLog = snapLog;
+      this.timetableBackupIntervalInMs = timetableBackupIntervalInMs;
+      logger.info("TimetableRecorder created with timetable backup interval at "
+          + timetableBackupIntervalInMs + " ms.");
+    }
+
+    @Override
+    public void run() {
+      // The lifecycle of this child thread should be tied to that of TimetableBackup
+      while (isRunning) {
+        try {
+          lock.lock();
+          try {
+            FileTxnLog.ZxidTimestampPair lastLoggedZxidTimestampPair =
+                snapLog.getLastLoggedZxidTimestampPair();
+            // Ignore if the last logged zxid is not valid (-1) because -1 (int) will cause a
+            // NumberFormatException during conversion to Hex String
+            // Also do not create repeat records
+            if (lastLoggedZxidTimestampPair.getZxid() >= 0
+                && lastLoggedZxidTimestampPair.getZxid() != lastLoggedZxidFromLastRun) {
+              timetableRecordMap.put(lastLoggedZxidTimestampPair.getTimestamp(),
+                  Long.toHexString(lastLoggedZxidTimestampPair.getZxid()));
+              lastLoggedZxidFromLastRun = lastLoggedZxidTimestampPair.getZxid();
+            }
+          } catch (Exception e) {
+            // Bad state, this shouldn't happen. Throw an exception
+            throw new BackupException(
+                "TimetableRecorder::run(): failed to record a timestamp-zxid mapping!", e);
+          } finally {
+            lock.unlock();
+          }
+          synchronized (this) { // synchronized to get notification of termination in case of shutdown
+            wait(timetableBackupIntervalInMs);
+          }
+        } catch (InterruptedException e) {
+          logger.warn("TimetableRecorder::run(): Interrupted exception while waiting for "
+              + "timetable backup interval.", e.fillInStackTrace());
+        } catch (Exception e) {
+          logger.error("TimetableRecorder::run(): Hit unexpected exception", e.fillInStackTrace());
+        }
+      }
+    }
+  }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/timetable/TimetableBackup.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/timetable/TimetableBackup.java
@@ -126,6 +126,9 @@ public class TimetableBackup extends BackupProcess {
    * @return
    */
   private String makeTimetableBackupFileName() {
+    String name = String.format("%s.%d-%d", TIMETABLE_PREFIX, timetableRecordMap.firstKey(),
+        timetableRecordMap.lastKey());
+    System.out.println(name);
     return String.format("%s.%d-%d", TIMETABLE_PREFIX, timetableRecordMap.firstKey(),
         timetableRecordMap.lastKey());
   }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/timetable/TimetableBackup.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/timetable/TimetableBackup.java
@@ -70,9 +70,9 @@ public class TimetableBackup extends BackupProcess {
     this.tmpDir = tmpDir;
     // Start creating records
     (new Thread(new TimetableRecorder(snapLog, timetableBackupIntervalInMs))).start();
-    logger.info(
-        "Starting TimetableBackup Process with backup interval: " + backupIntervalInMilliseconds
-            + " ms and timetable backup interval: " + timetableBackupIntervalInMs + " ms.");
+    logger.info("TimetableBackup::Starting TimetableBackup Process with backup interval: "
+        + backupIntervalInMilliseconds + " ms and timetable backup interval: "
+        + timetableBackupIntervalInMs + " ms.");
   }
 
   @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/timetable/TimetableUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/timetable/TimetableUtil.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup.timetable;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.ObjectInputStream;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.apache.zookeeper.server.backup.exception.BackupException;
+
+/**
+ * Util methods used to operate on timetable backup.
+ */
+public class TimetableUtil {
+  private static final String LATEST = "latest";
+
+  /**
+   * Returns the last zxid corresponding to the timestamp preceding the timestamp given as argument.
+   * @param timetableBackupFiles
+   * @param timestamp timestamp string (long), or "latest"
+   * @return Hex String representation of the zxid found
+   */
+  public static String findLastZxidFromTimestamp(File[] timetableBackupFiles, String timestamp) {
+    // Verify arguments: backup files and timestamp
+    if (timetableBackupFiles == null || timetableBackupFiles.length == 0) {
+      throw new IllegalArgumentException(
+          "TimetableUtil::findLastZxidFromTimestamp(): timetableBackupFiles argument is either null"
+              + " or empty!");
+    }
+
+    long timestampLong;
+    if (!timestamp.equalsIgnoreCase(LATEST)) {
+      try {
+        timestampLong = Long.decode(timestamp);
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException(
+            "TimetableUtil::findLastZxidFromTimestamp(): cannot convert the given timestamp to a"
+                + " valid long! timestamp: " + timestamp, e);
+      }
+    } else {
+      timestampLong = Long.MAX_VALUE;
+    }
+
+    // Convert timetable backup files to an ordered Map<Long, String>, timestamp:zxid pairs
+    TreeMap<Long, String> timestampZxidPairs = new TreeMap<>();
+    try {
+      for (File file : timetableBackupFiles) {
+        FileInputStream fis = new FileInputStream(file);
+        ObjectInputStream ois = new ObjectInputStream(fis);
+        @SuppressWarnings("unchecked")
+        Map<Long, String> map = (TreeMap<Long, String>) ois.readObject();
+        timestampZxidPairs.putAll(map);
+      }
+    } catch (Exception e) {
+      throw new BackupException(
+          "TimetableUtil::findLastZxidFromTimestamp(): failed to read timetable backup files!", e);
+    }
+
+    // Check if the given timestamp is in range
+    if (!timestamp.equalsIgnoreCase(LATEST) && (timestampLong < timestampZxidPairs.firstKey()
+        || timestampLong > timestampZxidPairs.lastKey())) {
+      throw new IllegalArgumentException(
+          "TimetableUtil::findLastZxidFromTimestamp(): timestamp given is not in the timestamp "
+              + "range given in the backup files!");
+    }
+
+    // Find the last zxid corresponding to the timestamp given
+    Map.Entry<Long, String> floorEntry = timestampZxidPairs.floorEntry(timestampLong);
+    if (floorEntry == null) {
+      throw new BackupException("TimetableUtil::findLastZxidFromTimestamp(): floorEntry is null!");
+    }
+    return floorEntry.getValue();
+  }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnLog.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnLog.java
@@ -381,6 +381,55 @@ public class FileTxnLog implements TxnLog, Closeable {
         return zxid;
     }
 
+    /**
+     * get the last zxid/timestamp pair that was logged in the transaction logs
+     * @return the last zxid logged in the transaction logs and its corresponding timestamp
+     */
+    public ZxidTimestampPair getLastLoggedZxidTimestampPair() {
+        File[] files = getLogFiles(logDir.listFiles(), 0);
+        long maxLog = files.length > 0 ? Util
+            .getZxidFromName(files[files.length - 1].getName(), LOG_FILE_PREFIX) : -1;
+
+        TxnIterator itr = null;
+        ZxidTimestampPair zxidTimestampPair = null;
+        try {
+            FileTxnLog txn = new FileTxnLog(logDir);
+            itr = txn.read(maxLog);
+            zxidTimestampPair = new ZxidTimestampPair(maxLog, itr.getHeader().getTime());
+            while (itr.next()) {
+                TxnHeader hdr = itr.getHeader();
+                zxidTimestampPair = new ZxidTimestampPair(hdr.getZxid(), hdr.getTime());
+            }
+        } catch (IOException e) {
+            LOG.warn("getLastLoggedZxidTimestampPair():: Unexpected exception", e);
+        } finally {
+            close(itr);
+        }
+        if (zxidTimestampPair == null) {
+            // In case of an exception, return an invalid ZxidTimestampPair
+            zxidTimestampPair = new ZxidTimestampPair(-1, -1);
+        }
+        return zxidTimestampPair;
+    }
+
+    public class ZxidTimestampPair {
+        private final long zxid;
+        private final long timestamp;
+
+        public ZxidTimestampPair(long zxid, long timestamp) {
+            this.zxid = zxid;
+            this.timestamp = timestamp;
+        }
+
+        public long getZxid() {
+            return zxid;
+        }
+
+        public long getTimestamp() {
+            return timestamp;
+        }
+    }
+
     private void close(TxnIterator itr) {
         if (itr != null) {
             try {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
@@ -454,12 +454,12 @@ public class FileTxnSnapLog {
     }
 
     /**
-     * the last logged zxid + timestamp pair from the transaction log
-     * @return last logged zxid and timestamp
+     * the last logged TxnHeader from the transaction log
+     * @return last logged TxnHeader
      */
-    public FileTxnLog.ZxidTimestampPair getLastLoggedZxidTimestampPair() {
+    public TxnHeader getLastLoggedTxnHeader() {
         FileTxnLog txnLog = new FileTxnLog(dataDir);
-        return txnLog.getLastLoggedZxidTimestampPair();
+        return txnLog.getLastLoggedTxnHeader();
     }
 
     /**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/FileTxnSnapLog.java
@@ -454,6 +454,15 @@ public class FileTxnSnapLog {
     }
 
     /**
+     * the last logged zxid + timestamp pair from the transaction log
+     * @return last logged zxid and timestamp
+     */
+    public FileTxnLog.ZxidTimestampPair getLastLoggedZxidTimestampPair() {
+        FileTxnLog txnLog = new FileTxnLog(dataDir);
+        return txnLog.getLastLoggedZxidTimestampPair();
+    }
+
+    /**
      * save the datatree and the sessions into a snapshot
      * @param dataTree the datatree to be serialized onto disk
      * @param sessionsWithTimeouts the session timeouts to be

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/ZxidRange.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/ZxidRange.java
@@ -23,7 +23,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Range;
 
 /**
- * A range of of "long"s with an optional high "long" value to represent ZXID or timestamp ranges.
+ * A range of Zxids with an optional high zxid.
  */
 public class ZxidRange {
   public static final ZxidRange INVALID = new ZxidRange(-1L, Optional.of(-1L), true);
@@ -51,7 +51,7 @@ public class ZxidRange {
     this(low, Optional.<Long>absent(), false);
   }
 
-  public ZxidRange(com.google.common.collect.Range<Long> range) {
+  public ZxidRange(Range<Long> range) {
     this(range.lowerEndpoint(), range.upperEndpoint());
   }
 
@@ -61,13 +61,11 @@ public class ZxidRange {
     if (zxidParts.length == 1 && !value.endsWith("-")) {
       try {
         return new ZxidRange(Long.parseLong(zxidParts[0], 16));
-      } catch (NumberFormatException e) {
-      }
+      } catch (NumberFormatException e) { }
     } else if (zxidParts.length == 2) {
       try {
         return new ZxidRange(Long.parseLong(zxidParts[0], 16), Long.parseLong(zxidParts[1], 16));
-      } catch (NumberFormatException e) {
-      }
+      } catch (NumberFormatException e) { }
     }
 
     return ZxidRange.INVALID;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/ZxidRange.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/persistence/ZxidRange.java
@@ -23,7 +23,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Range;
 
 /**
- * A range of Zxids with an optional high zxid.
+ * A range of of "long"s with an optional high "long" value to represent ZXID or timestamp ranges.
  */
 public class ZxidRange {
   public static final ZxidRange INVALID = new ZxidRange(-1L, Optional.of(-1L), true);
@@ -51,7 +51,7 @@ public class ZxidRange {
     this(low, Optional.<Long>absent(), false);
   }
 
-  public ZxidRange(Range<Long> range) {
+  public ZxidRange(com.google.common.collect.Range<Long> range) {
     this(range.lowerEndpoint(), range.upperEndpoint());
   }
 
@@ -61,11 +61,13 @@ public class ZxidRange {
     if (zxidParts.length == 1 && !value.endsWith("-")) {
       try {
         return new ZxidRange(Long.parseLong(zxidParts[0], 16));
-      } catch (NumberFormatException e) { }
+      } catch (NumberFormatException e) {
+      }
     } else if (zxidParts.length == 2) {
       try {
         return new ZxidRange(Long.parseLong(zxidParts[0], 16), Long.parseLong(zxidParts[1], 16));
-      } catch (NumberFormatException e) { }
+      } catch (NumberFormatException e) {
+      }
     }
 
     return ZxidRange.INVALID;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -109,6 +109,7 @@ public class QuorumPeerConfig {
     protected boolean syncEnabled = true;
 
     // ZooKeeper server-side backup config
+    protected boolean backupEnabled = false;
     protected BackupConfig backupConfig;
     protected BackupConfig.Builder backupConfigBuilder = new BackupConfig.Builder();
 
@@ -350,7 +351,8 @@ public class QuorumPeerConfig {
             } else if (key.equals("autopurge.purgeInterval")) {
                 purgeInterval = Integer.parseInt(value);
             } else if (key.equals(BackupSystemProperty.BACKUP_ENABLED)) {
-                backupConfigBuilder.setEnabled(Boolean.parseBoolean(value));
+                backupEnabled = Boolean.parseBoolean(value);
+                backupConfigBuilder.setEnabled(backupEnabled);
             } else if (key.equals(BackupSystemProperty.BACKUP_STATUS_DIR)) {
                 backupConfigBuilder.setStatusDir(vff.create(value));
             } else if (key.equals(BackupSystemProperty.BACKUP_TMP_DIR)) {
@@ -369,6 +371,12 @@ public class QuorumPeerConfig {
                 backupConfigBuilder.setStorageProviderClassName(value);
             } else if (key.equals(BackupSystemProperty.BACKUP_NAMESPACE)) {
                 backupConfigBuilder.setNamespace(value);
+            } else if (key.equals(BackupSystemProperty.BACKUP_TIMETABLE_ENABLED)) {
+                backupConfigBuilder.setTimetableEnabled(Boolean.parseBoolean(value));
+            } else if (key.equals(BackupSystemProperty.BACKUP_TIMETABLE_STORAGE_PATH)) {
+                backupConfigBuilder.setTimetableStoragePath(value);
+            } else if (key.equals(BackupSystemProperty.BACKUP_TIMETABLE_BACKUP_INTERVAL_MS)) {
+                backupConfigBuilder.setTimetableBackupIntervalInMs(Long.parseLong(value));
             } else if (key.equals("standaloneEnabled")) {
                 if (value.toLowerCase().equals("true")) {
                     setStandaloneEnabled(true);
@@ -539,11 +547,13 @@ public class QuorumPeerConfig {
         }
 
         // Create a BackupConfig object for backup
-        try {
-            backupConfigBuilder.build().ifPresent(b -> backupConfig = b);
-        } catch (org.apache.zookeeper.common.ConfigException e) {
-            // TODO: Merge QuorumPeerConfig.ConfigException and org.apache.zookeeper.common.ConfigException
-            throw new ConfigException(e.getMessage(), e);
+        if (backupEnabled) {
+            try {
+                backupConfigBuilder.build().ifPresent(b -> backupConfig = b);
+            } catch (org.apache.zookeeper.common.ConfigException e) {
+                // TODO: Merge QuorumPeerConfig.ConfigException and org.apache.zookeeper.common.ConfigException
+                throw new ConfigException(e.getMessage(), e);
+            }
         }
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerMain.java
@@ -138,18 +138,10 @@ public class QuorumPeerMain {
             config.getPurgeInterval());
         purgeMgr.start();
 
-        if (config.getBackupConfig() != null) {
-            // Backup is enabled if the backup config is not null
-            BackupStorageProvider storageProvider;
-            try {
-                storageProvider = createStorageProviderImpl(config.getBackupConfig());
-            } catch (Exception e) {
-                throw new BackupException(e.getMessage(), e);
-            }
+        if (config.backupEnabled && config.getBackupConfig() != null) {
+            // Backup is enabled and the backup config is not null
             BackupManager backupManager = new BackupManager(config.dataDir, config.dataLogDir,
-                config.getBackupConfig().getStatusDir(), config.getBackupConfig().getTmpDir(),
-                config.getBackupConfig().getBackupIntervalInMinutes(), storageProvider,
-                config.getBackupConfig().getNamespace(), config.getServerId());
+                config.getServerId(), config.getBackupConfig());
             backupManager.start();
         }
 
@@ -160,27 +152,6 @@ public class QuorumPeerMain {
             // there is only server in the quorum -- run as standalone
             ZooKeeperServerMain.main(args);
         }
-    }
-
-    /**
-     * Instantiates the storage provider implementation by reflection. This allows the user to
-     * choose which BackupStorageProvider implementation to use by specifying the fully-qualified
-     * class name in BackupConfig (read from Properties).
-     * @param backupConfig
-     * @return
-     * @throws ClassNotFoundException
-     * @throws NoSuchMethodException
-     * @throws IllegalAccessException
-     * @throws InvocationTargetException
-     * @throws InstantiationException
-     */
-    private BackupStorageProvider createStorageProviderImpl(BackupConfig backupConfig)
-        throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException,
-               InvocationTargetException, InstantiationException {
-        Class<?> clazz = Class.forName(backupConfig.getStorageProviderClassName());
-        Constructor<?> constructor = clazz.getConstructor(BackupConfig.class);
-        Object storageProvider = constructor.newInstance(backupConfig);
-        return (BackupStorageProvider) storageProvider;
     }
 
     public void runFromConfig(QuorumPeerConfig config) throws IOException, AdminServerException {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/BackupBeanTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/BackupBeanTest.java
@@ -51,6 +51,7 @@ public class BackupBeanTest extends ZKTestCase {
   private static final Logger LOG = LoggerFactory.getLogger(BackupBeanTest.class);
   private static final String HOSTPORT = "127.0.0.1:" + PortAssignment.unique();
   private static final int CONNECTION_TIMEOUT = 300000;
+  private static final int TEST_BACKUP_INTERVAL_MINUTES = 15;
   private static final String TEST_NAMESPACE = "TEST_NAMESPACE";
 
   private ZooKeeper connection;
@@ -140,8 +141,7 @@ public class BackupBeanTest extends ZKTestCase {
   @Test
   public void testMBeanRegistration() throws IOException {
     // Register MBean when initializing backup manager
-    BackupManager bm = new BackupManager(dataDir, dataDir, dataDir, backupTmpDir, 15,
-        new FileSystemBackupStorage(backupConfig), TEST_NAMESPACE, 0);
+    BackupManager bm = new BackupManager(dataDir, dataDir, 0, backupConfig);
     String expectedMBeanName = "Backup_" + TEST_NAMESPACE + ".server0";
     Set<ZKMBeanInfo> mbeans = MBeanRegistry.getInstance().getRegisteredBeans();
     Assert.assertTrue(containsMBean(mbeans, expectedMBeanName, false));
@@ -161,8 +161,7 @@ public class BackupBeanTest extends ZKTestCase {
 
   @Test
   public void testMBeanUpdate() throws Exception {
-    MockBackupManager backupManager = new MockBackupManager(dataDir, dataDir, dataDir, backupTmpDir, 15,
-        new FileSystemBackupStorage(backupConfig), TEST_NAMESPACE, 0);
+    MockBackupManager backupManager = new MockBackupManager(dataDir, dataDir, 0, backupConfig);
     BackupBean backupBean = backupManager.getBackupBean();
 
     Assert.assertEquals(0, backupBean.getMinutesSinceLastSuccessfulSnapshotIteration());
@@ -216,11 +215,9 @@ public class BackupBeanTest extends ZKTestCase {
 
   private static class MockBackupManager extends BackupManager {
 
-    public MockBackupManager(File snapDir, File dataLogDir, File backupStatusDir, File tmpDir,
-        int backupIntervalInMinutes, BackupStorageProvider backupStorageProvider, String namespace,
-        long serverId) throws IOException {
-      super(snapDir, dataLogDir, backupStatusDir, tmpDir, backupIntervalInMinutes,
-          backupStorageProvider, namespace, serverId);
+    public MockBackupManager(File snapDir, File dataLogDir, long serverId,
+        BackupConfig backupConfig) throws IOException {
+      super(snapDir, dataLogDir, serverId, backupConfig);
     }
 
     public BackupBean getBackupBean() {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/BackupConfigTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/BackupConfigTest.java
@@ -147,13 +147,13 @@ public class BackupConfigTest {
   @Test
   public void testRetentionMaintenanceInterval() throws Exception {
     assertEquals(BackupConfig.DEFAULT_RETENTION_MAINTENANCE_INTERVAL_HOURS,
-        builder().build().get().getRetentionMaintenanceInterval());
+        builder().build().get().getRetentionMaintenanceIntervalInHours());
     int expected = 3; // 3 hours
     assertEquals(expected, builder().setRetentionMaintenanceIntervalInHours(expected).build().get()
-        .getRetentionMaintenanceInterval());
+        .getRetentionMaintenanceIntervalInHours());
     assertEquals(expected, builder()
         .withProperty(BackupSystemProperty.BACKUP_RETENTION_MAINTENANCE_INTERVAL_HOURS, "3")
-        .build().get().getRetentionMaintenanceInterval());
+        .build().get().getRetentionMaintenanceIntervalInHours());
   }
 
   private BackupConfig.Builder builder() {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/timetable/TimetableUtilTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/timetable/TimetableUtilTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup.timetable;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TimetableUtilTest {
+  private static final int NUM_BACKUP_FILES = 5;
+  private static final File[] TIMETABLE_BACKUP_FILES = new File[NUM_BACKUP_FILES];
+
+  /**
+   * Creates a timetable sequence: (10, 10), (20, 20), ..., (50, 50) for testing
+   * @throws IOException
+   */
+  @BeforeClass
+  public static void setupTestData() throws IOException {
+    for (int i = 1; i <= NUM_BACKUP_FILES; i++) {
+      // Multiple by 10 to give it space in between
+      createTimetableBackupFile(i * 10, i * 10, i - 1);
+    }
+  }
+
+  @AfterClass
+  public static void removeTestData() {
+    for (File file : TIMETABLE_BACKUP_FILES) {
+      file.delete();
+    }
+  }
+
+  @Test
+  public void testFindLastZxidFromTimestamp() {
+    String result =
+        TimetableUtil.findLastZxidFromTimestamp(TIMETABLE_BACKUP_FILES, Long.toString(25L));
+    Assert.assertEquals(Long.toHexString(20), result);
+
+    result = TimetableUtil.findLastZxidFromTimestamp(TIMETABLE_BACKUP_FILES, Long.toString(35L));
+    Assert.assertEquals(Long.toHexString(30), result);
+
+    result = TimetableUtil.findLastZxidFromTimestamp(TIMETABLE_BACKUP_FILES, Long.toString(50L));
+    Assert.assertEquals(Long.toHexString(50), result);
+
+    result = TimetableUtil.findLastZxidFromTimestamp(TIMETABLE_BACKUP_FILES, Long.toString(10L));
+    Assert.assertEquals(Long.toHexString(10), result);
+
+    result = TimetableUtil.findLastZxidFromTimestamp(TIMETABLE_BACKUP_FILES, Long.toString(41L));
+    Assert.assertEquals(Long.toHexString(40), result);
+  }
+
+  @Test
+  public void testFindLatestZxidFromTimestamp() {
+    String result = TimetableUtil.findLastZxidFromTimestamp(TIMETABLE_BACKUP_FILES, "latest");
+    Assert.assertEquals(Long.toHexString(50), result);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testTimestampOutsideWindowLow() {
+    String result = TimetableUtil.findLastZxidFromTimestamp(TIMETABLE_BACKUP_FILES, Long.toString(5));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testTimestampOutsideWindowHigh() {
+    String result =
+        TimetableUtil.findLastZxidFromTimestamp(TIMETABLE_BACKUP_FILES, Long.toString(55));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testEmptyFiles() {
+    String result = TimetableUtil.findLastZxidFromTimestamp(null, Long.toString(25));
+  }
+
+  private static void createTimetableBackupFile(long timestamp, long zxid, int fileNum)
+      throws IOException {
+    Map<Long, String> timetableRecords = new TreeMap<>();
+    timetableRecords.put(timestamp, Long.toHexString(zxid));
+
+    File file = new File("timetable." + fileNum);
+    FileOutputStream f = new FileOutputStream(file);
+    ObjectOutputStream s = new ObjectOutputStream(f);
+    s.writeObject(timetableRecords);
+    s.close();
+
+    TIMETABLE_BACKUP_FILES[fileNum] = file;
+  }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/timetable/TimetableUtilTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/timetable/TimetableUtilTest.java
@@ -99,7 +99,7 @@ public class TimetableUtilTest {
     Map<Long, String> timetableRecords = new TreeMap<>();
     timetableRecords.put(timestamp, Long.toHexString(zxid));
 
-    File file = new File("timetable." + fileNum);
+    File file = new File("timetable." + timestamp + "-" + timestamp);
     FileOutputStream f = new FileOutputStream(file);
     ObjectOutputStream s = new ObjectOutputStream(f);
     s.writeObject(timetableRecords);


### PR DESCRIPTION
This commit adds the timetable feature and enables timetable metadata backup on the server side. Also, an unstable assert check in testBackupManager() in BackupManagerTest has been fixed.

Tests written: 
BackupManagerTest::testTimetableBackup()
TimetableUtilTest

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.zookeeper.test.BackupManagerTest
[INFO] Running org.apache.zookeeper.server.backup.timetable.TimetableUtilTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.411 s - in org.apache.zookeeper.server.backup.timetable.TimetableUtilTest
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 17.87 s - in org.apache.zookeeper.test.BackupManagerTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  29.563 s
[INFO] Finished at: 2021-03-08T00:17:12-08:00
[INFO] ------------------------------------------------------------------------
```