### PR TITLE
Logging improvements on restoration tool

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/RestoreCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/RestoreCommand.java
@@ -75,6 +75,7 @@ public class RestoreCommand extends CliCommand {
     public static final String TIMETABLE_STORAGE_PATH = "m";
     public static final String LOCAL_RESTORE_TEMP_DIR_PATH = "r";
     public static final String DRY_RUN = "n";
+    public static final String HELP = "h";
 
     // Create a private constructor so it can't be instantiated
     private OptionShortForm() {
@@ -166,6 +167,10 @@ public class RestoreCommand extends CliCommand {
 
   @Override
   public boolean exec() throws CliException {
+    if (cl.hasOption(OptionShortForm.HELP)) {
+      System.out.println(getUsageStr());
+      return true;
+    }
     return tool.runWithRetries(cl);
   }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/timetable/TimetableUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/timetable/TimetableUtil.java
@@ -44,9 +44,10 @@ public final class TimetableUtil {
    * entering an arbitrarily high timestamp value and the tool restoring to the latest backup point.
    * @param timetableBackupFiles
    * @param timestamp timestamp string (long), or "latest"
-   * @return Hex String representation of the zxid found
+   * @return A map entry consists of timestamp in Long and Hex String representation of the zxid found
    */
-  public static String findLastZxidFromTimestamp(File[] timetableBackupFiles, String timestamp) {
+  public static Map.Entry<Long, String> findLastZxidFromTimestamp(File[] timetableBackupFiles,
+      String timestamp) {
     // Verify argument: backup files
     if (timetableBackupFiles == null || timetableBackupFiles.length == 0) {
       throw new IllegalArgumentException(
@@ -96,8 +97,9 @@ public final class TimetableUtil {
     // Check if the given timestamp is in range
     if (!isLatest && (timestampLong < lowerBound || timestampLong > upperBound)) {
       throw new IllegalArgumentException(
-          "TimetableUtil::findLastZxidFromTimestamp(): timestamp given is not in the timestamp "
-              + "range given in the backup files!");
+          "TimetableUtil::findLastZxidFromTimestamp(): timestamp given " + timestampLong
+              + " is not in the timestamp range [" + lowerBound + " , " + upperBound
+              + "] given in the backup files!");
     }
 
     // Check if a file is found (this shouldn't happen if timestamp is in range)
@@ -124,6 +126,6 @@ public final class TimetableUtil {
     if (floorEntry == null) {
       throw new BackupException("TimetableUtil::findLastZxidFromTimestamp(): floorEntry is null!");
     }
-    return floorEntry.getValue();
+    return floorEntry;
   }
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/timetable/TimetableUtilTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/timetable/TimetableUtilTest.java
@@ -56,42 +56,42 @@ public class TimetableUtilTest {
   @Test
   public void testFindLastZxidFromTimestamp() {
     String result =
-        TimetableUtil.findLastZxidFromTimestamp(TIMETABLE_BACKUP_FILES, Long.toString(25L));
+        TimetableUtil.findLastZxidFromTimestamp(TIMETABLE_BACKUP_FILES, Long.toString(25L)).getValue();
     Assert.assertEquals(Long.toHexString(20), result);
 
-    result = TimetableUtil.findLastZxidFromTimestamp(TIMETABLE_BACKUP_FILES, Long.toString(35L));
+    result = TimetableUtil.findLastZxidFromTimestamp(TIMETABLE_BACKUP_FILES, Long.toString(35L)).getValue();
     Assert.assertEquals(Long.toHexString(30), result);
 
-    result = TimetableUtil.findLastZxidFromTimestamp(TIMETABLE_BACKUP_FILES, Long.toString(50L));
+    result = TimetableUtil.findLastZxidFromTimestamp(TIMETABLE_BACKUP_FILES, Long.toString(50L)).getValue();
     Assert.assertEquals(Long.toHexString(50), result);
 
-    result = TimetableUtil.findLastZxidFromTimestamp(TIMETABLE_BACKUP_FILES, Long.toString(10L));
+    result = TimetableUtil.findLastZxidFromTimestamp(TIMETABLE_BACKUP_FILES, Long.toString(10L)).getValue();
     Assert.assertEquals(Long.toHexString(10), result);
 
-    result = TimetableUtil.findLastZxidFromTimestamp(TIMETABLE_BACKUP_FILES, Long.toString(41L));
+    result = TimetableUtil.findLastZxidFromTimestamp(TIMETABLE_BACKUP_FILES, Long.toString(41L)).getValue();
     Assert.assertEquals(Long.toHexString(40), result);
   }
 
   @Test
   public void testFindLatestZxidFromTimestamp() {
-    String result = TimetableUtil.findLastZxidFromTimestamp(TIMETABLE_BACKUP_FILES, "latest");
+    String result = TimetableUtil.findLastZxidFromTimestamp(TIMETABLE_BACKUP_FILES, "latest").getValue();
     Assert.assertEquals(Long.toHexString(50), result);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testTimestampOutsideWindowLow() {
-    String result = TimetableUtil.findLastZxidFromTimestamp(TIMETABLE_BACKUP_FILES, Long.toString(5));
+    String result = TimetableUtil.findLastZxidFromTimestamp(TIMETABLE_BACKUP_FILES, Long.toString(5)).getValue();
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testTimestampOutsideWindowHigh() {
     String result =
-        TimetableUtil.findLastZxidFromTimestamp(TIMETABLE_BACKUP_FILES, Long.toString(55));
+        TimetableUtil.findLastZxidFromTimestamp(TIMETABLE_BACKUP_FILES, Long.toString(55)).getValue();
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testEmptyFiles() {
-    String result = TimetableUtil.findLastZxidFromTimestamp(null, Long.toString(25));
+    String result = TimetableUtil.findLastZxidFromTimestamp(null, Long.toString(25)).getValue();
   }
 
   private static void createTimetableBackupFile(long timestamp, long zxid, int fileNum)


### PR DESCRIPTION
This commit includes several improvements on loggings for the zk restoration tool to enhance the restoration user experience.
1. Add an option -h to CLI that displays all command options and descriptions
2. Differentiate between insufficient backup files and IO errors, only retry for IO errors
3. Clearly display which timestamp we actually restore to. The message looks like "Restoring to 04/13/2021 14:29:09, original request was to restore to 04/13/2021 14:29:09".
4. Improve log message when given timestamp is out of range. The new error message looks like "TimetableUtil::findLastZxidFromTimestamp(): timestamp given 55 is not in the timestamp range [10 ,50] given in the backup files!"

Tests:
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.zookeeper.test.BackupManagerTest
[INFO] Running org.apache.zookeeper.server.backup.RestorationToolTest
[INFO] Running org.apache.zookeeper.server.backup.timetable.TimetableUtilTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.091 s - in org.apache.zookeeper.server.backup.timetable.TimetableUtilTest
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 18.752 s - in org.apache.zookeeper.test.BackupManagerTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 38.834 s - in org.apache.zookeeper.server.backup.RestorationToolTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------