### PR TITLE
Two minor improvements on BackupManager and FileSystemBackupStorage

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
@@ -666,8 +666,6 @@ public class BackupManager {
   public synchronized void start() throws IOException {
     logger.info("BackupManager starting.");
 
-    initialize();
-
     (new Thread(logBackup)).start();
     (new Thread(snapBackup)).start();
   }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/storage/impl/FileSystemBackupStorage.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/storage/impl/FileSystemBackupStorage.java
@@ -65,13 +65,13 @@ public class FileSystemBackupStorage implements BackupStorageProvider {
    * @param backupConfig The information and settings about backup storage, to be set as a part of ZooKeeper server config
    */
   public FileSystemBackupStorage(BackupConfig backupConfig) {
-    this.backupConfig = backupConfig;
-    String backupStoragePath = this.backupConfig.getBackupStoragePath();
-    if (!new File(backupStoragePath).exists()) {
+    if (!new File(backupConfig.getBackupStoragePath()).exists()) {
       throw new BackupException(
-          "The backup storage is not ready, please check the path: " + backupStoragePath);
+          "The backup storage is not ready, please check the path: " + backupConfig
+              .getBackupStoragePath());
     }
-    fileRootPath = String.join(File.separator, backupStoragePath,
+    this.backupConfig = backupConfig;
+    fileRootPath = String.join(File.separator, this.backupConfig.getBackupStoragePath(),
         this.backupConfig.getNamespace());
     rwLock = new ReentrantReadWriteLock();
     sharedLock = rwLock.readLock();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/storage/impl/FileSystemBackupStorage.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/storage/impl/FileSystemBackupStorage.java
@@ -66,7 +66,12 @@ public class FileSystemBackupStorage implements BackupStorageProvider {
    */
   public FileSystemBackupStorage(BackupConfig backupConfig) {
     this.backupConfig = backupConfig;
-    fileRootPath = String.join(File.separator, this.backupConfig.getBackupStoragePath(),
+    String backupStoragePath = this.backupConfig.getBackupStoragePath();
+    if (!new File(backupStoragePath).exists()) {
+      throw new BackupException(
+          "The backup storage is not ready, please check the path: " + backupStoragePath);
+    }
+    fileRootPath = String.join(File.separator, backupStoragePath,
         this.backupConfig.getNamespace());
     rwLock = new ReentrantReadWriteLock();
     sharedLock = rwLock.readLock();

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/storage/impl/FileSystemBackupStorageTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/storage/impl/FileSystemBackupStorageTest.java
@@ -52,17 +52,17 @@ public class FileSystemBackupStorageTest {
   private static List<File> testFiles;
   private static List<File> backupFiles;
   private static final String NAMESPACE = "test";
-  private static final String backupStoragePath = "./localBackupStorageTest";
+  private static final String BACKUP_STORAGE_PATH = "./localBackupStorageTest";
 
   @BeforeClass
   public static void beforeClass() throws ConfigException, IOException {
     // Build backup config that point the backup storage to a local directory
-    new File(backupStoragePath).mkdir();
+    new File(BACKUP_STORAGE_PATH).mkdir();
     BackupConfig backupConfig = new BackupConfig.Builder().setEnabled(true)
         .setStatusDir(new File("./localBackupStorageTest/backup/status")).
             setTmpDir(new File("./localBackupStorageTest/tmp/backup"))
         .setStorageProviderClassName(FileSystemBackupStorage.class.getName())
-        .setBackupStoragePath(backupStoragePath).setNamespace(NAMESPACE).build().get();
+        .setBackupStoragePath(BACKUP_STORAGE_PATH).setNamespace(NAMESPACE).build().get();
 
     backupStorage = new FileSystemBackupStorage(backupConfig);
     // The path to the directory that contains all directories and files created for this test

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/storage/impl/FileSystemBackupStorageTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/storage/impl/FileSystemBackupStorageTest.java
@@ -52,15 +52,17 @@ public class FileSystemBackupStorageTest {
   private static List<File> testFiles;
   private static List<File> backupFiles;
   private static final String NAMESPACE = "test";
+  private static final String backupStoragePath = "./localBackupStorageTest";
 
   @BeforeClass
   public static void beforeClass() throws ConfigException, IOException {
     // Build backup config that point the backup storage to a local directory
+    new File(backupStoragePath).mkdir();
     BackupConfig backupConfig = new BackupConfig.Builder().setEnabled(true)
         .setStatusDir(new File("./localBackupStorageTest/backup/status")).
             setTmpDir(new File("./localBackupStorageTest/tmp/backup"))
         .setStorageProviderClassName(FileSystemBackupStorage.class.getName())
-        .setBackupStoragePath("./localBackupStorageTest").setNamespace(NAMESPACE).build().get();
+        .setBackupStoragePath(backupStoragePath).setNamespace(NAMESPACE).build().get();
 
     backupStorage = new FileSystemBackupStorage(backupConfig);
     // The path to the directory that contains all directories and files created for this test


### PR DESCRIPTION
This commit includes two minor improvements:
1. Removed duplicated calls of initialize() in BackupManager. Currently initialize() is called twice: once inside BackupManager constructor, and once inside start().
2. Add a check for backup storage path existence in FileSystemBackupStorage constructor. This is to ensure we fail it early if there is something wrong with the setup of backup storage, instead of writing backup files to unexpected places.

Tests:
Passed BackupManagerTest and FileSystemBackupStorageTest.
Ran zk server locally with the new code and checked log.