### PR TITLE
Add timetable to backup status file

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
@@ -62,9 +62,7 @@ public class BackupManager {
   // backupStatus, backupLogZxid and backedupSnapZxid need to be access while synchronized
   // on backupStatus.
   private final BackupStatus backupStatus;
-  private long backedupLogZxid;
-  private long backedupSnapZxid;
-  private long backedupTimestamp;
+  private BackupPoint backupPoint;
 
   private final BackupStorageProvider backupStorage;
   private final long serverId;
@@ -178,7 +176,7 @@ public class BackupManager {
      * @param snapLog the FileTxnSnapLog object to use
      */
     public TxnLogBackup(FileTxnSnapLog snapLog) {
-      super(LoggerFactory.getLogger(TxnLogBackup.class), backupStorage,
+      super(LoggerFactory.getLogger(TxnLogBackup.class), BackupManager.this.backupStorage,
           backupIntervalInMilliseconds);
       this.snapLog = snapLog;
     }
@@ -194,12 +192,12 @@ public class BackupManager {
           : latest.getZxid(ZxidPart.MAX_ZXID);
 
       logger.info("Latest Zxid from storage: {}  from status: {}",
-          ZxidUtils.zxidToString(rZxid), ZxidUtils.zxidToString(backedupLogZxid));
+          ZxidUtils.zxidToString(rZxid), ZxidUtils.zxidToString(backupPoint.getLogZxid()));
 
-      if (rZxid != backedupLogZxid) {
+      if (rZxid != backupPoint.getLogZxid()) {
         synchronized (backupStatus) {
-          backedupLogZxid = rZxid;
-          backupStatus.update(backedupLogZxid, backedupSnapZxid);
+          backupPoint.setLogZxid(rZxid);
+          backupStatus.update(backupPoint);
         }
       }
     }
@@ -344,11 +342,12 @@ public class BackupManager {
 
     protected void backupComplete(BackupFile file) throws IOException {
       synchronized (backupStatus) {
-        backedupLogZxid = file.getMaxZxid();
-        backupStatus.update(backedupLogZxid, backedupSnapZxid);
+        backupPoint.setLogZxid(file.getMaxZxid());
+        backupStatus.update(backupPoint);
       }
 
-      logger.info("Updated backedup tnxlog zxid to {}", ZxidUtils.zxidToString(backedupLogZxid));
+      logger.info("Updated backedup tnxlog zxid to {}",
+          ZxidUtils.zxidToString(backupPoint.getLogZxid()));
     }
   }
 
@@ -364,7 +363,8 @@ public class BackupManager {
      * @param snapLog the FileTxnSnapLog object to use
      */
     public SnapBackup(FileTxnSnapLog snapLog) {
-      super(LoggerFactory.getLogger(SnapBackup.class), backupStorage, backupIntervalInMilliseconds);
+      super(LoggerFactory.getLogger(SnapBackup.class), BackupManager.this.backupStorage,
+          backupIntervalInMilliseconds);
       this.snapLog = snapLog;
     }
 
@@ -379,12 +379,12 @@ public class BackupManager {
           : latest.getZxid(ZxidPart.MIN_ZXID);
 
       logger.info("Latest Zxid from storage: {}  from status: {}",
-          ZxidUtils.zxidToString(rZxid), ZxidUtils.zxidToString(backedupLogZxid));
+          ZxidUtils.zxidToString(rZxid), ZxidUtils.zxidToString(backupPoint.getSnapZxid()));
 
-      if (rZxid != backedupSnapZxid) {
+      if (rZxid != backupPoint.getSnapZxid()) {
         synchronized (backupStatus) {
-          backedupSnapZxid = rZxid;
-          backupStatus.update(backedupLogZxid, backedupSnapZxid);
+          backupPoint.setSnapZxid(rZxid);
+          backupStatus.update(backupPoint);
         }
       }
     }
@@ -401,7 +401,7 @@ public class BackupManager {
 
       // Get all available snapshots excluding the ones whose lastProcessedZxid falls into the
       // zxid range [0, backedupSnapZxid]
-      List<File> candidateSnapshots = snapLog.findValidSnapshots(0, backedupSnapZxid);
+      List<File> candidateSnapshots = snapLog.findValidSnapshots(0, backupPoint.getSnapZxid());
       // Sort candidateSnapshots from oldest to newest
       Collections.reverse(candidateSnapshots);
 
@@ -464,12 +464,13 @@ public class BackupManager {
 
     protected void backupComplete(BackupFile file) throws IOException {
       synchronized (backupStatus) {
-        backedupSnapZxid = file.getMinZxid();
-        backupStatus.update(backedupLogZxid, backedupSnapZxid);
+        backupPoint.setSnapZxid(file.getMinZxid());
+        backupStatus.update(backupPoint);
       }
       backupStats.incrementNumberOfSnapshotFilesBackedUpThisIteration();
 
-      logger.info("Updated backedup snap zxid to {}", ZxidUtils.zxidToString(backedupSnapZxid));
+      logger.info("Updated backedup snap zxid to {}",
+          ZxidUtils.zxidToString(backupPoint.getSnapZxid()));
     }
   }
 
@@ -547,13 +548,13 @@ public class BackupManager {
 
   public long getBackedupLogZxid() {
     synchronized (backupStatus) {
-      return backedupLogZxid;
+      return backupPoint.getLogZxid();
     }
   }
 
   public long getBackedupSnapZxid() {
     synchronized (backupStatus) {
-      return backedupSnapZxid;
+      return backupPoint.getSnapZxid();
     }
   }
 
@@ -571,12 +572,8 @@ public class BackupManager {
 
     synchronized (backupStatus) {
       backupStatus.createIfNeeded();
-      BackupPoint bp = backupStatus.read();
-      backedupLogZxid = bp.getLogZxid();
-      backedupSnapZxid = bp.getSnapZxid();
-      if (backupConfig.isTimetableEnabled()) {
-        backedupTimestamp = bp.getTimestamp();
-      }
+      // backupPoint is only to be initialized once via backupStatus.read() in initialize()
+      backupPoint = backupStatus.read();
     }
 
     if (!tmpDir.exists()) {
@@ -611,7 +608,7 @@ public class BackupManager {
       }
       timetableBackup = new TimetableBackup(new FileTxnSnapLog(dataLogDir, snapDir), tmpDir,
           timetableBackupStorage, backupIntervalInMilliseconds,
-          backupConfig.getTimetableBackupIntervalInMs());
+          backupConfig.getTimetableBackupIntervalInMs(), backupStatus, backupPoint);
       timetableBackup.initialize();
     }
   }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
@@ -28,7 +28,7 @@ import org.apache.zookeeper.server.backup.storage.BackupStorageProvider;
 import org.apache.zookeeper.server.backup.timetable.TimetableBackup;
 import org.apache.zookeeper.server.persistence.*;
 import org.apache.zookeeper.server.backup.BackupUtil.BackupFileType;
-import org.apache.zookeeper.server.backup.BackupUtil.ZxidPart;
+import org.apache.zookeeper.server.backup.BackupUtil.IntervalEndpoint;
 import org.apache.zookeeper.server.util.ZxidUtils;
 import org.apache.zookeeper.txn.TxnHeader;
 import org.slf4j.Logger;
@@ -185,11 +185,11 @@ public class BackupManager {
       backupStorage.cleanupInvalidFiles(null);
 
       BackupFileInfo latest =
-          BackupUtil.getLatest(backupStorage, BackupFileType.TXNLOG, ZxidPart.MIN_ZXID);
+          BackupUtil.getLatest(backupStorage, BackupFileType.TXNLOG, IntervalEndpoint.START);
 
       long rZxid = latest == null
           ? BackupUtil.INVALID_LOG_ZXID
-          : latest.getZxid(ZxidPart.MAX_ZXID);
+          : latest.getIntervalEndpoint(IntervalEndpoint.END);
 
       logger.info("Latest Zxid from storage: {}  from status: {}",
           ZxidUtils.zxidToString(rZxid), ZxidUtils.zxidToString(backupPoint.getLogZxid()));
@@ -372,11 +372,11 @@ public class BackupManager {
       backupStorage.cleanupInvalidFiles(null);
 
       BackupFileInfo latest =
-          BackupUtil.getLatest(backupStorage, BackupFileType.SNAPSHOT, ZxidPart.MIN_ZXID);
+          BackupUtil.getLatest(backupStorage, BackupFileType.SNAPSHOT, IntervalEndpoint.START);
 
       long rZxid = latest == null
           ? BackupUtil.INVALID_SNAP_ZXID
-          : latest.getZxid(ZxidPart.MIN_ZXID);
+          : latest.getIntervalEndpoint(IntervalEndpoint.START);
 
       logger.info("Latest Zxid from storage: {}  from status: {}",
           ZxidUtils.zxidToString(rZxid), ZxidUtils.zxidToString(backupPoint.getSnapZxid()));

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupPoint.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupPoint.java
@@ -19,7 +19,9 @@
 package org.apache.zookeeper.server.backup;
 
 /**
- * Describes the point to which backups of log and snap files have been completed.
+ * Describes the point to which backups of log and snap files have been completed. It also includes
+ * a timestamp field to describe the last timestamp timetable has been backed up to (only
+ * applicable when timetable is enabled).
  */
 public class BackupPoint {
   private long logZxid;
@@ -30,6 +32,7 @@ public class BackupPoint {
    * Create an instance of a BackupPoint
    * @param logZxid the highest log zxid that has been backed up
    * @param snapZxid the start zxid of the latest snap that has been backedup
+   * @param timestamp the latest timestamp that was backed up into timetable
    */
   public BackupPoint(long logZxid, long snapZxid, long timestamp) {
     this.logZxid = logZxid;
@@ -66,7 +69,7 @@ public class BackupPoint {
   }
 
   /**
-   * Set the starting timestamp of the latest backed up timetable backup file
+   * Set the ending timestamp of the latest backed up timetable backup file
    * @param timestamp
    * @return
    */

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupPoint.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupPoint.java
@@ -22,8 +22,8 @@ package org.apache.zookeeper.server.backup;
  * Describes the point to which backups of log and snap files have been completed.
  */
 public class BackupPoint {
-  private final long logZxid;
-  private final long snapZxid;
+  private long logZxid;
+  private long snapZxid;
   private long timestamp; // backup timetable is optional
 
   /**
@@ -31,9 +31,10 @@ public class BackupPoint {
    * @param logZxid the highest log zxid that has been backed up
    * @param snapZxid the start zxid of the latest snap that has been backedup
    */
-  public BackupPoint(long logZxid, long snapZxid) {
+  public BackupPoint(long logZxid, long snapZxid, long timestamp) {
     this.logZxid = logZxid;
     this.snapZxid = snapZxid;
+    this.timestamp = timestamp;
   }
 
   /**
@@ -42,11 +43,19 @@ public class BackupPoint {
    */
   public long getLogZxid() { return logZxid; }
 
+  public void setLogZxid(long logZxid) {
+    this.logZxid = logZxid;
+  }
+
   /**
    * Get the starting zxid of the latest backed up snap
    * @return the starting zxid of the latest backed up snap
    */
   public long getSnapZxid() { return snapZxid; }
+
+  public void setSnapZxid(long snapZxid) {
+    this.snapZxid = snapZxid;
+  }
 
   /**
    * Get the starting timestamp of the latest backed up timetable backup file

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupProcess.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupProcess.java
@@ -9,12 +9,12 @@ import org.apache.zookeeper.server.backup.storage.BackupStorageProvider;
 import org.slf4j.Logger;
 
 /**
- * Base class for the txnlog and snap back processes.
- * Provides the main backup loop and copying to remote storage (via HDFS APIs)
+ * Base class for the txnlog and snap backup, and timetable backup processes.
+ * Provides the main backup loop and copying to remote storage (via HDFS, NFS, etc. APIs)
  */
 public abstract class BackupProcess implements Runnable {
   protected final Logger logger;
-  private BackupStorageProvider backupStorage;
+  protected final BackupStorageProvider backupStorage;
   private final long backupIntervalInMilliseconds;
   protected volatile boolean isRunning = true;
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupUtil.java
@@ -45,9 +45,9 @@ public class BackupUtil {
   /**
    * Identifiers for the two zxids in a backedup file name
    */
-  public enum ZxidPart {
-    MIN_ZXID,
-    MAX_ZXID
+  public enum IntervalEndpoint {
+    START,
+    END
   }
 
   /**
@@ -114,16 +114,16 @@ public class BackupUtil {
     private static final long serialVersionUID = -2648639884525140318L;
 
     private SortOrder sortOrder;
-    private ZxidPart whichZxid;
+    private IntervalEndpoint whichIntervalEndpoint;
 
-    public BackupFileComparator(ZxidPart whichZxid, SortOrder sortOrder) {
+    public BackupFileComparator(IntervalEndpoint whichIntervalEndpoint, SortOrder sortOrder) {
       this.sortOrder = sortOrder;
-      this.whichZxid = whichZxid;
+      this.whichIntervalEndpoint = whichIntervalEndpoint;
     }
 
     public int compare(BackupFileInfo o1, BackupFileInfo o2) {
-      long z1 = o1.getZxid(whichZxid);
-      long z2 = o2.getZxid(whichZxid);
+      long z1 = o1.getIntervalEndpoint(whichIntervalEndpoint);
+      long z2 = o2.getIntervalEndpoint(whichIntervalEndpoint);
 
       int result = Long.compare(z1, z2);
 
@@ -141,13 +141,13 @@ public class BackupUtil {
   private static Function<BackupFileInfo, Range<Long>> zxidRangeExtractor =
       new Function<BackupFileInfo, Range<Long>>() {
         public Range<Long> apply(BackupFileInfo fileInfo) {
-          return fileInfo.getZxidRange();
+          return fileInfo.getRange();
         }
       };
 
   /**
    * Creates a file name string for a backup file by appending a high zxid/long in Hex if it
-   * doesn't already.
+   * doesn't already contain an ending zxid.
    * @param standardName
    * @param highZxid
    * @return
@@ -168,36 +168,42 @@ public class BackupUtil {
   }
 
   /**
-   * Sort a list of backup files based on the specified zxid in the requested sort order
+   * Sort a list of backup files based on the specified interval endpoint in the requested
+   * sort order
    * @param files the files to sort
-   * @param whichZxid which zxid to sort by
-   * @param sortOrder which direction in which to sort the zxid
+   * @param whichIntervalEndpoint which interval endpoint to sort by
+   * @param sortOrder which direction in which to sort the files
    */
-  public static void sort(List<BackupFileInfo> files, ZxidPart whichZxid, SortOrder sortOrder) {
-    Collections.sort(files, new BackupFileComparator(whichZxid, sortOrder));
+  public static void sort(List<BackupFileInfo> files, IntervalEndpoint whichIntervalEndpoint, SortOrder sortOrder) {
+    Collections.sort(files, new BackupFileComparator(whichIntervalEndpoint, sortOrder));
   }
 
   /**
-   * Get an zxid range from the backup file name
+   * Get a range from the backup file name. This range is usually a zxid range, but in the case of
+   * timetable backup, it is a timestamp range.
    * @param name the name of the file
    * @param prefix the prefix to match
-   * @return return the zxid range for the file
+   * @return return the range for the file
    */
-  public static Range<Long> getZxidRangeFromName(String name, String prefix) {
-    Range<Long> zxidRange = Range.singleton(-1L);
+  public static Range<Long> getRangeFromName(String name, String prefix) {
+    Range<Long> range = Range.singleton(-1L);
     String nameParts[] = name.split("[\\.-]");
 
     if (nameParts.length == 3 && nameParts[0].equals(prefix)) {
       try {
-        zxidRange = Range.closed(Long.parseLong(nameParts[1], 16), Long.parseLong(nameParts[2], 16));
-      } catch (NumberFormatException e) { }
+        // timetable backup files contain decimal longs, not hex
+        int radix = prefix.equals(TimetableBackup.TIMETABLE_PREFIX) ? 10 : 16;
+        range =
+            Range.closed(Long.parseLong(nameParts[1], radix), Long.parseLong(nameParts[2], radix));
+      } catch (NumberFormatException e) {
+      }
     }
 
-    return zxidRange;
+    return range;
   }
 
   /**
-   * Sort backup files by the min zxid part in ascending order
+   * Sort backup files by the starting point of the interval (min zxid part) in ascending order
    * @param bsp the backup provide from which to get the files
    * @param fileType the backup file to get
    * @return the files listed in the specified order using the request zxid
@@ -208,84 +214,84 @@ public class BackupUtil {
   }
 
   /**
-   * Sort backup files by the min zxid part in ascending order
+   * Sort backup files by the starting point of the interval (min zxid part) in ascending order
    * @param bsp the backup provide from which to get the files
    * @param fileType the backup file to get
-   * @return the files listed in the specified order using the request zxid
+   * @return the files listed in the specified order using the requested interval part
    */
   public static List<BackupFileInfo> getBackupFilesByMin(
       BackupStorageProvider bsp,
       File path,
       BackupFileType fileType) throws IOException {
 
-    return getBackupFiles(bsp, path, fileType, ZxidPart.MIN_ZXID, SortOrder.ASCENDING);
+    return getBackupFiles(bsp, path, fileType, IntervalEndpoint.START, SortOrder.ASCENDING);
   }
 
   /**
-   * Sort backup files by the specified zxid part
+   * Sort backup files by the specified interval part
    * @param bsp the backup provide from which to get the files
    * @param fileType the backup file to get
-   * @param whichZxid which zxid to sort by
-   * @param sortOrder which direction to sort the zxid in
+   * @param whichIntervalEndpoint which interval part (min or max) to sort by
+   * @param sortOrder which direction to sort the values (e.g. zxid) in
    * @return the file info for the matching files sorted on the request zxid
    */
   public static List<BackupFileInfo> getBackupFiles(
       BackupStorageProvider bsp,
       BackupFileType fileType,
-      ZxidPart whichZxid,
+      IntervalEndpoint whichIntervalEndpoint,
       SortOrder sortOrder) throws IOException {
 
-    return getBackupFiles(bsp, null, fileType, whichZxid, sortOrder);
+    return getBackupFiles(bsp, null, fileType, whichIntervalEndpoint, sortOrder);
   }
 
   /**
-   * Sort backup files by the specified zxid part
+   * Sort backup files by the specified interval endpoint
    * @param bsp the backup provide from which to get the files
    * @param fileType the backup file to get
-   * @param whichZxid which zxid to sort by
-   * @param sortOrder which direction to sort the zxid in
-   * @return the file info for the matching files sorted on the request zxid
+   * @param whichIntervalEndpoint which interval endpoint to sort by
+   * @param sortOrder which direction to sort the ranges in
+   * @return the file info for the matching files sorted on the requested interval endpoint
    */
   public static List<BackupFileInfo> getBackupFiles(
       BackupStorageProvider bsp,
       File path,
       BackupFileType fileType,
-      ZxidPart whichZxid, SortOrder
+      IntervalEndpoint whichIntervalEndpoint, SortOrder
       sortOrder) throws IOException {
 
-    return getBackupFiles(bsp, path, new BackupFileType[] { fileType }, whichZxid, sortOrder);
+    return getBackupFiles(bsp, path, new BackupFileType[] { fileType }, whichIntervalEndpoint, sortOrder);
   }
 
   /**
    * Sort the backup files of the requested types by the specified zxid part
    * @param bsp the backup provide from which to get the files
    * @param fileTypes the backup file types to get
-   * @param whichZxid which zxid to sort by
-   * @param sortOrder which direction in which to sort based on the requested zxid
-   * @return the file info for the matching files sorted on the request zxid
+   * @param whichIntervalEndpoint which interval endpoint to sort by
+   * @param sortOrder which direction in which to sort based on the requested interval endpoint
+   * @return the file info for the matching files sorted by the requested interval endpoint
    */
   public static List<BackupFileInfo> getBackupFiles(
       BackupStorageProvider bsp,
       BackupFileType[] fileTypes,
-      ZxidPart whichZxid,
+      IntervalEndpoint whichIntervalEndpoint,
       SortOrder sortOrder) throws IOException {
 
-    return getBackupFiles(bsp, null, fileTypes, whichZxid, sortOrder);
+    return getBackupFiles(bsp, null, fileTypes, whichIntervalEndpoint, sortOrder);
   }
 
   /**
    * Sort the backup files of the requested types by the specified zxid part
    * @param bsp the backup provide from which to get the files
    * @param fileTypes the backup file types to get
-   * @param whichZxid which zxid to sort by
-   * @param sortOrder which direction in which to sort based on the requested zxid
-   * @return the file info for the matching files sorted on the request zxid
+   * @param whichIntervalEndpoint which interval endpoint to sort by
+   * @param sortOrder which direction in which to sort based on the requested interval endpoint
+   * @return the file info for the matching files sorted by the requested interval endpoint
    */
   public static List<BackupFileInfo> getBackupFiles(
       BackupStorageProvider bsp,
       File path,
       BackupFileType[] fileTypes,
-      ZxidPart whichZxid,
+      IntervalEndpoint whichIntervalEndpoint,
       SortOrder sortOrder) throws IOException {
 
     List<BackupFileInfo> files = new ArrayList<BackupFileInfo>();
@@ -298,7 +304,7 @@ public class BackupUtil {
       }
     }
 
-    sort(files, whichZxid, sortOrder);
+    sort(files, whichIntervalEndpoint, sortOrder);
     return files;
   }
 
@@ -306,47 +312,47 @@ public class BackupUtil {
    * Get the latest backup file of the given type.
    * @param bsp the backup storage provider
    * @param fileType the file to get
-   * @param whichZxid sorted based on which zxid
+   * @param whichIntervalEndpoint sorted based on which interval endpoint
    * @return the latest backup file if one exists, null otherwise
    * @throws IOException
    */
   public static BackupFileInfo getLatest(
       BackupStorageProvider bsp,
       BackupFileType fileType,
-      ZxidPart whichZxid) throws IOException {
-    List<BackupFileInfo> files = getBackupFiles(bsp, fileType, whichZxid, SortOrder.DESCENDING);
+      IntervalEndpoint whichIntervalEndpoint) throws IOException {
+    List<BackupFileInfo> files = getBackupFiles(bsp, fileType, whichIntervalEndpoint, SortOrder.DESCENDING);
 
     return files.isEmpty() ? null : files.get(0);
   }
 
   /**
-   * Get both the zxids for each of the files matching the prefix
+   * Get both interval endpoints (Range) for each of the files matching the prefix
    * @param bsp the backup storage provide to get the files from
    * @param fileType the backup file to get
-   * @return the list of zxid pairs
+   * @return the list of interval endpoint pairs (ranges)
    * @throws IOException
    */
-  public static List<Range<Long>> getZxids(BackupStorageProvider bsp, BackupFileType fileType)
+  public static List<Range<Long>> getRanges(BackupStorageProvider bsp, BackupFileType fileType)
       throws IOException {
 
-    return getZxids(bsp, null, fileType);
+    return getRanges(bsp, null, fileType);
   }
 
   /**
-   * Get both the zxids for each of the files matching the prefix
+   * Get the ranges for each of the files matching the prefix
    * @param bsp the backup storage provide to get the files from
    * @param fileType the backup file to get
    * @return the list of zxid pairs
    * @throws IOException
    */
-  public static List<Range<Long>> getZxids(
+  public static List<Range<Long>> getRanges(
       BackupStorageProvider bsp,
       File path,
       BackupFileType fileType) throws IOException {
 
     return Lists.newArrayList(
         Lists.transform(
-            getBackupFiles(bsp, path, fileType, ZxidPart.MIN_ZXID, SortOrder.ASCENDING),
+            getBackupFiles(bsp, path, fileType, IntervalEndpoint.START, SortOrder.ASCENDING),
             zxidRangeExtractor));
   }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupUtil.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 
 import org.apache.zookeeper.server.backup.storage.BackupStorageProvider;
+import org.apache.zookeeper.server.backup.timetable.TimetableBackup;
 import org.apache.zookeeper.server.persistence.Util;
 
 /**
@@ -37,6 +38,8 @@ public class BackupUtil {
   // first valid tnxlog zxid is 1 while first valid zxid for snapshots is 0
   public static final long INVALID_LOG_ZXID = 0;
   public static final long INVALID_SNAP_ZXID = -1;
+  // invalid timestamp is -1 by convention
+  public static final long INVALID_TIMESTAMP = -1L;
   public static final String LOST_LOG_PREFIX = "lostLogs";
 
   /**
@@ -53,7 +56,8 @@ public class BackupUtil {
   public enum BackupFileType {
     SNAPSHOT(Util.SNAP_PREFIX),
     TXNLOG(Util.TXLOG_PREFIX),
-    LOSTLOG(BackupUtil.LOST_LOG_PREFIX);
+    LOSTLOG(BackupUtil.LOST_LOG_PREFIX),
+    TIMETABLE(TimetableBackup.TIMETABLE_PREFIX);
 
     private final String prefix;
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupUtil.java
@@ -206,7 +206,7 @@ public class BackupUtil {
    * Sort backup files by the starting point of the interval (min zxid part) in ascending order
    * @param bsp the backup provide from which to get the files
    * @param fileType the backup file to get
-   * @return the files listed in the specified order using the request zxid
+   * @return the files listed in the specified order using the requested interval endpoint
    */
   public static List<BackupFileInfo> getBackupFilesByMin(BackupStorageProvider bsp, BackupFileType fileType)
       throws IOException {
@@ -217,7 +217,7 @@ public class BackupUtil {
    * Sort backup files by the starting point of the interval (min zxid part) in ascending order
    * @param bsp the backup provide from which to get the files
    * @param fileType the backup file to get
-   * @return the files listed in the specified order using the requested interval part
+   * @return the files listed in the specified order using the requested interval endpoint
    */
   public static List<BackupFileInfo> getBackupFilesByMin(
       BackupStorageProvider bsp,
@@ -228,12 +228,12 @@ public class BackupUtil {
   }
 
   /**
-   * Sort backup files by the specified interval part
+   * Sort backup files by the specified interval endpoint
    * @param bsp the backup provide from which to get the files
    * @param fileType the backup file to get
    * @param whichIntervalEndpoint which interval part (min or max) to sort by
    * @param sortOrder which direction to sort the values (e.g. zxid) in
-   * @return the file info for the matching files sorted on the request zxid
+   * @return the file info for the matching files sorted by the requested interval endpoint
    */
   public static List<BackupFileInfo> getBackupFiles(
       BackupStorageProvider bsp,
@@ -250,7 +250,7 @@ public class BackupUtil {
    * @param fileType the backup file to get
    * @param whichIntervalEndpoint which interval endpoint to sort by
    * @param sortOrder which direction to sort the ranges in
-   * @return the file info for the matching files sorted on the requested interval endpoint
+   * @return the file info for the matching files sorted by the requested interval endpoint
    */
   public static List<BackupFileInfo> getBackupFiles(
       BackupStorageProvider bsp,
@@ -263,7 +263,7 @@ public class BackupUtil {
   }
 
   /**
-   * Sort the backup files of the requested types by the specified zxid part
+   * Sort the backup files of the requested types by the specified interval endpoint
    * @param bsp the backup provide from which to get the files
    * @param fileTypes the backup file types to get
    * @param whichIntervalEndpoint which interval endpoint to sort by
@@ -280,7 +280,7 @@ public class BackupUtil {
   }
 
   /**
-   * Sort the backup files of the requested types by the specified zxid part
+   * Sort the backup files of the requested types by the specified interval endpoint
    * @param bsp the backup provide from which to get the files
    * @param fileTypes the backup file types to get
    * @param whichIntervalEndpoint which interval endpoint to sort by

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/timetable/TimetableBackup.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/timetable/TimetableBackup.java
@@ -95,11 +95,11 @@ public class TimetableBackup extends BackupProcess {
     // NOTE: it is okay to use ZxidPart here because timetable backup files also follow zxid-like
     // naming convention, with timestamp range instead of zxid range
     BackupFileInfo latest = BackupUtil.getLatest(backupStorage, BackupUtil.BackupFileType.TIMETABLE,
-        BackupUtil.ZxidPart.MIN_ZXID);
+        BackupUtil.IntervalEndpoint.START);
 
     // Use ZxidPart.MAX_ZXID, which will give us the ending (max) timestamp
     long latestTimestampBackedUp = latest == null ? BackupUtil.INVALID_TIMESTAMP
-        : latest.getZxid(BackupUtil.ZxidPart.MAX_ZXID);
+        : latest.getIntervalEndpoint(BackupUtil.IntervalEndpoint.END);
 
     logger.info(
         "TimetableBackup::initialize(): latest timestamp from storage: {}, from BackupStatus: {}",

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/timetable/TimetableBackup.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/timetable/TimetableBackup.java
@@ -92,12 +92,9 @@ public class TimetableBackup extends BackupProcess {
   @Override
   protected void initialize() throws IOException {
     // Get the latest timetable backup file from backup storage
-    // NOTE: it is okay to use ZxidPart here because timetable backup files also follow zxid-like
-    // naming convention, with timestamp range instead of zxid range
     BackupFileInfo latest = BackupUtil.getLatest(backupStorage, BackupUtil.BackupFileType.TIMETABLE,
-        BackupUtil.IntervalEndpoint.START);
+        BackupUtil.IntervalEndpoint.END);
 
-    // Use ZxidPart.MAX_ZXID, which will give us the ending (max) timestamp
     long latestTimestampBackedUp = latest == null ? BackupUtil.INVALID_TIMESTAMP
         : latest.getIntervalEndpoint(BackupUtil.IntervalEndpoint.END);
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/timetable/TimetableBackup.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/timetable/TimetableBackup.java
@@ -22,17 +22,22 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
+import java.util.Comparator;
+import java.util.SortedSet;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import org.apache.zookeeper.server.backup.BackupFileInfo;
 import org.apache.zookeeper.server.backup.BackupManager;
+import org.apache.zookeeper.server.backup.BackupPoint;
 import org.apache.zookeeper.server.backup.BackupProcess;
+import org.apache.zookeeper.server.backup.BackupStatus;
+import org.apache.zookeeper.server.backup.BackupUtil;
 import org.apache.zookeeper.server.backup.exception.BackupException;
 import org.apache.zookeeper.server.backup.storage.BackupStorageProvider;
-import org.apache.zookeeper.server.persistence.FileTxnLog;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
-import org.apache.zookeeper.server.persistence.TxnLog;
 import org.apache.zookeeper.txn.TxnHeader;
 import org.slf4j.LoggerFactory;
 
@@ -51,8 +56,14 @@ public class TimetableBackup extends BackupProcess {
   // Lock is used to keep access to timetableRecordMap exclusive
   private final Lock lock = new ReentrantLock(true);
 
-  // File to be backed up each iteration
-  private BackupManager.BackupFile timetableBackupFile;
+  // Candidate files to be backed up each iteration sorted by name (using SortedSet)
+  private final SortedSet<BackupManager.BackupFile> candidateTimetableBackupFiles =
+      new TreeSet<>(Comparator.comparing(o -> o.getFile().getName()));
+  // BackupStatus is used here to keep track of timetable backup status in case of a crash/restart
+  // BackupStatus is written to a file. After a crash (e.g. JVM crash) or a restart, the
+  // locally-stored zkBackupStatus file will be read back to restore a BackupPoint
+  private final BackupStatus backupStatus;
+  private final BackupPoint backupPoint;
 
   /**
    * Create an instance of TimetableBackup.
@@ -61,13 +72,16 @@ public class TimetableBackup extends BackupProcess {
    * @param backupStorageProvider
    * @param backupIntervalInMilliseconds
    * @param timetableBackupIntervalInMs
+   * @param backupStatus
    */
   public TimetableBackup(FileTxnSnapLog snapLog, File tmpDir,
       BackupStorageProvider backupStorageProvider, long backupIntervalInMilliseconds,
-      long timetableBackupIntervalInMs) {
+      long timetableBackupIntervalInMs, BackupStatus backupStatus, BackupPoint backupPoint) {
     super(LoggerFactory.getLogger(TimetableBackup.class), backupStorageProvider,
         backupIntervalInMilliseconds);
     this.tmpDir = tmpDir;
+    this.backupStatus = backupStatus;
+    this.backupPoint = backupPoint;
     // Start creating records
     (new Thread(new TimetableRecorder(snapLog, timetableBackupIntervalInMs))).start();
     logger.info("TimetableBackup::Starting TimetableBackup Process with backup interval: "
@@ -77,27 +91,49 @@ public class TimetableBackup extends BackupProcess {
 
   @Override
   protected void initialize() throws IOException {
+    // Get the latest timetable backup file from backup storage
+    // NOTE: it is okay to use ZxidPart here because timetable backup files also follow zxid-like
+    // naming convention, with timestamp range instead of zxid range
+    BackupFileInfo latest = BackupUtil.getLatest(backupStorage, BackupUtil.BackupFileType.TIMETABLE,
+        BackupUtil.ZxidPart.MIN_ZXID);
+
+    // Use ZxidPart.MAX_ZXID, which will give us the ending (max) timestamp
+    long latestTimestampBackedUp = latest == null ? BackupUtil.INVALID_TIMESTAMP
+        : latest.getZxid(BackupUtil.ZxidPart.MAX_ZXID);
+
+    logger.info(
+        "TimetableBackup::initialize(): latest timestamp from storage: {}, from BackupStatus: {}",
+        latestTimestampBackedUp, backupPoint.getTimestamp());
+
+    if (latestTimestampBackedUp != backupPoint.getTimestamp()) {
+      synchronized (backupStatus) {
+        backupPoint.setTimestamp(latestTimestampBackedUp);
+        backupStatus.update(backupPoint);
+      }
+    }
   }
 
   @Override
   protected void startIteration() throws IOException {
+    // It's possible that the last iteration failed and left some tmp backup files behind - add
+    // them back to candidate backup files so the I/O write will happen again
+    getAllTmpBackupFiles();
+
     // Create a timetable backup file from the cached records (timetableRecordMap)
     lock.lock();
     try {
       if (!timetableRecordMap.isEmpty()) {
         // Create a temp timetable backup file
-        // Putting the zxid values here is okay; the actual backup file name will contain the
-        // starting and ending timestamps, not zxids
-        long lowestZxid = Long.valueOf(timetableRecordMap.firstEntry().getValue(), 16);
-        long highestZxid = Long.valueOf(timetableRecordMap.lastEntry().getValue(), 16);
-        timetableBackupFile =
-            new BackupManager.BackupFile(createTimetableBackupFile(), true, lowestZxid,
-                highestZxid); // make it temporary so that it will be deleted after iteration
+        // Make the backup file temporary so that it will be deleted after the iteration provided
+        // the I/O write to the backup storage succeeds. Otherwise, this temporary backup file will
+        // continue to exist in tmpDir locally until it's successfully written to the backup storage
+        BackupManager.BackupFile timetableBackupFromThisIteration =
+            new BackupManager.BackupFile(createTimetableBackupFile(), true, 0, 0);
+        candidateTimetableBackupFiles.add(timetableBackupFromThisIteration);
         timetableRecordMap.clear(); // Clear the map
       }
     } catch (Exception e) {
-      logger.error(
-          "TimetableBackup::getNextFileToBackup(): failed to get next timetable file to back up!",
+      logger.error("TimetableBackup::startIteration(): failed to create timetable file to back up!",
           e);
     } finally {
       lock.unlock();
@@ -106,19 +142,30 @@ public class TimetableBackup extends BackupProcess {
 
   @Override
   protected void endIteration(boolean errorFree) {
-    // timetableRecordMap is cleared in startIteration() already, so no need to clear it here
+    // timetableRecordMap is cleared in startIteration() already, so we do not clear it here
   }
 
   @Override
   protected BackupManager.BackupFile getNextFileToBackup() throws IOException {
-    BackupManager.BackupFile nextFile = timetableBackupFile;
-    timetableBackupFile = null;
+    BackupManager.BackupFile nextFile = null;
+    if (!candidateTimetableBackupFiles.isEmpty()) {
+      nextFile = candidateTimetableBackupFiles.first();
+    }
     return nextFile;
   }
 
   @Override
   protected void backupComplete(BackupManager.BackupFile file) throws IOException {
-    // TODO: consider updating BackupStatus if necessary
+    // Remove from the candidate set because it has been copied to the backup storage successfully
+    candidateTimetableBackupFiles.remove(file);
+    synchronized (backupStatus) {
+      // Update the latest timestamp to which the timetable backup was successful
+      backupPoint.setTimestamp(Long.parseLong(file.getFile().getName().split("-")[1]));
+      backupStatus.update(backupPoint);
+    }
+    logger.info(
+        "TimetableBackup::backupComplete(): backup complete for file: {}. Updated backed up "
+            + "timestamp to {}", file.getFile().getName(), backupPoint.getTimestamp());
   }
 
   /**
@@ -138,13 +185,32 @@ public class TimetableBackup extends BackupProcess {
    */
   private File createTimetableBackupFile() throws IOException {
     File tempTimetableBackupFile = new File(tmpDir, makeTimetableBackupFileName());
+    logger.info(
+        "TimetableBackup::createTimetableBackupFile(): created temporary timetable backup file with"
+            + " name: " + tempTimetableBackupFile.getName());
     FileOutputStream fos = new FileOutputStream(tempTimetableBackupFile);
     ObjectOutputStream oos = new ObjectOutputStream(fos);
     oos.writeObject(timetableRecordMap);
     oos.flush();
     oos.close();
     fos.close();
+    logger.info(
+        "TimetableBackup::createTimetableBackupFile(): successfully wrote cached timetable data to "
+            + "temporary timetable backup file with name: " + tempTimetableBackupFile.getName());
     return tempTimetableBackupFile;
+  }
+
+  /**
+   * Get all temporary timetable backup files in tmpDir.
+   */
+  private void getAllTmpBackupFiles() {
+    File[] tmpBackupFiles = tmpDir.listFiles(f -> f.getName().startsWith(TIMETABLE_PREFIX));
+    if (tmpBackupFiles != null && tmpBackupFiles.length != 0) {
+      for (File file : tmpBackupFiles) {
+        // Note that zxid are not needed for timetable backup files, so we just put 0 here
+        candidateTimetableBackupFiles.add(new BackupManager.BackupFile(file, true, 0, 0));
+      }
+    }
   }
 
   /**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/timetable/TimetableUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/timetable/TimetableUtil.java
@@ -29,9 +29,13 @@ import org.apache.zookeeper.server.backup.exception.BackupException;
 /**
  * Util methods used to operate on timetable backup.
  */
-public class TimetableUtil {
+public final class TimetableUtil {
   private static final String LATEST = "latest";
   private static final String TIMETABLE_PREFIX = "timetable.";
+
+  private TimetableUtil() {
+    // Util class
+  }
 
   /**
    * Returns the last zxid corresponding to the timestamp preceding the timestamp given as argument.


### PR DESCRIPTION
Resolves https://github.com/linkedin/zookeeper/issues/34

The backup status file stored in statusDir for ZooKeeper backup is used to coordinate between snapshot and TxLog backup processes. It is used in case of failure or restart so that the respective threads can pick up where they left off before restarting. This commit adds timetable to the status file so that in case of restart, the timetable backup process will also pick up where it left off and retry any temporary timetable backup files on the backup server.

This commit also includes some refactors such as replacing internal long variables with a POJO named BackupPoint.

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.zookeeper.server.backup.timetable.TimetableUtilTest
[INFO] Running org.apache.zookeeper.test.BackupManagerTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.066 s - in org.apache.zookeeper.server.backup.timetable.TimetableUtilTest
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 18.495 s - in org.apache.zookeeper.test.BackupManagerTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  28.492 s
[INFO] Finished at: 2021-03-18T22:45:13-07:00
```