### PR TITLE
Enable maven deploy plugin

### DIFF
--- a/zookeeper-assembly/pom.xml
+++ b/zookeeper-assembly/pom.xml
@@ -168,8 +168,8 @@
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
         <configuration>
-          <!-- this module isn't to be deployed to Maven Central -->
-          <skip>true</skip>
+          <!-- Deploy artifacts to Bintray/JFrog -->
+          <skip>false</skip>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Setting this value to true allows GitHub Action workflow to publish tarball to Bintray/JFrog.