### PR TITLE
Add "-f" overwrite option to restoration tool

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/RestoreCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/RestoreCommand.java
@@ -19,6 +19,8 @@
 
 package org.apache.zookeeper.cli;
 
+import java.util.Scanner;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
@@ -41,7 +43,8 @@ public class RestoreCommand extends CliCommand {
           + OptionFullCommand.BACKUP_STORE + "] [" + OptionFullCommand.SNAP_DESTINATION + "] ["
           + OptionFullCommand.LOG_DESTINATION + "] [" + OptionFullCommand.TIMETABLE_STORAGE_PATH
           + "](needed if restore to a timestamp) [" + OptionFullCommand.LOCAL_RESTORE_TEMP_DIR_PATH
-          + "](optional) [" + OptionFullCommand.DRY_RUN + "](optional)";
+          + "](optional) [" + OptionFullCommand.DRY_RUN + "](optional) ["
+          + OptionFullCommand.OVERWRITE + "](optional)";
 
   public final class OptionLongForm {
     /* Required if no restore timestamp is specified */
@@ -60,6 +63,8 @@ public class RestoreCommand extends CliCommand {
     public static final String LOCAL_RESTORE_TEMP_DIR_PATH = "local_restore_temp_dir_path";
     /* Optional. Default value false */
     public static final String DRY_RUN = "dry_run";
+    /* Optional. Default value false */
+    public static final String OVERWRITE = "overwrite";
 
     // Create a private constructor so it can't be instantiated
     private OptionLongForm() {
@@ -76,6 +81,7 @@ public class RestoreCommand extends CliCommand {
     public static final String LOCAL_RESTORE_TEMP_DIR_PATH = "r";
     public static final String DRY_RUN = "n";
     public static final String HELP = "h";
+    public static final String OVERWRITE = "overwrite";
 
     // Create a private constructor so it can't be instantiated
     private OptionShortForm() {
@@ -99,6 +105,7 @@ public class RestoreCommand extends CliCommand {
         "-" + OptionShortForm.LOCAL_RESTORE_TEMP_DIR_PATH + " "
             + OptionLongForm.LOCAL_RESTORE_TEMP_DIR_PATH;
     public static final String DRY_RUN = "-" + OptionShortForm.DRY_RUN;
+    public static final String OVERWRITE = "-" + OptionShortForm.OVERWRITE;
 
     // Create a private constructor so it can't be instantiated
     private OptionFullCommand() {
@@ -119,6 +126,7 @@ public class RestoreCommand extends CliCommand {
     options.addOption(new Option(OptionShortForm.LOCAL_RESTORE_TEMP_DIR_PATH, true,
         OptionLongForm.LOCAL_RESTORE_TEMP_DIR_PATH));
     options.addOption(new Option(OptionShortForm.DRY_RUN, false, OptionLongForm.DRY_RUN));
+    options.addOption(new Option(OptionShortForm.OVERWRITE, false, OptionLongForm.OVERWRITE));
   }
 
   public RestoreCommand() {
@@ -145,7 +153,9 @@ public class RestoreCommand extends CliCommand {
         + OptionFullCommand.LOCAL_RESTORE_TEMP_DIR_PATH
         + ": Optional, local path for creating a temporary intermediate directory for restoration, the directory will be deleted after restoration is done\n    "
         + OptionFullCommand.DRY_RUN + " " + OptionLongForm.DRY_RUN
-        + ": Optional, no files will be actually copied in a dry run";
+        + ": Optional, no files will be actually copied in a dry run\n    " + OptionFullCommand.OVERWRITE
+        + " " + OptionLongForm.OVERWRITE
+        + ": Optional, default false. If set to true, the destination directories will be overwritten if exist";
   }
 
   @Override
@@ -170,6 +180,26 @@ public class RestoreCommand extends CliCommand {
     if (cl.hasOption(OptionShortForm.HELP)) {
       System.out.println(getUsageStr());
       return true;
+    }
+    if (cl.hasOption(OptionShortForm.OVERWRITE)) {
+      Scanner scanner = new Scanner(System.in);
+      boolean repeat = true;
+      while (repeat) {
+        System.out.println(
+            "Are you sure you want to overwrite the destination directories? Please enter \"yes/no\".");
+        String input = scanner.nextLine().toLowerCase();
+        switch (input) {
+          case "yes":
+            repeat = false;
+            break;
+          case "no":
+            System.out.println(
+                "Exiting restoration. Please remove the \"overwrite\" option from the command, and try again.");
+            return true;
+          default:
+            break;
+        }
+      }
     }
     return tool.runWithRetries(cl);
   }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/RestoreCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/RestoreCommand.java
@@ -194,8 +194,8 @@ public class RestoreCommand extends CliCommand {
             break;
           case "no":
             out.println(
-                "Exiting restoration. Please remove the \"overwrite\" option from the command, and try again.");
-            return true;
+                "Exiting restoration. Please remove the \"-f\" (overwrite) option from the command, and try again.");
+            return false;
           default:
             out.println("Could not recognize the input: " + input + ". Please try again.");
             break;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/RestoreCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/RestoreCommand.java
@@ -81,7 +81,7 @@ public class RestoreCommand extends CliCommand {
     public static final String LOCAL_RESTORE_TEMP_DIR_PATH = "r";
     public static final String DRY_RUN = "n";
     public static final String HELP = "h";
-    public static final String OVERWRITE = "overwrite";
+    public static final String OVERWRITE = "f";
 
     // Create a private constructor so it can't be instantiated
     private OptionShortForm() {
@@ -153,9 +153,9 @@ public class RestoreCommand extends CliCommand {
         + OptionFullCommand.LOCAL_RESTORE_TEMP_DIR_PATH
         + ": Optional, local path for creating a temporary intermediate directory for restoration, the directory will be deleted after restoration is done\n    "
         + OptionFullCommand.DRY_RUN + " " + OptionLongForm.DRY_RUN
-        + ": Optional, no files will be actually copied in a dry run\n    " + OptionFullCommand.OVERWRITE
-        + " " + OptionLongForm.OVERWRITE
-        + ": Optional, default false. If set to true, the destination directories will be overwritten if exist";
+        + ": Optional, no files will be actually copied in a dry run\n    "
+        + OptionFullCommand.OVERWRITE + " " + OptionLongForm.OVERWRITE
+        + ": Optional, default false. If true, the destination directories will be overwritten\n";
   }
 
   @Override
@@ -178,14 +178,14 @@ public class RestoreCommand extends CliCommand {
   @Override
   public boolean exec() throws CliException {
     if (cl.hasOption(OptionShortForm.HELP)) {
-      System.out.println(getUsageStr());
+      out.println(getUsageStr());
       return true;
     }
     if (cl.hasOption(OptionShortForm.OVERWRITE)) {
       Scanner scanner = new Scanner(System.in);
       boolean repeat = true;
       while (repeat) {
-        System.out.println(
+        out.println(
             "Are you sure you want to overwrite the destination directories? Please enter \"yes/no\".");
         String input = scanner.nextLine().toLowerCase();
         switch (input) {
@@ -193,10 +193,11 @@ public class RestoreCommand extends CliCommand {
             repeat = false;
             break;
           case "no":
-            System.out.println(
+            out.println(
                 "Exiting restoration. Please remove the \"overwrite\" option from the command, and try again.");
             return true;
           default:
+            out.println("Could not recognize the input: " + input + ". Please try again.");
             break;
         }
       }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/RestoreFromBackupTool.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/RestoreFromBackupTool.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -299,13 +298,14 @@ public class RestoreFromBackupTool {
         return true;
       } catch (IllegalArgumentException re) {
         System.err.println(
-            "Restore attempt failed due to insufficient backup files. Error message: "
-                + re.getMessage());
+            "Restore attempt failed, could not find all the required backup files to restore. "
+                + "Error message: " + re.getMessage());
         return false;
       } catch (BackupException be) {
         System.err.println(
-            "Restoration attempt failed due to a backup exception, please check the environment and try again. Error message: "
-                + be.getMessage());
+            "Restoration attempt failed due to a backup exception, it's usually caused by required"
+                + "directories not exist or failure of creating directories, etc. Please check the message. "
+                + "Error message: " + be.getMessage());
         return false;
       } catch (Exception e) {
         tries++;
@@ -352,10 +352,13 @@ public class RestoreFromBackupTool {
                   + dataDir.getPath() + " are: " + Arrays.toString(dataDirFiles)
                   + "; and files under snapDir: " + snapDir.getPath() + " are: " + Arrays
                   .toString(snapDirFiles) + ".");
+          Arrays.stream(Objects.requireNonNull(dataDir.listFiles())).forEach(File::delete);
+          Arrays.stream(Objects.requireNonNull(snapDir.listFiles())).forEach(File::delete);
         } else {
           throw new BackupException(
-              "The destination directories are not empty, user chose not to overwrite existing files, exiting restoration. Please check the destination directory dataDir path: "
-                  + dataDir.getPath() + ", and snapDir path" + snapDir.getPath());
+              "The destination directories are not empty, user chose not to overwrite existing files, exiting restoration. "
+                  + "Please check the destination directory dataDir path: " + dataDir.getPath()
+                  + ", and snapDir path" + snapDir.getPath());
         }
       }
 
@@ -612,8 +615,7 @@ public class RestoreFromBackupTool {
       LOG.info(
           "Copying " + processedFile.getPath() + " from temp dir to final destination directory "
               + finalDestinationBase.getPath() + ".");
-      Files.copy(processedFile.toPath(), new File(finalDestinationBase, fileName).toPath(),
-          StandardCopyOption.REPLACE_EXISTING);
+      Files.copy(processedFile.toPath(), new File(finalDestinationBase, fileName).toPath());
     }
   }
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/RestorationToolTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/RestorationToolTest.java
@@ -334,6 +334,13 @@ public class RestorationToolTest extends ZKTestCase {
     validateRestoreCoverage(restoreZxid);
 
     //Restore to latest
+    //Use an empty directory as restoration destination; otherwise, the restoration will fail
+    restoreDir = ClientBase.createTmpDir();
+    restoreSnapLog = new FileTxnSnapLog(restoreDir, restoreDir);
+    when(cl.getOptionValue(RestoreCommand.OptionShortForm.SNAP_DESTINATION))
+        .thenReturn(restoreDir.getPath());
+    when(cl.getOptionValue(RestoreCommand.OptionShortForm.LOG_DESTINATION))
+        .thenReturn(restoreDir.getPath());
     when(cl.getOptionValue(RestoreCommand.OptionShortForm.RESTORE_ZXID))
         .thenReturn(BackupUtil.LATEST);
     Assert.assertTrue(restoreTool.runWithRetries(cl));
@@ -365,6 +372,13 @@ public class RestorationToolTest extends ZKTestCase {
     Assert.assertTrue(restoreTool.runWithRetries(cl));
 
     //Restore to latest using timestamp
+    //Use an empty directory as restoration destination; otherwise, the restoration will fail
+    restoreDir = ClientBase.createTmpDir();
+    restoreSnapLog = new FileTxnSnapLog(restoreDir, restoreDir);
+    when(cl.getOptionValue(RestoreCommand.OptionShortForm.SNAP_DESTINATION))
+        .thenReturn(restoreDir.getPath());
+    when(cl.getOptionValue(RestoreCommand.OptionShortForm.LOG_DESTINATION))
+        .thenReturn(restoreDir.getPath());
     when(cl.getOptionValue(RestoreCommand.OptionShortForm.RESTORE_TIMESTAMP))
         .thenReturn(BackupUtil.LATEST);
     Assert.assertTrue(restoreTool.runWithRetries(cl));


### PR DESCRIPTION
This commit adds a check on wether the restoration destination directories specified by the user are empty or not, and adds a "-f" overwrite option to zk CLI "restore" command to enable restoration to be done while they are not empty.
A. If the destination directories are empty -> restoration will be run.
B. If the destination directories are not empty
    (a) If "-f" option is specified -> Prompt to user to confirm if they want to overwrite the directories by typing "yes" or "no"
          (1) User types "yes" -> restoration will be run. Destination directories are cleared out and restored files will be written to the directories. A list of file names of files existing inside the destination directories before restoration will be logged for reference.
          (2) User types "no" -> exit the program, restoration will not be run
          (3) User types responses other than "yes" or "no" -> Keep prompting to user asking for confirmation
    (b) If "-f" option is not specified -> exit the program, restoration will not be run

Tests:
1. Manually ran the CLI and tested all the above mentioned scenarios 
2. 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.zookeeper.server.backup.RestorationToolTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 31.801 s - in org.apache.zookeeper.server.backup.RestorationToolTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  45.748 s
[INFO] Finished at: 2021-04-16T15:12:55-07:00
[INFO] ------------------------------------------------------------------------