### PR TITLE
Add Spot Restoration Tool

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/SpotRestorationTool.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/SpotRestorationTool.java
@@ -23,7 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This is a tool for automatic restoration of ZK data based on a zk node path using a collection of
+ * This is a tool for automatic zk path-based restoration of ZK data based on a zk node path using a collection of
  * snapshot and transaction logs.
  */
 public class SpotRestorationTool {
@@ -76,19 +76,21 @@ public class SpotRestorationTool {
       // Do nothing since we are trying to build a data tree in memory, not in actual zk server
     });
 
-    DataNode originalNode = dataTree.getNode(targetZNodePath);
-    if (originalNode == null) {
+    DataNode restoredTargetNode = dataTree.getNode(targetZNodePath);
+    if (restoredTargetNode == null) {
+      LOG.info(
+          "The target znode path does not exist in the restored zk data tree. Exit spot restoration.");
       return;
     }
-    Stat originalNodeStat = new Stat();
-    originalNode.copyStat(originalNodeStat);
+    Stat restoredTargetNodeStat = new Stat();
+    restoredTargetNode.copyStat(restoredTargetNodeStat);
 
     LOG.info(
         "The restored zk data tree is constructed. The highest zxid restored is: " + zxidRestored);
-    LOG.info("Requested path node data: " + Arrays.toString(originalNode.getData()));
-    LOG.info(
-        "Requested path node children: " + Arrays.toString(originalNode.getChildren().toArray()));
-    LOG.info("Requested path node stat: " + originalNodeStat.toString());
+    LOG.info("Restored target node data: " + Arrays.toString(restoredTargetNode.getData()));
+    LOG.info("Restored target node children: " + Arrays
+        .toString(restoredTargetNode.getChildren().toArray()));
+    LOG.info("Restored target node stat: " + restoredTargetNodeStat.toString());
     String requestMsg = "Do you want to restore to this point? Enter \"yes\" or \"no\".";
     String yesMsg = "Performing spot restoration of the ZNode path: " + targetZNodePath;
     String noMsg =
@@ -213,11 +215,12 @@ public class SpotRestorationTool {
   private void skipNodeOrStopRestoration(String errorNodePath, Exception exception) {
     String errorMsg = exception.toString() + "\n";
     String requestMsg =
-        errorMsg + "Do you want to continue the restoration? Enter \"yes\" to skip this node "
+        errorMsg + "Do you want to continue the spot restoration? Enter \"yes\" to skip this node "
             + errorNodePath
-            + ", and continue the restoration for the other nodes; enter \"no\" to stop the restoration.";
-    String yesMsg = "Skipping node " + errorNodePath + ". Continuing restoration for other nodes.";
-    String noMsg = "Restoration is stopped. Reason: " + errorMsg;
+            + ", and continue the spot restoration for the other nodes; enter \"no\" to stop the spot restoration.";
+    String yesMsg =
+        "Skipping node " + errorNodePath + ". Continuing spot restoration for other nodes.";
+    String noMsg = "Spot restoration is stopped. Reason: " + errorMsg;
     if (!getUserConfirmation(requestMsg, yesMsg, noMsg)) {
       printExitMessages();
       System.exit(1);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/SpotRestorationTool.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/SpotRestorationTool.java
@@ -6,10 +6,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Scanner;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
@@ -72,7 +72,7 @@ public class SpotRestorationTool {
         "Starting spot restoration for znode path " + targetZNodePath + ", using data provided in "
             + snapLog.getDataDir().getPath());
     DataTree dataTree = new DataTree();
-    long zxidRestored = snapLog.restore(dataTree, Maps.newHashMap(), (hdr, rec, digest) -> {
+    long zxidRestored = snapLog.restore(dataTree, new ConcurrentHashMap<>(), (hdr, rec, digest) -> {
       // Do nothing since we are trying to build a data tree in memory, not in actual zk server
     });
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/SpotRestorationTool.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/SpotRestorationTool.java
@@ -1,0 +1,276 @@
+package org.apache.zookeeper.server.backup;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import org.apache.jute.Record;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.data.ACL;
+import org.apache.zookeeper.data.Stat;
+import org.apache.zookeeper.server.DataNode;
+import org.apache.zookeeper.server.DataTree;
+import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
+import org.apache.zookeeper.txn.TxnDigest;
+import org.apache.zookeeper.txn.TxnHeader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is a tool for automatic restoration of ZK data based on a zk node path using a collection of
+ * snapshot and transaction logs.
+ */
+public class SpotRestorationTool {
+  private static final Logger LOG = LoggerFactory.getLogger(SpotRestorationTool.class);
+
+  File dataDir;
+  ZooKeeper zk;
+  FileTxnSnapLog snapLog;
+  boolean restoreRecursively;
+  String targetZNodePath;
+  List<String> messages;
+
+  /**
+   * Constructor
+   * @param dataDir The directory contains snapshot and transaction log files to be used for restoration
+   * @param zk A client connection to the zk server to be restored
+   * @param targetZNodePath The znode path to start the restoration
+   * @param restoreRecursively If true then restore the whole sub-data tree of the target znode;
+   *                           if false then restore the target znode only
+   * @throws IOException
+   */
+  public SpotRestorationTool(File dataDir, ZooKeeper zk, String targetZNodePath,
+      boolean restoreRecursively) throws IOException {
+    if (dataDir == null || !dataDir.exists()) {
+      throw new IllegalArgumentException(
+          "The provided dataDir is null or does not exist, please check the input.");
+    }
+    this.dataDir = dataDir;
+    this.zk = zk;
+    this.snapLog = new FileTxnSnapLog(dataDir, dataDir);
+    this.targetZNodePath = targetZNodePath;
+    this.restoreRecursively = restoreRecursively;
+    this.messages = Lists.newArrayList();
+  }
+
+  /**
+   * Run the spot restoration.
+   * 1. If a node exists in restored data tree but not in the zk server, create the node in the server
+   * 2. If a node exists in zk server but not the restored data tree, show messages ask user to manually delete the node
+   * 3. If a node exists in both zk server and restored data tree, show message ask user to take care of the node
+   * @throws IOException
+   */
+  public void run() throws IOException {
+    DataTree dataTree = new DataTree();
+    long zxidRestored =
+        snapLog.restore(dataTree, new ConcurrentHashMap<>(), new FileTxnSnapLog.PlayBackListener() {
+          @Override
+          public void onTxnLoaded(TxnHeader hdr, Record rec, TxnDigest digest) {
+            // Do nothing since we are trying to build a data tree in memory, not in actual zk server
+          }
+        });
+
+    DataNode originalNode = dataTree.getNode(targetZNodePath);
+    if (originalNode == null) {
+      return;
+    }
+    Stat originalNodeStat = new Stat();
+    originalNode.copyStat(originalNodeStat);
+
+    LOG.info(
+        "The restored zk data tree is constructed. The highest zxid restored is: " + zxidRestored);
+    LOG.info("Requested path node data: " + Arrays.toString(originalNode.getData()));
+    LOG.info(
+        "Requested path node children: " + Arrays.toString(originalNode.getChildren().toArray()));
+    LOG.info("Requested path node stat: " + originalNodeStat.toString());
+    String requestMsg = "Do you want to restore to this point? Enter \"yes\" or \"no\".";
+    String yesMsg = "Restoring ZooKeeper server...";
+    String noMsg = "Restoration aborted. Nothing has been changed.";
+    if (getUserConfirmation(requestMsg, yesMsg, noMsg)) {
+      traverseNode(zk, dataTree, targetZNodePath, true);
+      printExitMessages();
+    }
+  }
+
+  /**
+   * 1. Restore the node value in zk server;
+   * 2. check if there are deprecated nodes (exist in zk server but not in restored data tree) in its child nodes;
+   * 3. Do the above operations for all of its child nodes in the restored data tree
+   * @param zk A client connection to zk server
+   * @param dataTree The restored zk data tree
+   * @param path The znode path to restore
+   * @param targetNode True if the node being restored is the target znode that user specified;
+   *                   false if it's a child node of the target node
+   */
+  private void traverseNode(ZooKeeper zk, DataTree dataTree, String path, boolean targetNode) {
+    if (!restoreNode(zk, dataTree, path, targetNode) || !restoreRecursively) {
+      // This node is skipped, there's no need to traverse its child nodes
+      return;
+    }
+
+    // Find child nodes in restored data tree
+    DataNode node = dataTree.getNode(path);
+    Set<String> childrenSet = node.getChildren();
+    String[] children = childrenSet.toArray(new String[0]);
+
+    // Find child nodes that's in zk server but not in restored data tree
+    try {
+      List<String> destChildren = zk.getChildren(path, false);
+      for (String destChild : destChildren) {
+        if (!childrenSet.contains(destChild)) {
+          String nodePath = path + "/" + destChild;
+          messages.add(nodePath + ": This node does not exist in the restored data tree.");
+        }
+      }
+    } catch (Exception e) {
+      skipNodeOrStopRestoration(path, e);
+    }
+
+    // Traverse the child nodes of this node
+    for (String child : children) {
+      traverseNode(zk, dataTree, path + "/" + child, false);
+    }
+  }
+
+  /**
+   * Restore the znode in the zk server, currently only doing creation of non-existing nodes,
+   * and only supports persistent nodes
+   * @param zk A client connection to zk server
+   * @param dataTree The restored zk data tree
+   * @param path The znode path to restore
+   * @param targetNode True if the node being restored is the target znode that user specified;
+   *                   false if it's a child node of the target node
+   * @return True if the node is successfully restored, false if the node is skipped
+   */
+  private boolean restoreNode(ZooKeeper zk, DataTree dataTree, String path, boolean targetNode) {
+    DataNode node = dataTree.getNode(path);
+    try {
+      if (zk.exists(path, false) == null) {
+        Stat stat = new Stat();
+        node.copyStat(stat);
+        if (stat.getEphemeralOwner() != 0) {
+          messages.add(path
+              + ": The node is an ephemeral node, which is not supported in spot restoration.");
+        } else {
+          return createNode(path, dataTree);
+        }
+      } else if (targetNode) {
+        // If it is the target node that the user wants to restore,
+        //we don't skip it just because it already exists in the server,
+        //because we already get user's confirmation to restore this node
+        //and we need to get to its child nodes
+        zk.setData(path, node.getData(), -1);
+        return true;
+      } else {
+        messages.add(path + ": The node already exists in zk server.");
+      }
+    } catch (Exception e) {
+      skipNodeOrStopRestoration(path, e);
+    }
+    return false;
+  }
+
+  private void print(String message) {
+    System.out.println(message);
+  }
+
+  @VisibleForTesting
+  protected boolean getUserConfirmation(String requestMsg, String yesMsg, String noMsg) {
+    Scanner scanner = new Scanner(System.in);
+    while (true) {
+      print(requestMsg);
+      String input = scanner.nextLine().toLowerCase();
+      switch (input) {
+        case "yes":
+          print(yesMsg);
+          return true;
+        case "no":
+          print(noMsg);
+          return false;
+        default:
+          print("Could not recognize the input: " + input + ". Please try again.");
+          break;
+      }
+    }
+  }
+
+  private void skipNodeOrStopRestoration(String errorNodePath, Exception exception) {
+    String errorMsg = exception.toString() + "\n";
+    String requestMsg =
+        errorMsg + "Do you want to continue the restoration? Enter \"yes\" to skip this node "
+            + errorNodePath
+            + ", and continue the restoration for the other nodes; enter \"no\" to stop the restoration.";
+    String yesMsg = "Skipping node " + errorNodePath + ". Continuing restoration for other nodes.";
+    String noMsg = "Restoration is stopped. Reason: " + errorMsg;
+    if (!getUserConfirmation(requestMsg, yesMsg, noMsg)) {
+      printExitMessages();
+      System.exit(1);
+    } else {
+      messages.add(errorNodePath + ": " + errorMsg);
+    }
+  }
+
+  /**
+   * Print out all the messages about skipped nodes during restoration
+   */
+  private void printExitMessages() {
+    LOG.info("Spot restoration for " + targetZNodePath + " is successfully done.");
+    if (!messages.isEmpty()) {
+      LOG.warn("During the restoration, the following nodes are skipped.");
+      messages.forEach(this::print);
+      LOG.warn("Please examine the above nodes and take appropriate actions.");
+    }
+  }
+
+  /**
+   * Create the nodes which do not exist in the zk server
+   * @param path The node path
+   * @param dataTree The restored zk data tree
+   * @return True if node is successfully created, otherwise false
+   * @throws KeeperException
+   * @throws InterruptedException
+   */
+  private boolean createNode(String path, DataTree dataTree)
+      throws KeeperException, InterruptedException {
+    DataNode node = dataTree.getNode(path);
+    List<ACL> acls = dataTree.getACL(node);
+    if (acls == null || acls.isEmpty()) {
+      acls = ZooDefs.Ids.OPEN_ACL_UNSAFE;
+    }
+    boolean retry = false;
+    do {
+      try {
+        zk.create(path, node.getData(), acls, CreateMode.PERSISTENT);
+        return true;
+      } catch (KeeperException e) {
+        if (e.code().equals(KeeperException.Code.NONODE)) { // Parent node does not exist
+          String requestMsg = "The parent node for node " + path
+              + " does not exist, do you want to create its parent node(s)? Enter \"yes\" to create, enter \"no\" to skip this node or exit the restoration.";
+          String yesMsg = "Creating parent node(s) for " + path;
+          String noMsg =
+              "Skip node " + path + " or exit the restoration due to non-existing parent node.";
+          if (getUserConfirmation(requestMsg, yesMsg, noMsg)) {
+            String parentPath = path.substring(0, path.lastIndexOf('/'));
+            retry = createNode(parentPath, dataTree);
+          } else {
+            skipNodeOrStopRestoration(path, e);
+          }
+        } else if (e.code().equals(KeeperException.Code.NODEEXISTS)) {
+          messages.add(path + ": The node already exists in zk server.");
+        } else {
+          throw e;
+        }
+      }
+    } while (retry);
+    return false;
+  }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/RestorationToolTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/RestorationToolTest.java
@@ -400,8 +400,8 @@ public class RestorationToolTest extends ZKTestCase {
     //        Expected: nodes are created in the running zk server
     //    2. Nodes not exist in backup files but in the running zk server
     //        Path => value:
-    //          /testsr/deprecated => deprecated
-    //          /testsr/deprecated/node0 => deprecated0
+    //          /testsr/new => new
+    //          /testsr/new/node0 => new0
     //        Expected: messages printed at the end indicate the node is skipped
     //    3. Nodes exist in both backup files and in the running zk server, but with different values
     //        Path => value in backup files; value in running server
@@ -440,10 +440,10 @@ public class RestorationToolTest extends ZKTestCase {
     // Create several znodes in the running zk server
     connection.create("/testsr", "target".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE,
         CreateMode.PERSISTENT);
-    connection.create("/testsr/deprecated", "deprecated".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE,
+    connection.create("/testsr/new", "new".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE,
         CreateMode.PERSISTENT);
     connection
-        .create("/testsr/deprecated/node0", "deprecated0".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE,
+        .create("/testsr/new/node0", "new0".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE,
             CreateMode.PERSISTENT);
     connection.create("/testsr/existing", "existingVal".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE,
         CreateMode.PERSISTENT);
@@ -481,16 +481,16 @@ public class RestorationToolTest extends ZKTestCase {
     Assert.assertArrayEquals("restore0".getBytes(),
         connection.getData("/testsr/restore/node0", false, new Stat()));
 
-    // We do not delete deprecated nodes, only log them in the messages
-    Assert.assertNotNull(connection.exists("/testsr/deprecated", false));
-    Assert.assertNotNull(connection.exists("/testsr/deprecated/node0", false));
+    // We do not delete new nodes, only log them in the messages
+    Assert.assertNotNull(connection.exists("/testsr/new", false));
+    Assert.assertNotNull(connection.exists("/testsr/new/node0", false));
 
     // We do not update existing nodes' values, only log them in the messages
     Assert.assertArrayEquals("existingVal".getBytes(),
         connection.getData("/testsr/existing", false, new Stat()));
 
     LOG.info("Please examine the messages printed out. "
-        + "There should be messages for skipping nodes: \"/testsr/deprecated\" and \"/testsr/existing\".");
+        + "There should be messages for skipping nodes: \"/testsr/new\" and \"/testsr/existing\".");
 
 
     //TEST 2.

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/RestorationToolTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/RestorationToolTest.java
@@ -34,11 +34,13 @@ import java.util.stream.Collectors;
 import org.apache.commons.cli.CommandLine;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.DummyWatcher;
+import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.cli.RestoreCommand;
+import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.server.ServerCnxn;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.SyncRequestProcessor;
@@ -143,6 +145,7 @@ public class RestorationToolTest extends ZKTestCase {
         timestampInMiddle = System.currentTimeMillis();
       }
     }
+
     backupManager.getLogBackup().run(1);
     backupManager.getSnapBackup().run(1);
   }
@@ -383,5 +386,152 @@ public class RestorationToolTest extends ZKTestCase {
         .thenReturn(BackupUtil.LATEST);
     Assert.assertTrue(restoreTool.runWithRetries(cl));
     validateRestoreCoverage(txnCnt);
+  }
+
+  @Test
+  public void testSpotRestorationTool() throws IOException, InterruptedException, KeeperException {
+    //TEST 1.
+    //Target node: /testsr
+    // This test is going to test three scenarios:
+    //    1. Nodes exist in backup files but not in the running zk server
+    //        Path => value:
+    //          /testsr/restore => restore
+    //          /testsr/restore/node0 => restore0
+    //        Expected: nodes are created in the running zk server
+    //    2. Nodes not exist in backup files but in the running zk server
+    //        Path => value:
+    //          /testsr/deprecated => deprecated
+    //          /testsr/deprecated/node0 => deprecated0
+    //        Expected: messages printed at the end indicate the node is skipped
+    //    3. Nodes exist in both backup files and in the running zk server, but with different values
+    //        Path => value in backup files; value in running server
+    //          /testsr/existing => restoredVal; existingVal
+    //        Expected: messages printed at the end indicate the node is skipped
+
+    // Create several znodes in original zk server whose data will be backed up for testing
+    connection
+        .create("/testsr", "restoredTarget".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+    connection.create("/testsr/restore", "restore".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE,
+        CreateMode.PERSISTENT);
+    connection.create("/testsr/restore/node0", "restore0".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE,
+        CreateMode.PERSISTENT);
+    connection.create("/testsr/existing", "restoredVal".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE,
+        CreateMode.PERSISTENT);
+    backupManager.getLogBackup().run(1);
+    backupManager.getSnapBackup().run(1);
+
+    // Close the original zk server and zk client;
+    //start a new server as the server to be restored, and a new client connection
+    connection.close();
+    zks.shutdown();
+    LOG.info("ZK server is shut down.");
+
+    dataDir = ClientBase.createTmpDir();
+    LOG.info("Starting a new zk server.");
+    zks = new ZooKeeperServer(dataDir, dataDir, 3000);
+    SyncRequestProcessor.setSnapCount(100);
+    serverCnxnFactory.startup(zks);
+
+    LOG.info("Waiting for server startup");
+    Assert.assertTrue("waiting for server being up",
+        ClientBase.waitForServerUp(HOSTPORT, CONNECTION_TIMEOUT));
+    connection = new ZooKeeper(HOSTPORT, CONNECTION_TIMEOUT, DummyWatcher.INSTANCE);
+
+    // Create several znodes in the running zk server
+    connection.create("/testsr", "target".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE,
+        CreateMode.PERSISTENT);
+    connection.create("/testsr/deprecated", "deprecated".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE,
+        CreateMode.PERSISTENT);
+    connection
+        .create("/testsr/deprecated/node0", "deprecated0".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE,
+            CreateMode.PERSISTENT);
+    connection.create("/testsr/existing", "existingVal".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE,
+        CreateMode.PERSISTENT);
+
+    // Copy backup files to restoreDir
+    RestoreFromBackupTool restoreTool = new RestoreFromBackupTool();
+    CommandLine cl = Mockito.mock(CommandLine.class);
+    when(cl.hasOption(RestoreCommand.OptionShortForm.RESTORE_ZXID)).thenReturn(true);
+    when(cl.hasOption(RestoreCommand.OptionShortForm.BACKUP_STORE)).thenReturn(true);
+    when(cl.hasOption(RestoreCommand.OptionShortForm.SNAP_DESTINATION)).thenReturn(true);
+    when(cl.hasOption(RestoreCommand.OptionShortForm.LOG_DESTINATION)).thenReturn(true);
+    when(cl.getOptionValue(RestoreCommand.OptionShortForm.RESTORE_ZXID))
+        .thenReturn((BackupUtil.LATEST));
+    when(cl.getOptionValue(RestoreCommand.OptionShortForm.BACKUP_STORE))
+        .thenReturn("gpfs::" + backupDir.getPath() + ":" + TEST_NAMESPACE);
+    when(cl.getOptionValue(RestoreCommand.OptionShortForm.SNAP_DESTINATION))
+        .thenReturn(restoreDir.getPath());
+    when(cl.getOptionValue(RestoreCommand.OptionShortForm.LOG_DESTINATION))
+        .thenReturn(restoreDir.getPath());
+    Assert.assertTrue(restoreTool.runWithRetries(cl));
+
+    // Do spot restoration using the backup files
+    String targetZnodePath = "/testsr";
+    MockSpotRestorationTool tool =
+        new MockSpotRestorationTool(restoreDir, connection, targetZnodePath, true);
+    tool.run();
+
+    // The target node's value should be updated
+    Assert.assertArrayEquals("restoredTarget".getBytes(),
+        connection.getData("/testsr", false, new Stat()));
+
+    // These nodes should be created in the zk server
+    Assert.assertArrayEquals("restore".getBytes(),
+        connection.getData("/testsr/restore", false, new Stat()));
+    Assert.assertArrayEquals("restore0".getBytes(),
+        connection.getData("/testsr/restore/node0", false, new Stat()));
+
+    // We do not delete deprecated nodes, only log them in the messages
+    Assert.assertNotNull(connection.exists("/testsr/deprecated", false));
+    Assert.assertNotNull(connection.exists("/testsr/deprecated/node0", false));
+
+    // We do not update existing nodes' values, only log them in the messages
+    Assert.assertArrayEquals("existingVal".getBytes(),
+        connection.getData("/testsr/existing", false, new Stat()));
+
+    LOG.info("Please examine the messages printed out. "
+        + "There should be messages for skipping nodes: \"/testsr/deprecated\" and \"/testsr/existing\".");
+
+
+    //TEST 2.
+    //  Test target node's parent nodes do not exist
+    connection.close();
+    zks.shutdown();
+    LOG.info("ZK server is shut down.");
+
+    dataDir = ClientBase.createTmpDir();
+    LOG.info("Starting a new zk server.");
+    zks = new ZooKeeperServer(dataDir, dataDir, 3000);
+    SyncRequestProcessor.setSnapCount(100);
+    serverCnxnFactory.startup(zks);
+
+    LOG.info("Waiting for server startup");
+    Assert.assertTrue("waiting for server being up",
+        ClientBase.waitForServerUp(HOSTPORT, CONNECTION_TIMEOUT));
+    connection = new ZooKeeper(HOSTPORT, CONNECTION_TIMEOUT, DummyWatcher.INSTANCE);
+
+    targetZnodePath = "/testsr/restore/node0";
+    tool =
+        new MockSpotRestorationTool(restoreDir, connection, targetZnodePath, true);
+    tool.run();
+
+    Assert.assertArrayEquals("restoredTarget".getBytes(),
+        connection.getData("/testsr", false, new Stat()));
+    Assert.assertArrayEquals("restore".getBytes(),
+        connection.getData("/testsr/restore", false, new Stat()));
+    Assert.assertArrayEquals("restore0".getBytes(),
+        connection.getData("/testsr/restore/node0", false, new Stat()));
+  }
+
+  class MockSpotRestorationTool extends SpotRestorationTool {
+    public MockSpotRestorationTool(File dataDir, ZooKeeper zk, String targetZNodePath,
+        boolean restoreRecursively) throws IOException {
+      super(dataDir, zk, targetZNodePath, restoreRecursively);
+    }
+
+    @Override
+    protected boolean getUserConfirmation(String requestMsg, String yesMsg, String noMsg) {
+      return true;
+    }
   }
 }


### PR DESCRIPTION
This commit adds a spot restoration tool which  does the following:
1. Construct a zk data tree from a provided collection of snapshot and transaction log files
2. Restore the value of a znode with user specified path, and its sub data tree as well if requested by user

This commit adds a new class `SpotRestorationTool`.
Test: A test `testSpotRestorationTool` is added to `RestorationToolTest` class