### PR TITLE
Add timetable backup metrics

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
@@ -577,7 +577,7 @@ public class BackupManager {
       MBeanRegistry.getInstance().register(backupBean, null);
       LOG.info("Registered Backup bean {} with JMX.", backupBean.getName());
     } catch (JMException e) {
-      LOG.warn("Failed to register Backup bean with JMX for namespace {} on server {}.", namespace,
+      LOG.error("Failed to register Backup bean with JMX for namespace {} on server {}.", namespace,
           serverId, e);
       backupBean = null;
     }
@@ -623,11 +623,14 @@ public class BackupManager {
       TimetableBackupStats timetableBackupStats = new TimetableBackupStats();
       timetableBackupBean = new TimetableBackupBean(timetableBackupStats, serverId);
       try {
-        MBeanRegistry.getInstance().register(timetableBackupBean, null);
+        // Put timetable backup bean under backup bean, so that they are coupled. this is
+        // consistent with the backup-timetable design where backup must be enabled in order for
+        // timetable to work
+        MBeanRegistry.getInstance().register(timetableBackupBean, backupBean);
         LOG.info("BackupManager::initialize(): registered timetable backup bean {} with JMX.",
             backupBean.getName());
       } catch (JMException e) {
-        LOG.warn(
+        LOG.error(
             "BackupManager::initialize(): Failed to register timetable backup bean with JMX for "
                 + "namespace {} on server {}.", namespace, serverId, e);
       }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
@@ -621,14 +621,19 @@ public class BackupManager {
 
       // create metric-related classes for timetable backup
       TimetableBackupStats timetableBackupStats = new TimetableBackupStats();
-      timetableBackupBean = new TimetableBackupBean(timetableBackupStats, serverId);
+      timetableBackupBean = new TimetableBackupBean(timetableBackupStats);
       try {
         // Put timetable backup bean under backup bean, so that they are coupled. this is
         // consistent with the backup-timetable design where backup must be enabled in order for
         // timetable to work
-        MBeanRegistry.getInstance().register(timetableBackupBean, backupBean);
-        LOG.info("BackupManager::initialize(): registered timetable backup bean {} with JMX.",
-            backupBean.getName());
+        if (backupBean != null) {
+          MBeanRegistry.getInstance().register(timetableBackupBean, backupBean);
+          LOG.info("BackupManager::initialize(): registered timetable backup bean {} with JMX.",
+              backupBean.getName());
+        } else {
+          LOG.error("BackupManager::initialize(): Failed to register timetable backup bean with "
+              + "JMX because parent BackupBean is null!");
+        }
       } catch (JMException e) {
         LOG.error(
             "BackupManager::initialize(): Failed to register timetable backup bean with JMX for "

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupStats.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupStats.java
@@ -27,6 +27,9 @@ import org.slf4j.LoggerFactory;
 public class BackupStats {
   private static final Logger LOG = LoggerFactory.getLogger(BackupStats.class);
 
+  /*
+    Snapshot backup metric declarations
+   */
   private int failedSnapshotIterationCount = 0;
   private long lastSuccessfulSnapshotBackupIterationFinishTime = System.currentTimeMillis();
   private boolean snapshotBackupActive = false;
@@ -35,6 +38,9 @@ public class BackupStats {
   private int numberOfSnapshotFilesBackedUpThisIteration = 0;
   private long lastSnapshotBackupIterationStartTime = System.currentTimeMillis();
 
+  /*
+    TxLog backup metric declarations
+   */
   private int failedTxnLogIterationCount = 0;
   private long lastSuccessfulTxnLogBackupIterationFinishTime = System.currentTimeMillis();
   private boolean txnLogBackupActive = false;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/TimetableBackupBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/TimetableBackupBean.java
@@ -21,18 +21,16 @@ package org.apache.zookeeper.server.backup.monitoring;
 import org.apache.zookeeper.jmx.ZKMBeanInfo;
 
 public class TimetableBackupBean implements ZKMBeanInfo, TimetableBackupMXBean {
-  public static final String TIMETABLE_BACKUP_MBEAN_PREFIX = "TimetableBackup";
+  public static final String TIMETABLE_BACKUP_MBEAN_NAME = "TimetableBackup";
   private final TimetableBackupStats backupStats;
-  private final String name;
 
-  public TimetableBackupBean(TimetableBackupStats backupStats, long serverId) {
+  public TimetableBackupBean(TimetableBackupStats backupStats) {
     this.backupStats = backupStats;
-    this.name = TIMETABLE_BACKUP_MBEAN_PREFIX + serverId;
   }
 
   @Override
   public String getName() {
-    return name;
+    return TIMETABLE_BACKUP_MBEAN_NAME;
   }
 
   @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/TimetableBackupBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/TimetableBackupBean.java
@@ -21,7 +21,7 @@ package org.apache.zookeeper.server.backup.monitoring;
 import org.apache.zookeeper.jmx.ZKMBeanInfo;
 
 public class TimetableBackupBean implements ZKMBeanInfo, TimetableBackupMXBean {
-  public static final String TIMETABLE_BACKUP_MBEAN_PREFIX = "Timetable_Backup_server";
+  public static final String TIMETABLE_BACKUP_MBEAN_PREFIX = "TimetableBackup";
   private final TimetableBackupStats backupStats;
   private final String name;
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/TimetableBackupBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/TimetableBackupBean.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup.monitoring;
+
+import org.apache.zookeeper.jmx.ZKMBeanInfo;
+
+public class TimetableBackupBean implements ZKMBeanInfo, TimetableBackupMXBean {
+  public static final String TIMETABLE_BACKUP_MBEAN_PREFIX = "Timetable_Backup_server";
+  private final TimetableBackupStats backupStats;
+  private final String name;
+
+  public TimetableBackupBean(TimetableBackupStats backupStats, long serverId) {
+    this.backupStats = backupStats;
+    this.name = TIMETABLE_BACKUP_MBEAN_PREFIX + serverId;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public boolean isHidden() {
+    return false;
+  }
+
+  // Timetable backup metrics
+  @Override
+  public int getNumConsecutiveFailedTimetableIterations() {
+    return backupStats.getNumConsecutiveFailedTimetableIterations();
+  }
+
+  @Override
+  public long getMinutesSinceLastSuccessfulTimetableIteration() {
+    return backupStats.getMinutesSinceLastSuccessfulTimetableIteration();
+  }
+
+  @Override
+  public boolean getTimetableBackupActiveStatus() {
+    return backupStats.getTimetableBackupActiveStatus();
+  }
+
+  @Override
+  public long getLastTimetableIterationDuration() {
+    return backupStats.getTimetableIterationDuration();
+  }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/TimetableBackupMXBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/TimetableBackupMXBean.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup.monitoring;
+
+public interface TimetableBackupMXBean {
+
+  // Timetable backup metrics
+
+  /**
+   * Counter
+   * For example: if backup iteration A fails, the number is 1; if next backup iteration B succeeds,
+   * the number is reset to 0.
+   * If A fails, the number is 1; if then the next iteration B fails again, the number is
+   * incremented to 2.
+   * @return
+   */
+  int getNumConsecutiveFailedTimetableIterations();
+
+  /**
+   * Counter
+   * @return Time passed (minutes) since last successful timetable backup iteration
+   */
+  long getMinutesSinceLastSuccessfulTimetableIteration();
+
+  /**
+   * Gauge
+   * @return If timetable backup is currently in progress
+   */
+  boolean getTimetableBackupActiveStatus();
+
+  /**
+   * Gauge
+   * @return How long it took to complete the last timetable backup iteration
+   */
+  long getLastTimetableIterationDuration();
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/TimetableBackupStats.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/TimetableBackupStats.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.backup.monitoring;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * TimetableBackupStats contains fields that represent metrics for timetable backup.
+ */
+public class TimetableBackupStats {
+  /*
+    Timetable backup metric declarations
+  */
+  private int failedTimetableIterationCount = 0;
+  private boolean timetableBackupActive = false;
+  private long lastSuccessfulTimetableBackupIterationFinishTime = System.currentTimeMillis();
+  private long timetableIterationDuration = 0L;
+  private long lastTimetableBackupIterationStartTime = System.currentTimeMillis();
+
+  // Timetable backup metrics
+
+  /**
+   * Counter
+   * For example: if backup iteration A fails, the number is 1; if next backup iteration B succeeds,
+   * the number is reset to 0.
+   * If A fails, the number is 1; if then the next iteration B fails again, the number is
+   * incremented to 2.
+   * @return Number of consecutive timetable backup errors since last successful timetable backup
+   *         iteration
+   */
+  public int getNumConsecutiveFailedTimetableIterations() {
+    return failedTimetableIterationCount;
+  }
+
+  /**
+   * Counter
+   * @return Time passed (minutes) since last successful timetable backup iteration
+   */
+  public long getMinutesSinceLastSuccessfulTimetableIteration() {
+    return TimeUnit.MILLISECONDS
+        .toMinutes(System.currentTimeMillis() - lastSuccessfulTimetableBackupIterationFinishTime);
+  }
+
+  /**
+   * Gauge
+   * @return true if timetable backup is currently in progress
+   */
+  public boolean getTimetableBackupActiveStatus() {
+    return timetableBackupActive;
+  }
+
+  /**
+   * Gauge
+   * @return How long it took to complete the last timetable backup iteration
+   */
+  public long getTimetableIterationDuration() {
+    return timetableIterationDuration;
+  }
+
+  /**
+   * Record the status and timestamp when a timetable backup iteration starts
+   */
+  public void setTimetableBackupIterationStart() {
+    lastTimetableBackupIterationStartTime = System.currentTimeMillis();
+    timetableBackupActive = true;
+  }
+
+  /**
+   * Record the status and timestamp when a timetable backup iteration finishes.
+   * @param errorFree If this iteration finishes without error
+   */
+  public void setTimetableBackupIterationDone(boolean errorFree) {
+    long finishTime = System.currentTimeMillis();
+    timetableBackupActive = false;
+    timetableIterationDuration = finishTime - lastTimetableBackupIterationStartTime;
+    if (errorFree) {
+      lastSuccessfulTimetableBackupIterationFinishTime = finishTime;
+      failedTimetableIterationCount = 0;
+    } else {
+      failedTimetableIterationCount++;
+    }
+  }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/BackupBeanTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/BackupBeanTest.java
@@ -36,6 +36,7 @@ import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.SyncRequestProcessor;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.apache.zookeeper.server.backup.monitoring.BackupBean;
+import org.apache.zookeeper.server.backup.monitoring.TimetableBackupBean;
 import org.apache.zookeeper.server.backup.storage.BackupStorageProvider;
 import org.apache.zookeeper.server.backup.storage.impl.FileSystemBackupStorage;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
@@ -43,15 +44,20 @@ import org.apache.zookeeper.test.ClientBase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
+import org.junit.runners.MethodSorters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Tests ZooKeeper backup-related metrics: BackupBean and TimetableBackupBean.
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class BackupBeanTest extends ZKTestCase {
   private static final Logger LOG = LoggerFactory.getLogger(BackupBeanTest.class);
   private static final String HOSTPORT = "127.0.0.1:" + PortAssignment.unique();
   private static final int CONNECTION_TIMEOUT = 300000;
-  private static final int TEST_BACKUP_INTERVAL_MINUTES = 15;
   private static final String TEST_NAMESPACE = "TEST_NAMESPACE";
 
   private ZooKeeper connection;
@@ -79,8 +85,11 @@ public class BackupBeanTest extends ZKTestCase {
         setTmpDir(testBaseDir).
         setBackupStoragePath(backupDir.getAbsolutePath()).
         setNamespace(TEST_NAMESPACE).
-            setStorageProviderClassName(FileSystemBackupStorage.class.getName()).
-            build().get();
+        setStorageProviderClassName(FileSystemBackupStorage.class.getName()).
+        setTimetableEnabled(true).
+        setTimetableBackupIntervalInMs(100L). // 0.1s to ensure in-memory records are created
+        setTimetableStoragePath(backupDir.getAbsolutePath()).
+        build().get();
     backupStorage = new FileSystemBackupStorage(backupConfig);
 
     ClientBase.setupTestEnv();
@@ -139,17 +148,22 @@ public class BackupBeanTest extends ZKTestCase {
   }
 
   @Test
-  public void testMBeanRegistration() throws IOException {
+  public void test1_MBeanRegistration() throws IOException {
     // Register MBean when initializing backup manager
-    BackupManager bm = new BackupManager(dataDir, dataDir, 0, backupConfig);
-    String expectedMBeanName = "Backup_" + TEST_NAMESPACE + ".server0";
+    long serverId = 0L;
+    BackupManager bm = new BackupManager(dataDir, dataDir, serverId, backupConfig);
+    String expectedMBeanName = "Backup_" + TEST_NAMESPACE + ".server" + serverId;
+    String expectedTimetableMBeanName =
+        TimetableBackupBean.TIMETABLE_BACKUP_MBEAN_PREFIX + serverId;
     Set<ZKMBeanInfo> mbeans = MBeanRegistry.getInstance().getRegisteredBeans();
     Assert.assertTrue(containsMBean(mbeans, expectedMBeanName, false));
+    Assert.assertTrue(containsMBean(mbeans, expectedTimetableMBeanName, false));
 
     // Unregister MBean when stopping backup manager
     bm.stop();
     mbeans = MBeanRegistry.getInstance().getRegisteredBeans();
     Assert.assertFalse(containsMBean(mbeans, expectedMBeanName, false));
+    Assert.assertFalse(containsMBean(mbeans, expectedTimetableMBeanName, false));
   }
 
   private boolean containsMBean(Set<ZKMBeanInfo> mbeanSet, String mbeanName, boolean isHidden) {
@@ -160,7 +174,7 @@ public class BackupBeanTest extends ZKTestCase {
   }
 
   @Test
-  public void testMBeanUpdate() throws Exception {
+  public void test2_MBeanUpdate() throws Exception {
     MockBackupManager backupManager = new MockBackupManager(dataDir, dataDir, 0, backupConfig);
     BackupBean backupBean = backupManager.getBackupBean();
 
@@ -204,9 +218,36 @@ public class BackupBeanTest extends ZKTestCase {
     Assert.assertEquals(0, backupBean.getNumConsecutiveFailedSnapshotIterations());
     Assert.assertEquals(0, backupBean.getNumConsecutiveFailedTxnLogIterations());
 
-    Thread.sleep(60 * 1000);
+    // Wait one minute for metrics with minute granularity
+    Thread.sleep(60 * 1000L);
     Assert.assertTrue(backupBean.getMinutesSinceLastSuccessfulSnapshotIteration() > 0L);
     Assert.assertTrue(backupBean.getMinutesSinceLastSuccessfulTxnLogIteration() > 0L);
+
+    backupManager.stop();
+  }
+
+  @Test
+  public void test3_TimetableBackupMBean() throws IOException, InterruptedException {
+    MockBackupManager bm = new MockBackupManager(dataDir, dataDir, 0, backupConfig);
+    bm.initialize();
+    TimetableBackupBean timetableBackupBean = bm.getTimetableBackupBean();
+
+    bm.getTimetableBackup().run(1);
+
+    // Wait one minute for metrics with minute granularity
+    Thread.sleep(60 * 1000L);
+    long lastTimetableIterationDuration = timetableBackupBean.getLastTimetableIterationDuration();
+    long minutesSinceLastSuccessfulTimetableIteration =
+        timetableBackupBean.getMinutesSinceLastSuccessfulTimetableIteration();
+    int numConsecutiveFailedTimetableIterations =
+        timetableBackupBean.getNumConsecutiveFailedTimetableIterations();
+
+    // Verify the metric values
+    Assert.assertTrue(lastTimetableIterationDuration > 0L);
+    Assert.assertTrue(minutesSinceLastSuccessfulTimetableIteration > 0L);
+    Assert.assertEquals(0, numConsecutiveFailedTimetableIterations);
+
+    bm.stop();
   }
 
   private void createNode(ZooKeeper zk, String path) throws Exception {
@@ -224,6 +265,10 @@ public class BackupBeanTest extends ZKTestCase {
       return this.backupBean;
     }
 
+    public TimetableBackupBean getTimetableBackupBean() {
+      return this.timetableBackupBean;
+    }
+
     public MockSnapshotBackupProcess getSnapBackup(FileTxnSnapLog snapLog, boolean errorFree) {
       return new MockSnapshotBackupProcess(snapLog, errorFree, backupBean);
     }
@@ -233,8 +278,8 @@ public class BackupBeanTest extends ZKTestCase {
     }
 
     private class MockSnapshotBackupProcess extends BackupManager.SnapBackup {
-      private boolean expectedErrorFree;
-      private BackupBean backupBean;
+      private final boolean expectedErrorFree;
+      private final BackupBean backupBean;
 
       public MockSnapshotBackupProcess(FileTxnSnapLog snapLog, boolean expectedErrorFree,
           BackupBean backupBean) {
@@ -251,8 +296,8 @@ public class BackupBeanTest extends ZKTestCase {
     }
 
     private class MockTxnLogBackupProcess extends BackupManager.TxnLogBackup {
-      private boolean expectedErrorFree;
-      private BackupBean backupBean;
+      private final boolean expectedErrorFree;
+      private final BackupBean backupBean;
 
       public MockTxnLogBackupProcess(FileTxnSnapLog snapLog, boolean expectedErrorFree,
           BackupBean backupBean) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/BackupBeanTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/BackupBeanTest.java
@@ -154,7 +154,7 @@ public class BackupBeanTest extends ZKTestCase {
     BackupManager bm = new BackupManager(dataDir, dataDir, serverId, backupConfig);
     String expectedMBeanName = "Backup_" + TEST_NAMESPACE + ".server" + serverId;
     String expectedTimetableMBeanName =
-        TimetableBackupBean.TIMETABLE_BACKUP_MBEAN_PREFIX + serverId;
+        TimetableBackupBean.TIMETABLE_BACKUP_MBEAN_NAME;
     Set<ZKMBeanInfo> mbeans = MBeanRegistry.getInstance().getRegisteredBeans();
     Assert.assertTrue(containsMBean(mbeans, expectedMBeanName, false));
     Assert.assertTrue(containsMBean(mbeans, expectedTimetableMBeanName, false));

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/BackupManagerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/BackupManagerTest.java
@@ -88,6 +88,7 @@ public class BackupManagerTest extends ZKTestCase implements Watcher {
    */
   private static final long TIMETABLE_BACKUP_INTERVAL_IN_MS = 100L;
   private File timetableBackupDir;
+  private BackupConfig.Builder backupConfigBuilder;
 
   @Before
   public void setup() throws Exception {
@@ -100,7 +101,7 @@ public class BackupManagerTest extends ZKTestCase implements Watcher {
     timetableBackupDir = ClientBase.createTmpDir();
 
     // Create a dummy config
-    BackupConfig.Builder backupConfigBuilder = new BackupConfig.Builder();
+    backupConfigBuilder = new BackupConfig.Builder();
     backupConfig = backupConfigBuilder.
         setEnabled(true).
         setStatusDir(backupStatusDir).

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/BackupManagerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/BackupManagerTest.java
@@ -88,7 +88,6 @@ public class BackupManagerTest extends ZKTestCase implements Watcher {
    */
   private static final long TIMETABLE_BACKUP_INTERVAL_IN_MS = 100L;
   private File timetableBackupDir;
-  private BackupConfig.Builder backupConfigBuilder;
 
   @Before
   public void setup() throws Exception {
@@ -101,7 +100,7 @@ public class BackupManagerTest extends ZKTestCase implements Watcher {
     timetableBackupDir = ClientBase.createTmpDir();
 
     // Create a dummy config
-    backupConfigBuilder = new BackupConfig.Builder();
+    BackupConfig.Builder backupConfigBuilder = new BackupConfig.Builder();
     backupConfig = backupConfigBuilder.
         setEnabled(true).
         setStatusDir(backupStatusDir).


### PR DESCRIPTION
Timetable backup is supported as part of ZooRestore in order to enable users to restore to a point in time using a timestamp value. Since the timetable backup process is similar to snapshot and transaction log backups, we need metrics to monitor whether the backup of timetable metadata is working correctly. This commit adds the necessary metrics.

`test3_TimetableBackupMBean` has been added to the existing `BackupBeanTest` class.

`$ mvn test -Dtest=BackupBeanTest,BackupManagerTest,TimetableUtilTest,RestorationToolTest`

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.zookeeper.test.BackupManagerTest
[INFO] Running org.apache.zookeeper.server.backup.timetable.TimetableUtilTest
[INFO] Running org.apache.zookeeper.server.backup.BackupBeanTest
[INFO] Running org.apache.zookeeper.server.backup.RestorationToolTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.088 s - in org.apache.zookeeper.server.backup.timetable.TimetableUtilTest
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 18.562 s - in org.apache.zookeeper.test.BackupManagerTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 22.681 s - in org.apache.zookeeper.server.backup.RestorationToolTest


[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 123.949 s - in org.apache.zookeeper.server.backup.BackupBeanTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:14 min
[INFO] Finished at: 2021-03-25T10:48:32-07:00
[INFO] ------------------------------------------------------------------------
```