### PR TITLE
Add restore command to ZK CLI

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
@@ -57,6 +57,7 @@ import org.apache.zookeeper.cli.LsCommand;
 import org.apache.zookeeper.cli.MalformedCommandException;
 import org.apache.zookeeper.cli.ReconfigCommand;
 import org.apache.zookeeper.cli.RemoveWatchesCommand;
+import org.apache.zookeeper.cli.RestoreCommand;
 import org.apache.zookeeper.cli.SetAclCommand;
 import org.apache.zookeeper.cli.SetCommand;
 import org.apache.zookeeper.cli.SetQuotaCommand;
@@ -123,6 +124,7 @@ public class ZooKeeperMain {
         new GetAllChildrenNumberCommand().addToMap(commandMapCli);
         new VersionCommand().addToMap(commandMapCli);
         new AddWatchCommand().addToMap(commandMapCli);
+        new RestoreCommand().addToMap(commandMapCli);
 
         // add all to commandMap
         for (Entry<String, CliCommand> entry : commandMapCli.entrySet()) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/CliParseException.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/CliParseException.java
@@ -31,4 +31,7 @@ public class CliParseException extends CliException {
         super(message);
     }
 
+  public CliParseException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/RestoreCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/RestoreCommand.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.zookeeper.cli;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.Parser;
+import org.apache.commons.cli.PosixParser;
+import org.apache.zookeeper.server.backup.RestoreFromBackupTool;
+
+/**
+ * Restore command for ZkCli.
+ */
+public class RestoreCommand extends CliCommand {
+
+  private RestoreFromBackupTool tool;
+  private CommandLine cl;
+  private static Options options = new Options();
+  private static final String RESTORE_ZXID_STR = "restore_zxid";
+  private static final String RESTORE_TIMESTAMP_STR = "restore_timestamp";
+  private static final String BACKUP_STORE_STR = "backup_store";
+  private static final String SNAP_DESTINATION_STR = "snap_destination";
+  private static final String LOG_DESTINATION_STR = "log_destination";
+  private static final String TIMETABLE_STORAGE_PATH_STR = "timetable_storage_path";
+  private static final String LOCAL_RESTORE_TEMP_DIR_PATH_STR = "local_restore_temp_dir_path";
+  private static final String DRY_RUN_STR = "dry_run";
+  public static final String RESTORE_ZXID_OPTION = "z";
+  public static final String RESTORE_TIMESTAMP_OPTION = "t";
+  public static final String BACKUP_STORE_OPTION = "b";
+  public static final String SNAP_DESTINATION_OPTION = "s";
+  public static final String LOG_DESTINATION_OPTION = "l";
+  public static final String TIMETABLE_STORAGE_PATH_OPTION = "m";
+  public static final String LOCAL_RESTORE_TEMP_DIR_PATH_OPTION = "r";
+  public static final String DRY_RUN_OPTION = "n";
+  private static final String RESTORE_ZXID_CMD = "-" + RESTORE_ZXID_OPTION + " " + RESTORE_ZXID_STR;
+  private static final String RESTORE_TIMESTAMP_CMD =
+      "-" + RESTORE_TIMESTAMP_OPTION + " " + RESTORE_TIMESTAMP_STR;
+  private static final String BACKUP_STORE_CMD = "-" + BACKUP_STORE_OPTION + " " + BACKUP_STORE_STR;
+  private static final String SNAP_DESTINATION_CMD =
+      "-" + SNAP_DESTINATION_OPTION + " " + SNAP_DESTINATION_STR;
+  private static final String LOG_DESTINATION_CMD =
+      "-" + LOG_DESTINATION_OPTION + " " + LOG_DESTINATION_STR;
+  private static final String TIMETABLE_STORAGE_PATH_CMD =
+      "-" + TIMETABLE_STORAGE_PATH_OPTION + " " + TIMETABLE_STORAGE_PATH_STR;
+  private static final String LOCAL_RESTORE_TEMP_DIR_PATH_CMD =
+      "-" + LOCAL_RESTORE_TEMP_DIR_PATH_OPTION + " " + LOCAL_RESTORE_TEMP_DIR_PATH_STR;
+  private static final String DRY_RUN_CMD = "-" + DRY_RUN_OPTION;
+  private static final String RESTORE_CMD_STR = "restore";
+  private static final String OPTION_STR =
+      "[" + RESTORE_ZXID_CMD + "]/[" + RESTORE_TIMESTAMP_CMD + "] [" + BACKUP_STORE_CMD + "] ["
+          + SNAP_DESTINATION_CMD + "] [" + LOG_DESTINATION_CMD + "] [" + TIMETABLE_STORAGE_PATH_CMD
+          + "](needed if restore to a timestamp) [" + LOCAL_RESTORE_TEMP_DIR_PATH_CMD
+          + "](optional) [" + DRY_RUN_CMD + "](optional)";
+
+  static {
+    options.addOption(new Option(RESTORE_ZXID_OPTION, true, RESTORE_ZXID_STR));
+    options.addOption(new Option(RESTORE_TIMESTAMP_OPTION, true, RESTORE_TIMESTAMP_STR));
+    options.addOption(new Option(BACKUP_STORE_OPTION, true, BACKUP_STORE_STR));
+    options.addOption(new Option(SNAP_DESTINATION_OPTION, true, SNAP_DESTINATION_STR));
+    options.addOption(new Option(LOG_DESTINATION_OPTION, true, LOG_DESTINATION_STR));
+    options.addOption(new Option(TIMETABLE_STORAGE_PATH_OPTION, true, TIMETABLE_STORAGE_PATH_STR));
+    options.addOption(
+        new Option(LOCAL_RESTORE_TEMP_DIR_PATH_OPTION, true, LOCAL_RESTORE_TEMP_DIR_PATH_STR));
+    options.addOption(new Option(DRY_RUN_OPTION, false, DRY_RUN_STR));
+  }
+
+  public RestoreCommand() {
+    super(RESTORE_CMD_STR, OPTION_STR);
+    tool = new RestoreFromBackupTool();
+  }
+
+  @Override
+  public String getUsageStr() {
+    return "Usage: RestoreFromBackupTool  " + RESTORE_CMD_STR + " " + OPTION_STR + "\n    "
+        + RESTORE_ZXID_CMD
+        + ": the point to restore to, either the string 'latest' or a zxid in hex format. Choose one between this option or "
+        + RESTORE_TIMESTAMP_CMD + ", if both are specified, this option will be prioritized\n    "
+        + RESTORE_TIMESTAMP_CMD
+        + ": the point to restore to, a timestamp in long format. Choose one between this option or "
+        + RESTORE_ZXID_CMD + ".\n    " + BACKUP_STORE_CMD
+        + ": the connection information for the backup store\n           For GPFS the format is: gpfs:<config_path>:<backup_path>:<namespace>\n    "
+        + SNAP_DESTINATION_CMD + ": local destination path for restored snapshots\n    "
+        + LOG_DESTINATION_CMD + ": local destination path for restored txlogs\n    "
+        + TIMETABLE_STORAGE_PATH_CMD
+        + ": Needed if restore to a timestamp. Backup storage path for timetable files, for GPFS the format is: gpfs:<config_path>:<backup_path>:<namespace>, if not set, default to be same as backup storage path\n    "
+        + LOCAL_RESTORE_TEMP_DIR_PATH_CMD
+        + ": Optional, local path for creating a temporary intermediate directory for restoration, the directory will be deleted after restoration is done\n    "
+        + DRY_RUN_CMD + " " + DRY_RUN_STR
+        + ": Optional, no files will be actually copied in a dry run";
+  }
+
+  @Override
+  public CliCommand parse(String[] cmdArgs) throws CliParseException {
+    Parser parser = new PosixParser();
+    try {
+      cl = parser.parse(options, cmdArgs);
+    } catch (ParseException ex) {
+      throw new CliParseException(getUsageStr(), ex);
+    }
+    if ((!cl.hasOption(RESTORE_ZXID_OPTION) && !cl.hasOption(RESTORE_TIMESTAMP_OPTION)) || !cl
+        .hasOption(BACKUP_STORE_OPTION) || !cl.hasOption(SNAP_DESTINATION_OPTION) || !cl
+        .hasOption(LOG_DESTINATION_OPTION)) {
+      throw new CliParseException("Missing required argument(s).\n" + getUsageStr());
+    }
+    return this;
+  }
+
+  @Override
+  public boolean exec() throws CliException {
+    return tool.runWithRetries(cl);
+  }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/RestoreCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/RestoreCommand.java
@@ -43,7 +43,7 @@ public class RestoreCommand extends CliCommand {
           + "](needed if restore to a timestamp) [" + OptionFullCommand.LOCAL_RESTORE_TEMP_DIR_PATH
           + "](optional) [" + OptionFullCommand.DRY_RUN + "](optional)";
 
-  public static final class OptionLongForm {
+  public final class OptionLongForm {
     /* Required if no restore timestamp is specified */
     public static final String RESTORE_ZXID = "restore_zxid";
     /* Required if no restore zxid is specified */
@@ -60,9 +60,13 @@ public class RestoreCommand extends CliCommand {
     public static final String LOCAL_RESTORE_TEMP_DIR_PATH = "local_restore_temp_dir_path";
     /* Optional. Default value false */
     public static final String DRY_RUN = "dry_run";
+
+    // Create a private constructor so it can't be instantiated
+    private OptionLongForm() {
+    }
   }
 
-  public static final class OptionShortForm {
+  public final class OptionShortForm {
     public static final String RESTORE_ZXID = "z";
     public static final String RESTORE_TIMESTAMP = "t";
     public static final String BACKUP_STORE = "b";
@@ -71,9 +75,13 @@ public class RestoreCommand extends CliCommand {
     public static final String TIMETABLE_STORAGE_PATH = "m";
     public static final String LOCAL_RESTORE_TEMP_DIR_PATH = "r";
     public static final String DRY_RUN = "n";
+
+    // Create a private constructor so it can't be instantiated
+    private OptionShortForm() {
+    }
   }
 
-  public static final class OptionFullCommand {
+  public final class OptionFullCommand {
     public static final String RESTORE_ZXID =
         "-" + OptionShortForm.RESTORE_ZXID + " " + OptionLongForm.RESTORE_ZXID;
     public static final String RESTORE_TIMESTAMP =
@@ -90,6 +98,10 @@ public class RestoreCommand extends CliCommand {
         "-" + OptionShortForm.LOCAL_RESTORE_TEMP_DIR_PATH + " "
             + OptionLongForm.LOCAL_RESTORE_TEMP_DIR_PATH;
     public static final String DRY_RUN = "-" + OptionShortForm.DRY_RUN;
+
+    // Create a private constructor so it can't be instantiated
+    private OptionFullCommand() {
+    }
   }
 
   static {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/RestoreCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/RestoreCommand.java
@@ -35,52 +35,77 @@ public class RestoreCommand extends CliCommand {
   private RestoreFromBackupTool tool;
   private CommandLine cl;
   private static Options options = new Options();
-  private static final String RESTORE_ZXID_STR = "restore_zxid";
-  private static final String RESTORE_TIMESTAMP_STR = "restore_timestamp";
-  private static final String BACKUP_STORE_STR = "backup_store";
-  private static final String SNAP_DESTINATION_STR = "snap_destination";
-  private static final String LOG_DESTINATION_STR = "log_destination";
-  private static final String TIMETABLE_STORAGE_PATH_STR = "timetable_storage_path";
-  private static final String LOCAL_RESTORE_TEMP_DIR_PATH_STR = "local_restore_temp_dir_path";
-  private static final String DRY_RUN_STR = "dry_run";
-  public static final String RESTORE_ZXID_OPTION = "z";
-  public static final String RESTORE_TIMESTAMP_OPTION = "t";
-  public static final String BACKUP_STORE_OPTION = "b";
-  public static final String SNAP_DESTINATION_OPTION = "s";
-  public static final String LOG_DESTINATION_OPTION = "l";
-  public static final String TIMETABLE_STORAGE_PATH_OPTION = "m";
-  public static final String LOCAL_RESTORE_TEMP_DIR_PATH_OPTION = "r";
-  public static final String DRY_RUN_OPTION = "n";
-  private static final String RESTORE_ZXID_CMD = "-" + RESTORE_ZXID_OPTION + " " + RESTORE_ZXID_STR;
-  private static final String RESTORE_TIMESTAMP_CMD =
-      "-" + RESTORE_TIMESTAMP_OPTION + " " + RESTORE_TIMESTAMP_STR;
-  private static final String BACKUP_STORE_CMD = "-" + BACKUP_STORE_OPTION + " " + BACKUP_STORE_STR;
-  private static final String SNAP_DESTINATION_CMD =
-      "-" + SNAP_DESTINATION_OPTION + " " + SNAP_DESTINATION_STR;
-  private static final String LOG_DESTINATION_CMD =
-      "-" + LOG_DESTINATION_OPTION + " " + LOG_DESTINATION_STR;
-  private static final String TIMETABLE_STORAGE_PATH_CMD =
-      "-" + TIMETABLE_STORAGE_PATH_OPTION + " " + TIMETABLE_STORAGE_PATH_STR;
-  private static final String LOCAL_RESTORE_TEMP_DIR_PATH_CMD =
-      "-" + LOCAL_RESTORE_TEMP_DIR_PATH_OPTION + " " + LOCAL_RESTORE_TEMP_DIR_PATH_STR;
-  private static final String DRY_RUN_CMD = "-" + DRY_RUN_OPTION;
   private static final String RESTORE_CMD_STR = "restore";
   private static final String OPTION_STR =
-      "[" + RESTORE_ZXID_CMD + "]/[" + RESTORE_TIMESTAMP_CMD + "] [" + BACKUP_STORE_CMD + "] ["
-          + SNAP_DESTINATION_CMD + "] [" + LOG_DESTINATION_CMD + "] [" + TIMETABLE_STORAGE_PATH_CMD
-          + "](needed if restore to a timestamp) [" + LOCAL_RESTORE_TEMP_DIR_PATH_CMD
-          + "](optional) [" + DRY_RUN_CMD + "](optional)";
+      "[" + OptionFullCommand.RESTORE_ZXID + "]/[" + OptionFullCommand.RESTORE_TIMESTAMP + "] ["
+          + OptionFullCommand.BACKUP_STORE + "] [" + OptionFullCommand.SNAP_DESTINATION + "] ["
+          + OptionFullCommand.LOG_DESTINATION + "] [" + OptionFullCommand.TIMETABLE_STORAGE_PATH
+          + "](needed if restore to a timestamp) [" + OptionFullCommand.LOCAL_RESTORE_TEMP_DIR_PATH
+          + "](optional) [" + OptionFullCommand.DRY_RUN + "](optional)";
+
+  public static final class OptionLongForm {
+    /* Required if no restore timestamp is specified */
+    public static final String RESTORE_ZXID = "restore_zxid";
+    /* Required if no restore zxid is specified */
+    public static final String RESTORE_TIMESTAMP = "restore_timestamp";
+    /* Required */
+    public static final String BACKUP_STORE = "backup_store";
+    /* Required */
+    public static final String SNAP_DESTINATION = "snap_destination";
+    /* Required */
+    public static final String LOG_DESTINATION = "log_destination";
+    /* Optional. If not set, default to backup storage path */
+    public static final String TIMETABLE_STORAGE_PATH = "timetable_storage_path";
+    /* Optional. If not set, default to the log destination dir */
+    public static final String LOCAL_RESTORE_TEMP_DIR_PATH = "local_restore_temp_dir_path";
+    /* Optional. Default value false */
+    public static final String DRY_RUN = "dry_run";
+  }
+
+  public static final class OptionShortForm {
+    public static final String RESTORE_ZXID = "z";
+    public static final String RESTORE_TIMESTAMP = "t";
+    public static final String BACKUP_STORE = "b";
+    public static final String SNAP_DESTINATION = "s";
+    public static final String LOG_DESTINATION = "l";
+    public static final String TIMETABLE_STORAGE_PATH = "m";
+    public static final String LOCAL_RESTORE_TEMP_DIR_PATH = "r";
+    public static final String DRY_RUN = "n";
+  }
+
+  public static final class OptionFullCommand {
+    public static final String RESTORE_ZXID =
+        "-" + OptionShortForm.RESTORE_ZXID + " " + OptionLongForm.RESTORE_ZXID;
+    public static final String RESTORE_TIMESTAMP =
+        "-" + OptionShortForm.RESTORE_TIMESTAMP + " " + OptionLongForm.RESTORE_TIMESTAMP;
+    public static final String BACKUP_STORE =
+        "-" + OptionShortForm.BACKUP_STORE + " " + OptionLongForm.BACKUP_STORE;
+    public static final String SNAP_DESTINATION =
+        "-" + OptionShortForm.SNAP_DESTINATION + " " + OptionLongForm.SNAP_DESTINATION;
+    public static final String LOG_DESTINATION =
+        "-" + OptionShortForm.LOG_DESTINATION + " " + OptionLongForm.LOG_DESTINATION;
+    public static final String TIMETABLE_STORAGE_PATH =
+        "-" + OptionShortForm.TIMETABLE_STORAGE_PATH + " " + OptionLongForm.TIMETABLE_STORAGE_PATH;
+    public static final String LOCAL_RESTORE_TEMP_DIR_PATH =
+        "-" + OptionShortForm.LOCAL_RESTORE_TEMP_DIR_PATH + " "
+            + OptionLongForm.LOCAL_RESTORE_TEMP_DIR_PATH;
+    public static final String DRY_RUN = "-" + OptionShortForm.DRY_RUN;
+  }
 
   static {
-    options.addOption(new Option(RESTORE_ZXID_OPTION, true, RESTORE_ZXID_STR));
-    options.addOption(new Option(RESTORE_TIMESTAMP_OPTION, true, RESTORE_TIMESTAMP_STR));
-    options.addOption(new Option(BACKUP_STORE_OPTION, true, BACKUP_STORE_STR));
-    options.addOption(new Option(SNAP_DESTINATION_OPTION, true, SNAP_DESTINATION_STR));
-    options.addOption(new Option(LOG_DESTINATION_OPTION, true, LOG_DESTINATION_STR));
-    options.addOption(new Option(TIMETABLE_STORAGE_PATH_OPTION, true, TIMETABLE_STORAGE_PATH_STR));
+    options.addOption(new Option(OptionShortForm.RESTORE_ZXID, true, OptionLongForm.RESTORE_ZXID));
     options.addOption(
-        new Option(LOCAL_RESTORE_TEMP_DIR_PATH_OPTION, true, LOCAL_RESTORE_TEMP_DIR_PATH_STR));
-    options.addOption(new Option(DRY_RUN_OPTION, false, DRY_RUN_STR));
+        new Option(OptionShortForm.RESTORE_TIMESTAMP, true, OptionLongForm.RESTORE_TIMESTAMP));
+    options.addOption(new Option(OptionShortForm.BACKUP_STORE, true, OptionLongForm.BACKUP_STORE));
+    options.addOption(
+        new Option(OptionShortForm.SNAP_DESTINATION, true, OptionLongForm.SNAP_DESTINATION));
+    options.addOption(
+        new Option(OptionShortForm.LOG_DESTINATION, true, OptionLongForm.LOG_DESTINATION));
+    options.addOption(new Option(OptionShortForm.TIMETABLE_STORAGE_PATH, true,
+        OptionLongForm.TIMETABLE_STORAGE_PATH));
+    options.addOption(new Option(OptionShortForm.LOCAL_RESTORE_TEMP_DIR_PATH, true,
+        OptionLongForm.LOCAL_RESTORE_TEMP_DIR_PATH));
+    options.addOption(new Option(OptionShortForm.DRY_RUN, false, OptionLongForm.DRY_RUN));
   }
 
   public RestoreCommand() {
@@ -91,20 +116,22 @@ public class RestoreCommand extends CliCommand {
   @Override
   public String getUsageStr() {
     return "Usage: RestoreFromBackupTool  " + RESTORE_CMD_STR + " " + OPTION_STR + "\n    "
-        + RESTORE_ZXID_CMD
+        + OptionFullCommand.RESTORE_ZXID
         + ": the point to restore to, either the string 'latest' or a zxid in hex format. Choose one between this option or "
-        + RESTORE_TIMESTAMP_CMD + ", if both are specified, this option will be prioritized\n    "
-        + RESTORE_TIMESTAMP_CMD
+        + OptionFullCommand.RESTORE_TIMESTAMP
+        + ", if both are specified, this option will be prioritized\n    "
+        + OptionFullCommand.RESTORE_TIMESTAMP
         + ": the point to restore to, a timestamp in long format. Choose one between this option or "
-        + RESTORE_ZXID_CMD + ".\n    " + BACKUP_STORE_CMD
+        + OptionFullCommand.RESTORE_ZXID + ".\n    " + OptionFullCommand.BACKUP_STORE
         + ": the connection information for the backup store\n           For GPFS the format is: gpfs:<config_path>:<backup_path>:<namespace>\n    "
-        + SNAP_DESTINATION_CMD + ": local destination path for restored snapshots\n    "
-        + LOG_DESTINATION_CMD + ": local destination path for restored txlogs\n    "
-        + TIMETABLE_STORAGE_PATH_CMD
+        + OptionFullCommand.SNAP_DESTINATION
+        + ": local destination path for restored snapshots\n    "
+        + OptionFullCommand.LOG_DESTINATION + ": local destination path for restored txlogs\n    "
+        + OptionFullCommand.TIMETABLE_STORAGE_PATH
         + ": Needed if restore to a timestamp. Backup storage path for timetable files, for GPFS the format is: gpfs:<config_path>:<backup_path>:<namespace>, if not set, default to be same as backup storage path\n    "
-        + LOCAL_RESTORE_TEMP_DIR_PATH_CMD
+        + OptionFullCommand.LOCAL_RESTORE_TEMP_DIR_PATH
         + ": Optional, local path for creating a temporary intermediate directory for restoration, the directory will be deleted after restoration is done\n    "
-        + DRY_RUN_CMD + " " + DRY_RUN_STR
+        + OptionFullCommand.DRY_RUN + " " + OptionLongForm.DRY_RUN
         + ": Optional, no files will be actually copied in a dry run";
   }
 
@@ -116,9 +143,10 @@ public class RestoreCommand extends CliCommand {
     } catch (ParseException ex) {
       throw new CliParseException(getUsageStr(), ex);
     }
-    if ((!cl.hasOption(RESTORE_ZXID_OPTION) && !cl.hasOption(RESTORE_TIMESTAMP_OPTION)) || !cl
-        .hasOption(BACKUP_STORE_OPTION) || !cl.hasOption(SNAP_DESTINATION_OPTION) || !cl
-        .hasOption(LOG_DESTINATION_OPTION)) {
+    if ((!cl.hasOption(OptionShortForm.RESTORE_ZXID) && !cl
+        .hasOption(OptionShortForm.RESTORE_TIMESTAMP)) || !cl
+        .hasOption(OptionShortForm.BACKUP_STORE) || !cl.hasOption(OptionShortForm.SNAP_DESTINATION)
+        || !cl.hasOption(OptionShortForm.LOG_DESTINATION)) {
       throw new CliParseException("Missing required argument(s).\n" + getUsageStr());
     }
     return this;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupConfig.java
@@ -68,8 +68,8 @@ public class BackupConfig {
   private final String backupStoragePath;
   /*
    * The custom namespace string under which the backup files will be stored in.
-   * E.g.) <backupStoragePath>/<namespace>/snapshot/snapshot-123456
-   *       <backupStoragePath>/<namespace>/translog/translog-123456
+   * E.g.) <backupStoragePath>/<namespace>/snapshot-123456
+   *       <backupStoragePath>/<namespace>/translog-123456
    */
   private final String namespace;
 
@@ -82,8 +82,8 @@ public class BackupConfig {
 
   public BackupConfig(Builder builder) {
     this.builder = builder;
-    this.statusDir = builder.statusDir.get();
-    this.tmpDir = builder.tmpDir.get();
+    this.statusDir = builder.statusDir.orElse(null);
+    this.tmpDir = builder.tmpDir.orElse(null);
     this.backupIntervalInMinutes = builder.backupIntervalInMinutes.orElse(
         DEFAULT_BACKUP_INTERVAL_MINUTES);
     this.retentionPeriodInDays = builder.retentionPeriodInDays.orElse(DEFAULT_RETENTION_DAYS);
@@ -93,7 +93,7 @@ public class BackupConfig {
     this.storageProviderClassName = builder.storageProviderClassName.get();
     this.storageConfig = builder.storageConfig.orElse(null);
     this.backupStoragePath = builder.backupStoragePath.orElse("");
-    this.namespace = builder.namespace.orElse("");
+    this.namespace = builder.namespace.orElse("UNKNOWN");
     this.timetableEnabled = builder.timetableEnabled.orElse(false);
     // If timetable storage path is not given, use the backup storage path
     this.timetableStoragePath = builder.timetableStoragePath.orElse(backupStoragePath);
@@ -166,10 +166,10 @@ public class BackupConfig {
     private Optional<Integer> retentionPeriodInDays = Optional.of(DEFAULT_RETENTION_DAYS);
     private Optional<Integer> retentionMaintenanceIntervalInHours =
         Optional.of(DEFAULT_RETENTION_MAINTENANCE_INTERVAL_HOURS);
-    private Optional<String> storageProviderClassName = Optional.empty();
-    private Optional<File> storageConfig = Optional.empty();
-    private Optional<String> backupStoragePath = Optional.empty();
-    private Optional<String> namespace = Optional.empty();
+    protected Optional<String> storageProviderClassName = Optional.empty();
+    protected Optional<File> storageConfig = Optional.empty();
+    protected Optional<String> backupStoragePath = Optional.empty();
+    protected Optional<String> namespace = Optional.empty();
     private Optional<Boolean> timetableEnabled = Optional.empty();
     private Optional<String> timetableStoragePath = Optional.empty();
     private Optional<Long> timetableBackupIntervalInMs = Optional.empty();
@@ -403,6 +403,43 @@ public class BackupConfig {
       if (!storageProviderClassName.isPresent() || storageProviderClassName.get().equals("")) {
         throw new ConfigException("Please specify a valid storage provider class name.");
       }
+    }
+  }
+
+  public static class RestorationConfigBuilder extends Builder {
+    public RestorationConfigBuilder setStorageProviderClassName(
+        String storageProviderClassName) {
+      this.storageProviderClassName = Optional.of(storageProviderClassName);
+      return this;
+    }
+
+    public RestorationConfigBuilder setStorageConfig(File storageConfig) {
+      this.storageConfig = Optional.of(storageConfig);
+      return this;
+    }
+
+    public RestorationConfigBuilder setBackupStoragePath(String backupStoragePath) {
+      this.backupStoragePath = Optional.of(backupStoragePath);
+      return this;
+    }
+
+    public RestorationConfigBuilder setNamespace(String namespace) {
+      this.namespace = Optional.of(namespace);
+      return this;
+    }
+
+    @Override
+    public Optional<BackupConfig> build() throws ConfigException {
+      if (!storageProviderClassName.isPresent() || storageProviderClassName.get().isEmpty()) {
+        throw new ConfigException("Please specify a valid storage provider class name.");
+      }
+      if (!backupStoragePath.isPresent()) {
+        throw new ConfigException("Please specify a valid backup storage path..");
+      }
+      if (!namespace.isPresent()) {
+        throw new ConfigException("Please specify a valid namespace.");
+      }
+      return Optional.of(new BackupConfig(this));
     }
   }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupConfig.java
@@ -72,6 +72,7 @@ public class BackupConfig {
    *       <backupStoragePath>/<namespace>/translog-123456
    */
   private final String namespace;
+  private static final String UNKNOWN = "UNKNOWN";
 
   /*
    * Optional timetable configs
@@ -93,7 +94,7 @@ public class BackupConfig {
     this.storageProviderClassName = builder.storageProviderClassName.get();
     this.storageConfig = builder.storageConfig.orElse(null);
     this.backupStoragePath = builder.backupStoragePath.orElse("");
-    this.namespace = builder.namespace.orElse("UNKNOWN");
+    this.namespace = builder.namespace.orElse(UNKNOWN);
     this.timetableEnabled = builder.timetableEnabled.orElse(false);
     // If timetable storage path is not given, use the backup storage path
     this.timetableStoragePath = builder.timetableStoragePath.orElse(backupStoragePath);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupConfig.java
@@ -72,7 +72,7 @@ public class BackupConfig {
    *       <backupStoragePath>/<namespace>/translog-123456
    */
   private final String namespace;
-  private static final String UNKNOWN = "UNKNOWN";
+  private static final String UNKNOWN_NAMESPACE = "UNKNOWN";
 
   /*
    * Optional timetable configs
@@ -94,7 +94,7 @@ public class BackupConfig {
     this.storageProviderClassName = builder.storageProviderClassName.get();
     this.storageConfig = builder.storageConfig.orElse(null);
     this.backupStoragePath = builder.backupStoragePath.orElse("");
-    this.namespace = builder.namespace.orElse(UNKNOWN);
+    this.namespace = builder.namespace.orElse(UNKNOWN_NAMESPACE);
     this.timetableEnabled = builder.timetableEnabled.orElse(false);
     // If timetable storage path is not given, use the backup storage path
     this.timetableStoragePath = builder.timetableStoragePath.orElse(backupStoragePath);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
@@ -509,7 +509,7 @@ public class BackupManager {
     this.serverId = serverId;
     this.namespace = backupConfig.getNamespace() == null ? "UNKNOWN" : backupConfig.getNamespace();
     try {
-      backupStorage = createStorageProviderImpl(backupConfig);
+      backupStorage = BackupUtil.createStorageProviderImpl(backupConfig);
     } catch (ReflectiveOperationException e) {
       throw new BackupException(e.getMessage(), e);
     }
@@ -609,7 +609,7 @@ public class BackupManager {
       // This is because we want the timetable backup to be stored in a different storage path
       BackupStorageProvider timetableBackupStorage;
       try {
-        timetableBackupStorage = createStorageProviderImpl(
+        timetableBackupStorage = BackupUtil.createStorageProviderImpl(
             backupConfig.getBuilder().setBackupStoragePath(backupConfig.getTimetableStoragePath())
                 .build().get());
         LOG.info(
@@ -648,26 +648,5 @@ public class BackupManager {
           timetableBackupStats);
       timetableBackup.initialize();
     }
-  }
-
-  /**
-   * Instantiates the storage provider implementation by reflection. This allows the user to
-   * choose which BackupStorageProvider implementation to use by specifying the fully-qualified
-   * class name in BackupConfig (read from Properties).
-   * @param backupConfig
-   * @return
-   * @throws ClassNotFoundException
-   * @throws NoSuchMethodException
-   * @throws IllegalAccessException
-   * @throws InvocationTargetException
-   * @throws InstantiationException
-   */
-  private BackupStorageProvider createStorageProviderImpl(BackupConfig backupConfig)
-      throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException,
-             InvocationTargetException, InstantiationException {
-    Class<?> clazz = Class.forName(backupConfig.getStorageProviderClassName());
-    Constructor<?> constructor = clazz.getConstructor(BackupConfig.class);
-    Object storageProvider = constructor.newInstance(backupConfig);
-    return (BackupStorageProvider) storageProvider;
   }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/RestoreFromBackupTool.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/RestoreFromBackupTool.java
@@ -28,7 +28,7 @@ import java.util.List;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Range;
 import org.apache.commons.cli.CommandLine;
-import org.apache.zookeeper.cli.RestoreCommand.*;
+import org.apache.zookeeper.cli.RestoreCommand;
 import org.apache.zookeeper.common.ConfigException;
 import org.apache.zookeeper.server.backup.BackupUtil.BackupFileType;
 import org.apache.zookeeper.server.backup.BackupUtil.IntervalEndpoint;
@@ -123,13 +123,13 @@ public class RestoreFromBackupTool {
    * @throws IOException if the backup provider cannot be instantiated correctly.
    */
   public void parseArgs(CommandLine cl) {
-    String backupStoragePath = cl.getOptionValue(OptionShortForm.BACKUP_STORE);
+    String backupStoragePath = cl.getOptionValue(RestoreCommand.OptionShortForm.BACKUP_STORE);
     createBackupStorageProvider(backupStoragePath);
 
     // Read the restore point
-    if (cl.hasOption(OptionShortForm.RESTORE_ZXID)) {
+    if (cl.hasOption(RestoreCommand.OptionShortForm.RESTORE_ZXID)) {
       parseRestoreZxid(cl);
-    } else if (cl.hasOption(OptionShortForm.RESTORE_TIMESTAMP)) {
+    } else if (cl.hasOption(RestoreCommand.OptionShortForm.RESTORE_TIMESTAMP)) {
       parseRestoreTimestamp(cl, backupStoragePath);
     }
 
@@ -137,7 +137,7 @@ public class RestoreFromBackupTool {
     parseRestoreTempDir(cl);
 
     // Check if this is a dry-run
-    if (cl.hasOption(OptionShortForm.DRY_RUN)) {
+    if (cl.hasOption(RestoreCommand.OptionShortForm.DRY_RUN)) {
       dryRun = true;
     }
 
@@ -185,7 +185,7 @@ public class RestoreFromBackupTool {
   }
 
   private void parseRestoreZxid(CommandLine cl) {
-    String zxidToRestoreStr = cl.getOptionValue(OptionShortForm.RESTORE_ZXID);
+    String zxidToRestoreStr = cl.getOptionValue(RestoreCommand.OptionShortForm.RESTORE_ZXID);
     if (zxidToRestoreStr.equalsIgnoreCase(BackupUtil.LATEST)) {
       zxidToRestore = Long.MAX_VALUE;
     } else {
@@ -207,10 +207,11 @@ public class RestoreFromBackupTool {
   }
 
   private void parseRestoreTimestamp(CommandLine cl, String backupStoragePath) {
-    String timestampStr = cl.getOptionValue(OptionShortForm.RESTORE_TIMESTAMP);
+    String timestampStr = cl.getOptionValue(RestoreCommand.OptionShortForm.RESTORE_TIMESTAMP);
     String timetableStoragePath = backupStoragePath;
-    if (cl.hasOption(OptionShortForm.TIMETABLE_STORAGE_PATH)) {
-      timetableStoragePath = cl.getOptionValue(OptionShortForm.TIMETABLE_STORAGE_PATH);
+    if (cl.hasOption(RestoreCommand.OptionShortForm.TIMETABLE_STORAGE_PATH)) {
+      timetableStoragePath =
+          cl.getOptionValue(RestoreCommand.OptionShortForm.TIMETABLE_STORAGE_PATH);
     }
     File[] timetableFiles = new File(timetableStoragePath)
         .listFiles(file -> file.getName().startsWith(TimetableBackup.TIMETABLE_PREFIX));
@@ -233,8 +234,8 @@ public class RestoreFromBackupTool {
   private void parseRestoreDestination(CommandLine cl) {
     // Read restore destination: dataDir and logDir
     try {
-      File snapDir = new File(cl.getOptionValue(OptionShortForm.SNAP_DESTINATION));
-      File logDir = new File(cl.getOptionValue(OptionShortForm.LOG_DESTINATION));
+      File snapDir = new File(cl.getOptionValue(RestoreCommand.OptionShortForm.SNAP_DESTINATION));
+      File logDir = new File(cl.getOptionValue(RestoreCommand.OptionShortForm.LOG_DESTINATION));
       snapLog = new FileTxnSnapLog(logDir, snapDir);
     } catch (IOException ioe) {
       System.err.println("Could not setup transaction log utility." + ioe);
@@ -243,9 +244,9 @@ public class RestoreFromBackupTool {
   }
 
   private void parseRestoreTempDir(CommandLine cl) {
-    if (cl.hasOption(OptionShortForm.LOCAL_RESTORE_TEMP_DIR_PATH)) {
+    if (cl.hasOption(RestoreCommand.OptionShortForm.LOCAL_RESTORE_TEMP_DIR_PATH)) {
       String localRestoreTempDirPath =
-          cl.getOptionValue(OptionShortForm.LOCAL_RESTORE_TEMP_DIR_PATH);
+          cl.getOptionValue(RestoreCommand.OptionShortForm.LOCAL_RESTORE_TEMP_DIR_PATH);
       restoreTempDir = new File(localRestoreTempDirPath);
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/RestoreFromBackupTool.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/RestoreFromBackupTool.java
@@ -20,17 +20,23 @@ package org.apache.zookeeper.server.backup;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Range;
+import org.apache.commons.cli.CommandLine;
+import org.apache.zookeeper.cli.RestoreCommand;
+import org.apache.zookeeper.common.ConfigException;
 import org.apache.zookeeper.server.backup.BackupUtil.BackupFileType;
 import org.apache.zookeeper.server.backup.BackupUtil.IntervalEndpoint;
 import org.apache.zookeeper.server.backup.exception.BackupException;
 import org.apache.zookeeper.server.backup.storage.BackupStorageProvider;
 import org.apache.zookeeper.server.backup.storage.BackupStorageUtil;
+import org.apache.zookeeper.server.backup.timetable.TimetableBackup;
+import org.apache.zookeeper.server.backup.timetable.TimetableUtil;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
 import org.apache.zookeeper.server.persistence.Util;
 import org.apache.zookeeper.server.util.ZxidUtils;
@@ -45,6 +51,9 @@ import org.slf4j.LoggerFactory;
 public class RestoreFromBackupTool {
   private static final Logger LOG = LoggerFactory.getLogger(RestoreFromBackupTool.class);
 
+  private static final int MAX_RETRIES = 10;
+  private static final String HEX_PREFIX = "0x";
+
   BackupStorageProvider storage;
   FileTxnSnapLog snapLog;
   long zxidToRestore;
@@ -58,6 +67,21 @@ public class RestoreFromBackupTool {
   int mostRecentLogNeededIndex;
   int snapNeededIndex;
   int oldestLogNeededIndex;
+
+  public enum BackupStorageOption {
+    GPFS("org.apache.zookeeper.server.backup.storage.impl.FileSystemBackupStorage"),
+    NFS("org.apache.zookeeper.server.backup.storage.impl.FileSystemBackupStorage");
+
+    private String storageProviderClassName;
+
+    BackupStorageOption(String className) {
+      this.storageProviderClassName = className;
+    }
+
+    public String getStorageProviderClassName() {
+      return storageProviderClassName;
+    }
+  }
 
   /**
    * Default constructor; requires using parseArgs to setup state.
@@ -90,6 +114,162 @@ public class RestoreFromBackupTool {
     this.snapLog = snapLog;
     this.dryRun = dryRun;
     this.restoreTempDir = restoreTempDir;
+  }
+
+  /**
+   * Parse and validate arguments to the tool
+   * @param cl the command line object with user inputs
+   * @return true if the arguments parse correctly; false in all other cases.
+   * @throws IOException if the backup provider cannot be instantiated correctly.
+   */
+  public void parseArgs(CommandLine cl) {
+    // Read the backup storage path
+    String backupStoragePath = cl.getOptionValue(RestoreCommand.BACKUP_STORE_OPTION);
+    String[] backupStorageParams = backupStoragePath.split(":");
+    if (backupStorageParams.length != 4) {
+      System.err.println(
+          "Failed to parse backup storage connection information from the backup storage path provided, please check the input.");
+      System.err.println(
+          "For example: the format for a gpfs backup storage path should be \"gpfs:<config_path>:<backup_path>:<namespace>\".");
+      System.exit(1);
+    }
+
+    String userProvidedStorageName = backupStorageParams[0].toUpperCase();
+    try {
+      BackupStorageOption storageOption = BackupStorageOption.valueOf(userProvidedStorageName);
+      String backupStorageProviderClassName = storageOption.getStorageProviderClassName();
+
+      BackupConfig.RestorationConfigBuilder configBuilder =
+          new BackupConfig.RestorationConfigBuilder()
+              .setStorageProviderClassName(backupStorageProviderClassName)
+              .setBackupStoragePath(backupStorageParams[2]).setNamespace(backupStorageParams[3]);
+      if (!backupStorageParams[1].isEmpty()) {
+        configBuilder = configBuilder.setStorageConfig(new File(backupStorageParams[1]));
+      }
+      storage = BackupUtil.createStorageProviderImpl(configBuilder.build().get());
+    } catch (IllegalArgumentException e) {
+      System.err.println("Could not find a valid backup storage option based on the input: "
+          + userProvidedStorageName + ". Error message: " + e.getMessage());
+      System.exit(1);
+    } catch (ConfigException e) {
+      System.err.println(
+          "Could not generate a backup config based on the input, error message: " + e
+              .getMessage());
+      System.exit(1);
+    } catch (InstantiationException | InvocationTargetException | NoSuchMethodException | IllegalAccessException | ClassNotFoundException e) {
+      System.err.println(
+          "Could not generate a backup storage provider based on the input, error message: " + e
+              .getMessage());
+      System.exit(1);
+    }
+
+    // Read the restore point
+    if (cl.hasOption(RestoreCommand.RESTORE_ZXID_OPTION)) {
+      String zxidToRestoreStr = cl.getOptionValue(RestoreCommand.RESTORE_ZXID_OPTION);
+      if (zxidToRestoreStr.equalsIgnoreCase(BackupUtil.LATEST)) {
+        zxidToRestore = Long.MAX_VALUE;
+      } else {
+        int base = 10;
+        String numStr = zxidToRestoreStr;
+
+        if (zxidToRestoreStr.startsWith(HEX_PREFIX)) {
+          numStr = zxidToRestoreStr.substring(2);
+          base = 16;
+        }
+        try {
+          zxidToRestore = Long.parseLong(numStr, base);
+        } catch (NumberFormatException nfe) {
+          System.err
+              .println("Invalid number specified for restore zxid point, the input is: " + numStr);
+          System.exit(2);
+        }
+      }
+    } else if (cl.hasOption(RestoreCommand.RESTORE_TIMESTAMP_OPTION)) {
+      String timestampStr = cl.getOptionValue(RestoreCommand.RESTORE_TIMESTAMP_OPTION);
+      String timetableStoragePath = backupStoragePath;
+      if (cl.hasOption(RestoreCommand.TIMETABLE_STORAGE_PATH_OPTION)) {
+        timetableStoragePath = cl.getOptionValue(RestoreCommand.TIMETABLE_STORAGE_PATH_OPTION);
+      }
+      File[] timetableFiles = new File(timetableStoragePath)
+          .listFiles(file -> file.getName().startsWith(TimetableBackup.TIMETABLE_PREFIX));
+      if (timetableFiles == null || timetableFiles.length == 0) {
+        System.err.println("Could not find timetable files at the path: " + timetableStoragePath);
+        System.exit(2);
+      }
+      String zxidRestorePointInHex;
+      try {
+        zxidRestorePointInHex =
+            TimetableUtil.findLastZxidFromTimestamp(timetableFiles, timestampStr);
+        zxidToRestore = Long.parseLong(zxidRestorePointInHex, 16);
+      } catch (IllegalArgumentException | BackupException e) {
+        System.err.println(
+            "Could not find a valid zxid from timetable using the timestamp provided: "
+                + timestampStr + ". The error message is: " + e.getMessage());
+        System.exit(2);
+      }
+    }
+
+    // Read restore destination: dataDir and logDir
+    try {
+      File snapDir = new File(cl.getOptionValue(RestoreCommand.SNAP_DESTINATION_OPTION));
+      File logDir = new File(cl.getOptionValue(RestoreCommand.LOG_DESTINATION_OPTION));
+      snapLog = new FileTxnSnapLog(logDir, snapDir);
+    } catch (IOException ioe) {
+      System.err.println("Could not setup transaction log utility." + ioe);
+      System.exit(3);
+    }
+
+    // Get the local restore temp dir path if it is provided
+    if (cl.hasOption(RestoreCommand.LOCAL_RESTORE_TEMP_DIR_PATH_OPTION)) {
+      String localRestoreTempDirPath =
+          cl.getOptionValue(RestoreCommand.LOCAL_RESTORE_TEMP_DIR_PATH_OPTION);
+      restoreTempDir = new File(localRestoreTempDirPath);
+    }
+
+    if (restoreTempDir == null) {
+      // Default address for restore temp dir if not set. It will be deleted after the restoration is done.
+      this.restoreTempDir = new File(snapLog.getDataDir(), "RestoreTempDir_" + zxidToRestore);
+    }
+
+    // Check if this is a dry-run
+    if (cl.hasOption(RestoreCommand.DRY_RUN_OPTION)) {
+      dryRun = true;
+    }
+
+    System.out.println("parseArgs successful.");
+  }
+
+  /**
+   * Attempts to perform a restore with up to MAX_RETRIES retries.
+   * @return true if the restore completed successfully, false in all other cases.
+   */
+  public boolean runWithRetries(CommandLine cl) {
+    parseArgs(cl);
+
+    int tries = 0;
+
+    if (dryRun) {
+      System.out.println("This is a DRYRUN, no files will actually be copied.");
+    }
+
+    while (tries < MAX_RETRIES) {
+      try {
+        run();
+        return true;
+      } catch (IllegalArgumentException re) {
+        tries++;
+        System.err.println(
+            "Restore attempt failed due to insufficient backup files; attempting again. " + tries
+                + "/" + MAX_RETRIES + ". Error message: " + re.getMessage());
+      } catch (Exception e) {
+        tries++;
+        System.err.println("Restore attempt failed; attempting again. " + tries + "/" + MAX_RETRIES
+            + ". Error message: " + e.getMessage());
+      }
+    }
+
+    System.err.println("Failed to restore after " + (tries + 1) + " attempts.");
+    return false;
   }
 
   /**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/timetable/TimetableUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/timetable/TimetableUtil.java
@@ -24,13 +24,13 @@ import java.io.ObjectInputStream;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.apache.zookeeper.server.backup.BackupUtil;
 import org.apache.zookeeper.server.backup.exception.BackupException;
 
 /**
  * Util methods used to operate on timetable backup.
  */
 public final class TimetableUtil {
-  private static final String LATEST = "latest";
   private static final String TIMETABLE_PREFIX = "timetable.";
 
   private TimetableUtil() {
@@ -55,7 +55,7 @@ public final class TimetableUtil {
     }
 
     // Verify argument: timestamp
-    boolean isLatest = timestamp.equalsIgnoreCase(LATEST);
+    boolean isLatest = timestamp.equalsIgnoreCase(BackupUtil.LATEST);
     long timestampLong;
     if (isLatest) {
       timestampLong = Long.MAX_VALUE;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/RestorationToolTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/RestorationToolTest.java
@@ -38,6 +38,7 @@ import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.cli.RestoreCommand;
 import org.apache.zookeeper.server.ServerCnxn;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.SyncRequestProcessor;
@@ -57,7 +58,6 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.zookeeper.cli.RestoreCommand.*;
 import static org.mockito.Mockito.when;
 
 public class RestorationToolTest extends ZKTestCase {
@@ -318,20 +318,24 @@ public class RestorationToolTest extends ZKTestCase {
     int restoreZxid = random.nextInt(txnCnt);
     RestoreFromBackupTool restoreTool = new RestoreFromBackupTool();
     CommandLine cl = Mockito.mock(CommandLine.class);
-    when(cl.hasOption(OptionShortForm.RESTORE_ZXID)).thenReturn(true);
-    when(cl.hasOption(OptionShortForm.BACKUP_STORE)).thenReturn(true);
-    when(cl.hasOption(OptionShortForm.SNAP_DESTINATION)).thenReturn(true);
-    when(cl.hasOption(OptionShortForm.LOG_DESTINATION)).thenReturn(true);
-    when(cl.getOptionValue(OptionShortForm.RESTORE_ZXID)).thenReturn(String.valueOf(restoreZxid));
-    when(cl.getOptionValue(OptionShortForm.BACKUP_STORE))
+    when(cl.hasOption(RestoreCommand.OptionShortForm.RESTORE_ZXID)).thenReturn(true);
+    when(cl.hasOption(RestoreCommand.OptionShortForm.BACKUP_STORE)).thenReturn(true);
+    when(cl.hasOption(RestoreCommand.OptionShortForm.SNAP_DESTINATION)).thenReturn(true);
+    when(cl.hasOption(RestoreCommand.OptionShortForm.LOG_DESTINATION)).thenReturn(true);
+    when(cl.getOptionValue(RestoreCommand.OptionShortForm.RESTORE_ZXID))
+        .thenReturn(String.valueOf(restoreZxid));
+    when(cl.getOptionValue(RestoreCommand.OptionShortForm.BACKUP_STORE))
         .thenReturn("gpfs::" + backupDir.getPath() + ":" + TEST_NAMESPACE);
-    when(cl.getOptionValue(OptionShortForm.SNAP_DESTINATION)).thenReturn(restoreDir.getPath());
-    when(cl.getOptionValue(OptionShortForm.LOG_DESTINATION)).thenReturn(restoreDir.getPath());
+    when(cl.getOptionValue(RestoreCommand.OptionShortForm.SNAP_DESTINATION))
+        .thenReturn(restoreDir.getPath());
+    when(cl.getOptionValue(RestoreCommand.OptionShortForm.LOG_DESTINATION))
+        .thenReturn(restoreDir.getPath());
     Assert.assertTrue(restoreTool.runWithRetries(cl));
     validateRestoreCoverage(restoreZxid);
 
     //Restore to latest
-    when(cl.getOptionValue(OptionShortForm.RESTORE_ZXID)).thenReturn(BackupUtil.LATEST);
+    when(cl.getOptionValue(RestoreCommand.OptionShortForm.RESTORE_ZXID))
+        .thenReturn(BackupUtil.LATEST);
     Assert.assertTrue(restoreTool.runWithRetries(cl));
     validateRestoreCoverage(txnCnt);
   }
@@ -342,22 +346,27 @@ public class RestorationToolTest extends ZKTestCase {
     backupManager.getTimetableBackup().run(1);
     RestoreFromBackupTool restoreTool = new RestoreFromBackupTool();
     CommandLine cl = Mockito.mock(CommandLine.class);
-    when(cl.hasOption(OptionShortForm.RESTORE_ZXID)).thenReturn(false);
-    when(cl.hasOption(OptionShortForm.RESTORE_TIMESTAMP)).thenReturn(true);
-    when(cl.hasOption(OptionShortForm.BACKUP_STORE)).thenReturn(true);
-    when(cl.hasOption(OptionShortForm.SNAP_DESTINATION)).thenReturn(true);
-    when(cl.hasOption(OptionShortForm.LOG_DESTINATION)).thenReturn(true);
-    when(cl.hasOption(OptionShortForm.TIMETABLE_STORAGE_PATH)).thenReturn(true);
-    when(cl.getOptionValue(OptionShortForm.RESTORE_TIMESTAMP)).thenReturn(String.valueOf(timestampInMiddle));
-    when(cl.getOptionValue(OptionShortForm.BACKUP_STORE))
+    when(cl.hasOption(RestoreCommand.OptionShortForm.RESTORE_ZXID)).thenReturn(false);
+    when(cl.hasOption(RestoreCommand.OptionShortForm.RESTORE_TIMESTAMP)).thenReturn(true);
+    when(cl.hasOption(RestoreCommand.OptionShortForm.BACKUP_STORE)).thenReturn(true);
+    when(cl.hasOption(RestoreCommand.OptionShortForm.SNAP_DESTINATION)).thenReturn(true);
+    when(cl.hasOption(RestoreCommand.OptionShortForm.LOG_DESTINATION)).thenReturn(true);
+    when(cl.hasOption(RestoreCommand.OptionShortForm.TIMETABLE_STORAGE_PATH)).thenReturn(true);
+    when(cl.getOptionValue(RestoreCommand.OptionShortForm.RESTORE_TIMESTAMP))
+        .thenReturn(String.valueOf(timestampInMiddle));
+    when(cl.getOptionValue(RestoreCommand.OptionShortForm.BACKUP_STORE))
         .thenReturn("gpfs::" + backupDir.getPath() + ":" + TEST_NAMESPACE);
-    when(cl.getOptionValue(OptionShortForm.SNAP_DESTINATION)).thenReturn(restoreDir.getPath());
-    when(cl.getOptionValue(OptionShortForm.LOG_DESTINATION)).thenReturn(restoreDir.getPath());
-    when(cl.getOptionValue(OptionShortForm.TIMETABLE_STORAGE_PATH)).thenReturn(timetableDir.getPath() + "/" + TEST_NAMESPACE);
+    when(cl.getOptionValue(RestoreCommand.OptionShortForm.SNAP_DESTINATION))
+        .thenReturn(restoreDir.getPath());
+    when(cl.getOptionValue(RestoreCommand.OptionShortForm.LOG_DESTINATION))
+        .thenReturn(restoreDir.getPath());
+    when(cl.getOptionValue(RestoreCommand.OptionShortForm.TIMETABLE_STORAGE_PATH))
+        .thenReturn(timetableDir.getPath() + "/" + TEST_NAMESPACE);
     Assert.assertTrue(restoreTool.runWithRetries(cl));
 
     //Restore to latest using timestamp
-    when(cl.getOptionValue(OptionShortForm.RESTORE_TIMESTAMP)).thenReturn(BackupUtil.LATEST);
+    when(cl.getOptionValue(RestoreCommand.OptionShortForm.RESTORE_TIMESTAMP))
+        .thenReturn(BackupUtil.LATEST);
     Assert.assertTrue(restoreTool.runWithRetries(cl));
     validateRestoreCoverage(txnCnt);
   }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/RestorationToolTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/RestorationToolTest.java
@@ -138,6 +138,7 @@ public class RestorationToolTest extends ZKTestCase {
       if (getRandomBoolean(0.2f)) {
         zks.takeSnapshot();
       }
+      // Record a timestamp that's in the valid backup timestamp range, used to test restoration to timestamp
       if (i == txnCnt / 2) {
         timestampInMiddle = System.currentTimeMillis();
       }
@@ -317,46 +318,46 @@ public class RestorationToolTest extends ZKTestCase {
     int restoreZxid = random.nextInt(txnCnt);
     RestoreFromBackupTool restoreTool = new RestoreFromBackupTool();
     CommandLine cl = Mockito.mock(CommandLine.class);
-    when(cl.hasOption(RESTORE_ZXID_OPTION)).thenReturn(true);
-    when(cl.hasOption(BACKUP_STORE_OPTION)).thenReturn(true);
-    when(cl.hasOption(SNAP_DESTINATION_OPTION)).thenReturn(true);
-    when(cl.hasOption(LOG_DESTINATION_OPTION)).thenReturn(true);
-    when(cl.getOptionValue(RESTORE_ZXID_OPTION)).thenReturn(String.valueOf(restoreZxid));
-    when(cl.getOptionValue(BACKUP_STORE_OPTION))
+    when(cl.hasOption(OptionShortForm.RESTORE_ZXID)).thenReturn(true);
+    when(cl.hasOption(OptionShortForm.BACKUP_STORE)).thenReturn(true);
+    when(cl.hasOption(OptionShortForm.SNAP_DESTINATION)).thenReturn(true);
+    when(cl.hasOption(OptionShortForm.LOG_DESTINATION)).thenReturn(true);
+    when(cl.getOptionValue(OptionShortForm.RESTORE_ZXID)).thenReturn(String.valueOf(restoreZxid));
+    when(cl.getOptionValue(OptionShortForm.BACKUP_STORE))
         .thenReturn("gpfs::" + backupDir.getPath() + ":" + TEST_NAMESPACE);
-    when(cl.getOptionValue(SNAP_DESTINATION_OPTION)).thenReturn(restoreDir.getPath());
-    when(cl.getOptionValue(LOG_DESTINATION_OPTION)).thenReturn(restoreDir.getPath());
+    when(cl.getOptionValue(OptionShortForm.SNAP_DESTINATION)).thenReturn(restoreDir.getPath());
+    when(cl.getOptionValue(OptionShortForm.LOG_DESTINATION)).thenReturn(restoreDir.getPath());
     Assert.assertTrue(restoreTool.runWithRetries(cl));
     validateRestoreCoverage(restoreZxid);
 
     //Restore to latest
-    when(cl.getOptionValue(RESTORE_ZXID_OPTION)).thenReturn(BackupUtil.LATEST);
+    when(cl.getOptionValue(OptionShortForm.RESTORE_ZXID)).thenReturn(BackupUtil.LATEST);
     Assert.assertTrue(restoreTool.runWithRetries(cl));
     validateRestoreCoverage(txnCnt);
   }
 
   @Test
   public void testRestoreToTimestampByCommandLine() throws IOException {
-    //Restore to a timestamp in the middle of backup
+    //Test restoration CLI using a timestamp recorded in the midpoint of the test ZNode creation
     backupManager.getTimetableBackup().run(1);
     RestoreFromBackupTool restoreTool = new RestoreFromBackupTool();
     CommandLine cl = Mockito.mock(CommandLine.class);
-    when(cl.hasOption(RESTORE_ZXID_OPTION)).thenReturn(false);
-    when(cl.hasOption(RESTORE_TIMESTAMP_OPTION)).thenReturn(true);
-    when(cl.hasOption(BACKUP_STORE_OPTION)).thenReturn(true);
-    when(cl.hasOption(SNAP_DESTINATION_OPTION)).thenReturn(true);
-    when(cl.hasOption(LOG_DESTINATION_OPTION)).thenReturn(true);
-    when(cl.hasOption(TIMETABLE_STORAGE_PATH_OPTION)).thenReturn(true);
-    when(cl.getOptionValue(RESTORE_TIMESTAMP_OPTION)).thenReturn(String.valueOf(timestampInMiddle));
-    when(cl.getOptionValue(BACKUP_STORE_OPTION))
+    when(cl.hasOption(OptionShortForm.RESTORE_ZXID)).thenReturn(false);
+    when(cl.hasOption(OptionShortForm.RESTORE_TIMESTAMP)).thenReturn(true);
+    when(cl.hasOption(OptionShortForm.BACKUP_STORE)).thenReturn(true);
+    when(cl.hasOption(OptionShortForm.SNAP_DESTINATION)).thenReturn(true);
+    when(cl.hasOption(OptionShortForm.LOG_DESTINATION)).thenReturn(true);
+    when(cl.hasOption(OptionShortForm.TIMETABLE_STORAGE_PATH)).thenReturn(true);
+    when(cl.getOptionValue(OptionShortForm.RESTORE_TIMESTAMP)).thenReturn(String.valueOf(timestampInMiddle));
+    when(cl.getOptionValue(OptionShortForm.BACKUP_STORE))
         .thenReturn("gpfs::" + backupDir.getPath() + ":" + TEST_NAMESPACE);
-    when(cl.getOptionValue(SNAP_DESTINATION_OPTION)).thenReturn(restoreDir.getPath());
-    when(cl.getOptionValue(LOG_DESTINATION_OPTION)).thenReturn(restoreDir.getPath());
-    when(cl.getOptionValue(TIMETABLE_STORAGE_PATH_OPTION)).thenReturn(timetableDir.getPath() + "/" + TEST_NAMESPACE);
+    when(cl.getOptionValue(OptionShortForm.SNAP_DESTINATION)).thenReturn(restoreDir.getPath());
+    when(cl.getOptionValue(OptionShortForm.LOG_DESTINATION)).thenReturn(restoreDir.getPath());
+    when(cl.getOptionValue(OptionShortForm.TIMETABLE_STORAGE_PATH)).thenReturn(timetableDir.getPath() + "/" + TEST_NAMESPACE);
     Assert.assertTrue(restoreTool.runWithRetries(cl));
 
     //Restore to latest using timestamp
-    when(cl.getOptionValue(RESTORE_TIMESTAMP_OPTION)).thenReturn(BackupUtil.LATEST);
+    when(cl.getOptionValue(OptionShortForm.RESTORE_TIMESTAMP)).thenReturn(BackupUtil.LATEST);
     Assert.assertTrue(restoreTool.runWithRetries(cl));
     validateRestoreCoverage(txnCnt);
   }


### PR DESCRIPTION
This commit adds a CLI command to ZooKeeperMain, and it will allow zk admin to run commands on a machine to restore the backed-up zk snapshot and transaction log files up until a specified zxid or timestamp from backup storage to a local path. This enables the offline restoration of a zk server node to a desired time/zxid.

Tests added: testRestoreToZxidByCommandLine, testRestoreToTimestampByCommandLine
RestorationToolTest: 6 total, 6 passed
RestorationToolTest.testFailedRestorationWithOutOfRangeZxid passed 7.85s
RestorationToolTest.testSuccessfulRestorationToZxid passed 7.21s
RestorationToolTest.testRestoreToZxidByCommandLine passed 6.12s
RestorationToolTest.testRestoreToTimestampByCommandLine passed 7.45s
RestorationToolTest.testSuccessfulRestorationToLatest passed 5.92s
RestorationToolTest.testFailedRestorationWithLostLog passed 5.94s