### PR TITLE
ZOOKEEPER-4281: Allow packet of max packet length to be deserialized

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocket.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ClientCnxnSocket.java
@@ -117,7 +117,7 @@ abstract class ClientCnxnSocket {
 
     void readLength() throws IOException {
         int len = incomingBuffer.getInt();
-        if (len < 0 || len >= packetLen) {
+        if (len < 0 || len > packetLen) {
             throw new IOException("Packet len " + len + " is out of range!");
         }
         incomingBuffer = ByteBuffer.allocate(len);


### PR DESCRIPTION
### Problem
Resolves https://issues.apache.org/jira/browse/ZOOKEEPER-4281
Cherry pick the fix: https://github.com/apache/zookeeper/commit/1590a424cb7a8768b0ae01f2957856b1834dd68d 

There are sanity checks for packet size when deserializing a packet. One place has the inclusion: len >= packetLen.  It rejects to deserialize the bytes that are exactly sized jute.maxbuffer. It's confusing. This check should use ">" so the maxbuffer length packet can still be deserialized, like the other checks.
```
if (len < 0 || len >= packetLen) {
    throw new IOException("Packet len " + len + " is out of range!");
}
```
### Solution
Change: `len >= packetLen`   ->  `len > packetLen`
```
if (len < 0 || len > packetLen) {
```

