### PR TITLE
Make ZooSave & ZooRestore compatible with snapshot compression

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupFileInfo.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupFileInfo.java
@@ -82,7 +82,7 @@ public class BackupFileInfo {
         }
         String zxidPartWithoutEnd = nameParts[1].split("-")[0];
         // Combine all parts to generate a backup name
-        standardFileName = nameParts[0] + zxidPartWithoutEnd + nameParts[2];
+        standardFileName = nameParts[0] + "." + zxidPartWithoutEnd + "." + nameParts[2];
       }
       this.standardFile = new File(this.backupFile.getParentFile(), standardFileName);
     } else if (backedupFilename.startsWith(Util.TXLOG_PREFIX)) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupFileInfo.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupFileInfo.java
@@ -37,13 +37,15 @@ import org.apache.zookeeper.server.persistence.Util;
  * In the case of timetable backup file, it takes a format of timetable.lowTimestamp-highTimestamp.
  */
 public class BackupFileInfo {
+  public static final long NOT_SET = -1L;
+  private static final String DASH_DELIMITER = "-";
+
   private final File backupFile;
   private final File standardFile;
   private final Range<Long> range;
   private final BackupFileType fileType;
   private final long modificationTime;
   private final long size;
-  public static final long NOT_SET = -1;
 
   /**
    * Constructor that pulls backup metadata based on the backed-up filename
@@ -70,7 +72,7 @@ public class BackupFileInfo {
       String standardFileName;
       if (streamMode.isEmpty()) {
         // No compression was used, so simply drop the end part
-        standardFileName = backedupFilename.split("-")[0];
+        standardFileName = backedupFilename.split(DASH_DELIMITER)[0];
       } else {
         // Snapshot compression is enabled; standardName looks like "snapshot.<zxid>.<streamMode>"
         // Need to remove the ending zxid
@@ -80,14 +82,15 @@ public class BackupFileInfo {
               "BackupFileInfo: unable to create standardFile reference! backedupFilename: "
                   + backedupFilename + " StreamMode: " + streamMode);
         }
-        String zxidPartWithoutEnd = nameParts[1].split("-")[0];
+        String zxidPartWithoutEnd = nameParts[1].split(DASH_DELIMITER)[0];
         // Combine all parts to generate a backup name
         standardFileName = nameParts[0] + "." + zxidPartWithoutEnd + "." + nameParts[2];
       }
       this.standardFile = new File(this.backupFile.getParentFile(), standardFileName);
     } else if (backedupFilename.startsWith(Util.TXLOG_PREFIX)) {
       this.fileType = BackupFileType.TXNLOG;
-      this.standardFile = new File(this.backupFile.getParentFile(), backedupFilename.split("-")[0]);
+      this.standardFile =
+          new File(this.backupFile.getParentFile(), backedupFilename.split(DASH_DELIMITER)[0]);
     } else if (backedupFilename.startsWith(TimetableBackup.TIMETABLE_PREFIX)) {
       this.fileType = BackupFileType.TIMETABLE;
       this.standardFile = this.backupFile;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupUtil.java
@@ -153,8 +153,8 @@ public class BackupUtil {
   /**
    * Creates a file name string for a backup file by appending a high zxid/long in Hex if it
    * doesn't already contain an ending zxid.
-   * It also adds the snapshot extension in case snapshot compression is enabled.
-   * E.g.) snapshot.123.snappy -> snapshot.123-456.snappy
+   * It also adds the snapshot filename StreamMode extension in case snapshot compression is
+   * enabled. E.g.) snapshot.123.snappy -> snapshot.123-456.snappy
    * @param standardName
    * @param highZxid
    * @return

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupUtil.java
@@ -164,25 +164,24 @@ public class BackupUtil {
       // standard name already contains the zxid interval endpoint and if snapshot compression
       // is enabled, the standardName should already contain StreamMode extension, so just return
       return standardName;
+    }
+    if (SnapStream.getStreamMode(standardName).getName().isEmpty()) {
+      // No snapshot compression is used for this snapshot, so just append the zxid interval
+      // endpoint
+      return String.format("%s-%x", standardName, highZxid);
     } else {
-      if (SnapStream.getStreamMode(standardName).getName().isEmpty()) {
-        // No snapshot compression is used for this snapshot, so just append the zxid interval
-        // endpoint
-        return String.format("%s-%x", standardName, highZxid);
-      } else {
-        // Snapshot compression is enabled; standardName looks like "snapshot.<zxid>.<streamMode>"
-        // Need to append the ending zxid
-        String[] nameParts = standardName.split("\\.");
-        if (nameParts.length != 3) {
-          throw new BackupException(
-              "BackupUtil::makeBackupName(): unable to make backup name! standardName: "
-                  + standardName + " StreamMode: " + SnapStream.getStreamMode(standardName)
-                  .getName());
-        }
-        String zxidPart = String.format("%s-%x", nameParts[1], highZxid);
-        // Combine all parts to generate a backup name
-        return nameParts[0] + "." + zxidPart + "." + nameParts[2];
+      // Snapshot compression is enabled; standardName looks like "snapshot.<zxid>.<streamMode>"
+      // Need to append the ending zxid
+      String[] nameParts = standardName.split("\\.");
+      if (nameParts.length != 3) {
+        throw new BackupException(
+            "BackupUtil::makeBackupName(): unable to make backup name! standardName: "
+                + standardName + " StreamMode: " + SnapStream.getStreamMode(standardName)
+                .getName());
       }
+      String zxidPart = String.format("%s-%x", nameParts[1], highZxid);
+      // Combine all parts to generate a backup name
+      return nameParts[0] + "." + zxidPart + "." + nameParts[2];
     }
   }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupUtil.java
@@ -29,8 +29,10 @@ import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 
+import org.apache.zookeeper.server.backup.exception.BackupException;
 import org.apache.zookeeper.server.backup.storage.BackupStorageProvider;
 import org.apache.zookeeper.server.backup.timetable.TimetableBackup;
+import org.apache.zookeeper.server.persistence.SnapStream;
 import org.apache.zookeeper.server.persistence.Util;
 
 /**
@@ -151,14 +153,37 @@ public class BackupUtil {
   /**
    * Creates a file name string for a backup file by appending a high zxid/long in Hex if it
    * doesn't already contain an ending zxid.
+   * It also adds the snapshot extension in case snapshot compression is enabled.
+   * E.g.) snapshot.123.snappy -> snapshot.123-456.snappy
    * @param standardName
    * @param highZxid
    * @return
    */
   public static String makeBackupName(String standardName, long highZxid) {
-    return standardName.indexOf('-') >= 0
-        ? standardName
-        : String.format("%s-%x", standardName, highZxid);
+    if (standardName.indexOf('-') >= 0) {
+      // standard name already contains the zxid interval endpoint and if snapshot compression
+      // is enabled, the standardName should already contain StreamMode extension, so just return
+      return standardName;
+    } else {
+      if (SnapStream.getStreamMode(standardName).getName().isEmpty()) {
+        // No snapshot compression is used for this snapshot, so just append the zxid interval
+        // endpoint
+        return String.format("%s-%x", standardName, highZxid);
+      } else {
+        // Snapshot compression is enabled; standardName looks like "snapshot.<zxid>.<streamMode>"
+        // Need to append the ending zxid
+        String[] nameParts = standardName.split("\\.");
+        if (nameParts.length != 3) {
+          throw new BackupException(
+              "BackupUtil::makeBackupName(): unable to make backup name! standardName: "
+                  + standardName + " StreamMode: " + SnapStream.getStreamMode(standardName)
+                  .getName());
+        }
+        String zxidPart = String.format("%s-%x", nameParts[1], highZxid);
+        // Combine all parts to generate a backup name
+        return nameParts[0] + zxidPart + nameParts[2];
+      }
+    }
   }
 
   /**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupUtil.java
@@ -181,7 +181,7 @@ public class BackupUtil {
         }
         String zxidPart = String.format("%s-%x", nameParts[1], highZxid);
         // Combine all parts to generate a backup name
-        return nameParts[0] + zxidPart + nameParts[2];
+        return nameParts[0] + "." + zxidPart + "." + nameParts[2];
       }
     }
   }


### PR DESCRIPTION
ZooSave & ZooRestore, a new feature that enables server-side ZooKeeper snapshot backup, has its own naming scheme for naming backup files (mostly adding an ending ZXID interval). However, this naming scheme was not compatible with the newly-introduced feature to the upstream ZooKeeper main branch for snapshot compression. This is because snapshot compression appends a StreamMode extension if it is enabled.

This commit modifies the backup naming logic so that it considers the case where snapshot compression is enabled and thus the snapshot files on the server have a StreamMode extension. It also updates the BackupFileInfo initialization logic so that when the backed up snapshots are read back in, their standard names are populated correctly.

A test is added in BackupManagerTest: testBackupFileNamingOnStreamingMode().

```
% mvn test -Dtest=BackupManagerTest,FileSystemBackupStorageTest
...
[INFO] Running org.apache.zookeeper.server.backup.storage.impl.FileSystemBackupStorageTest
[INFO] Running org.apache.zookeeper.test.BackupManagerTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.136 s - in org.apache.zookeeper.server.backup.storage.impl.FileSystemBackupStorageTest
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 19.44 s - in org.apache.zookeeper.test.BackupManagerTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  28.802 s
[INFO] Finished at: 2021-05-16T10:20:07-07:00
[INFO] ------------------------------------------------------------------------
```