### PR TITLE
Set max page size less than jute maxbuffer

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -940,7 +940,7 @@ public class DataTree {
     }
 
     private boolean canPacketFitInMaxBuffer(int packetLength) {
-        return packetLength <= BinaryInputArchive.maxBuffer;
+        return packetLength < BinaryInputArchive.maxBuffer;
     }
 
     private int countReadChildrenBytes(Collection<String> children) {


### PR DESCRIPTION
### Description
The native zk jute check is
`if (size >= maxbuffer) throw exception();`
It means even the `packet == maxbuffer`, it still fails.
So to make pagination size accurate, we need to make a small change to make the max page size **LESS THAN** maxbuffer.  Currently it is `maxPage <= maxbuffer`.