### PR TITLE
Change naming for BackupBean

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
@@ -573,7 +573,7 @@ public class BackupManager {
   public synchronized void initialize() throws IOException {
     try {
       backupStats = new BackupStats();
-      backupBean = new BackupBean(backupStats, namespace, serverId);
+      backupBean = new BackupBean(backupStats, serverId);
       MBeanRegistry.getInstance().register(backupBean, null);
       LOG.info("Registered Backup bean {} with JMX.", backupBean.getName());
     } catch (JMException e) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupBean.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/monitoring/BackupBean.java
@@ -26,17 +26,12 @@ import org.slf4j.LoggerFactory;
  * This class implements ZK backup MBean
  */
 public class BackupBean implements ZKMBeanInfo, BackupMXBean {
-  private static final Logger LOG = LoggerFactory.getLogger(BackupBean.class);
-
   private final BackupStats backupStats;
   private final String name;
 
-  public BackupBean(BackupStats backupStats, String namespace, long serverId) {
+  public BackupBean(BackupStats backupStats, long serverId) {
     this.backupStats = backupStats;
-    if (namespace == null || namespace.isEmpty()) {
-      namespace = "UNKNOWN";
-    }
-    name = "Backup_" + namespace + ".server" + serverId;
+    this.name = "Backup_id" + serverId;
   }
 
   @Override

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/BackupBeanTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/BackupBeanTest.java
@@ -152,7 +152,7 @@ public class BackupBeanTest extends ZKTestCase {
     // Register MBean when initializing backup manager
     long serverId = 0L;
     BackupManager bm = new BackupManager(dataDir, dataDir, serverId, backupConfig);
-    String expectedMBeanName = "Backup_" + TEST_NAMESPACE + ".server" + serverId;
+    String expectedMBeanName = "Backup_id" + serverId;
     String expectedTimetableMBeanName =
         TimetableBackupBean.TIMETABLE_BACKUP_MBEAN_NAME;
     Set<ZKMBeanInfo> mbeans = MBeanRegistry.getInstance().getRegisteredBeans();


### PR DESCRIPTION
Namespace is not necessary in the backup bean's name because each application will have a host-level isolation when backup is enabled; in other words, we shouldn't see logically isolated hosts serving backup for multiple apps/namespaces/ZK quorums.  Therefore, it is possible to do a hostname-based lookup to identify which app (namespace) an emitted metric stands for. So this commit removes the namespace string from the metric name.

```
$ mvn test -Dtest=BackupBeanTest,BackupManagerTest,TimetableUtilTest,RestorationToolTest

[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.zookeeper.test.BackupManagerTest
[INFO] Running org.apache.zookeeper.server.backup.BackupBeanTest
[INFO] Running org.apache.zookeeper.server.backup.timetable.TimetableUtilTest
[INFO] Running org.apache.zookeeper.server.backup.RestorationToolTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.11 s - in org.apache.zookeeper.server.backup.timetable.TimetableUtilTest
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 18.735 s - in org.apache.zookeeper.test.BackupManagerTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 22.72 s - in org.apache.zookeeper.server.backup.RestorationToolTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 123.919 s - in org.apache.zookeeper.server.backup.BackupBeanTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:14 min
[INFO] Finished at: 2021-03-25T15:21:27-07:00
[INFO] ------------------------------------------------------------------------
```