### PR TITLE
Integrate spot restoration tool with CLI restore command

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/RestoreCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/RestoreCommand.java
@@ -44,7 +44,10 @@ public class RestoreCommand extends CliCommand {
           + OptionFullCommand.LOG_DESTINATION + "] [" + OptionFullCommand.TIMETABLE_STORAGE_PATH
           + "](needed if restore to a timestamp) [" + OptionFullCommand.LOCAL_RESTORE_TEMP_DIR_PATH
           + "](optional) [" + OptionFullCommand.DRY_RUN + "](optional) ["
-          + OptionFullCommand.OVERWRITE + "](optional)";
+          + OptionFullCommand.OVERWRITE + "](optional)\n Options for spot restoration: \n["
+          + OptionFullCommand.ZNODE_PATH_TO_RESTORE + "] ["
+          + OptionFullCommand.ZK_SERVER_CONNECTION_STRING + "] ["
+          + OptionFullCommand.RECURSIVE_SPOT_RESTORE + "](optional)";
 
   public final class OptionLongForm {
     /* Required if no restore timestamp is specified */
@@ -66,6 +69,14 @@ public class RestoreCommand extends CliCommand {
     /* Optional. Default value false */
     public static final String OVERWRITE = "overwrite";
 
+    //For spot restoration
+    /* Required */
+    public static final String ZNODE_PATH_TO_RESTORE = "znode_path_to_restore";
+    /* Required */
+    public static final String ZK_SERVER_CONNECTION_STRING = "zk_server_connection_string";
+    /* Optional. Default value false */
+    public static final String RECURSIVE_SPOT_RESTORE = "recursive_spot_restore";
+
     // Create a private constructor so it can't be instantiated
     private OptionLongForm() {
     }
@@ -82,6 +93,11 @@ public class RestoreCommand extends CliCommand {
     public static final String DRY_RUN = "n";
     public static final String HELP = "h";
     public static final String OVERWRITE = "f";
+
+    //For spot restoration
+    public static final String ZNODE_PATH_TO_RESTORE = "p";
+    public static final String ZK_SERVER_CONNECTION_STRING = "c";
+    public static final String RECURSIVE_SPOT_RESTORE = "a";
 
     // Create a private constructor so it can't be instantiated
     private OptionShortForm() {
@@ -107,6 +123,15 @@ public class RestoreCommand extends CliCommand {
     public static final String DRY_RUN = "-" + OptionShortForm.DRY_RUN;
     public static final String OVERWRITE = "-" + OptionShortForm.OVERWRITE;
 
+    //For spot restoration
+    public static final String ZNODE_PATH_TO_RESTORE =
+        "-" + OptionShortForm.ZNODE_PATH_TO_RESTORE + " " + OptionLongForm.ZNODE_PATH_TO_RESTORE;
+    public static final String ZK_SERVER_CONNECTION_STRING =
+        "-" + OptionShortForm.ZK_SERVER_CONNECTION_STRING + " "
+            + OptionLongForm.ZK_SERVER_CONNECTION_STRING;
+    public static final String RECURSIVE_SPOT_RESTORE =
+        "-" + OptionShortForm.RECURSIVE_SPOT_RESTORE;
+
     // Create a private constructor so it can't be instantiated
     private OptionFullCommand() {
     }
@@ -127,6 +152,14 @@ public class RestoreCommand extends CliCommand {
         OptionLongForm.LOCAL_RESTORE_TEMP_DIR_PATH));
     options.addOption(new Option(OptionShortForm.DRY_RUN, false, OptionLongForm.DRY_RUN));
     options.addOption(new Option(OptionShortForm.OVERWRITE, false, OptionLongForm.OVERWRITE));
+
+    //For spot restoration
+    options.addOption(new Option(OptionShortForm.ZNODE_PATH_TO_RESTORE, true,
+        OptionLongForm.ZNODE_PATH_TO_RESTORE));
+    options.addOption(new Option(OptionShortForm.ZK_SERVER_CONNECTION_STRING, true,
+        OptionLongForm.ZK_SERVER_CONNECTION_STRING));
+    options.addOption(new Option(OptionShortForm.RECURSIVE_SPOT_RESTORE, false,
+        OptionLongForm.RECURSIVE_SPOT_RESTORE));
   }
 
   public RestoreCommand() {
@@ -136,26 +169,48 @@ public class RestoreCommand extends CliCommand {
 
   @Override
   public String getUsageStr() {
-    return "Usage: RestoreFromBackupTool  " + RESTORE_CMD_STR + " " + OPTION_STR + "\n    "
+    return "Usage: RestoreFromBackupTool  " + RESTORE_CMD_STR + " " + OPTION_STR
+        + "\n    Options for both offline restoration and spot restoration:\n    "
         + OptionFullCommand.RESTORE_ZXID
-        + ": the point to restore to, either the string 'latest' or a zxid in hex format. Choose one between this option or "
-        + OptionFullCommand.RESTORE_TIMESTAMP
-        + ", if both are specified, this option will be prioritized\n    "
+        + ": the point to restore to, either the string 'latest' or a zxid in hex format. "
+        + "Choose one between this option or " + OptionFullCommand.RESTORE_TIMESTAMP
+        + ", if both are specified, this option will be prioritized. "
+        + "Required for both offline restoration and spot restoration.\n    "
         + OptionFullCommand.RESTORE_TIMESTAMP
         + ": the point to restore to, a timestamp in long format. Choose one between this option or "
-        + OptionFullCommand.RESTORE_ZXID + ".\n    " + OptionFullCommand.BACKUP_STORE
-        + ": the connection information for the backup store\n           For GPFS the format is: gpfs:<config_path>:<backup_path>:<namespace>\n    "
-        + OptionFullCommand.SNAP_DESTINATION
-        + ": local destination path for restored snapshots\n    "
-        + OptionFullCommand.LOG_DESTINATION + ": local destination path for restored txlogs\n    "
+        + OptionFullCommand.RESTORE_ZXID
+        + ". Required for both offline restoration and spot restoration.\n    "
+        + OptionFullCommand.BACKUP_STORE
+        + ": the connection information for the backup store\n           "
+        + "For GPFS the format is: gpfs:<config_path>:<backup_path>:<namespace>\n           "
+        + "Required for both offline restoration and spot restoration.\n    "
+        + OptionFullCommand.SNAP_DESTINATION + ": local destination path for restored snapshots. "
+        + "Required for both offline restoration and spot restoration. "
+        + "For spot restoration, this path should be same as the log destination.\n    "
+        + OptionFullCommand.LOG_DESTINATION + ": local destination path for restored txlogs. "
+        + "Required for both offline restoration and spot restoration.  "
+        + "For spot restoration, this path should be same as the snap destination.\n    "
         + OptionFullCommand.TIMETABLE_STORAGE_PATH
-        + ": Needed if restore to a timestamp. Backup storage path for timetable files, for GPFS the format is: gpfs:<config_path>:<backup_path>:<namespace>, if not set, default to be same as backup storage path\n    "
+        + ": Needed if restore to a timestamp. Backup storage path for timetable files. "
+        + "For GPFS the format is: gpfs:<config_path>:<backup_path>:<namespace>. "
+        + "If not set, default to be same as backup storage path\n    "
         + OptionFullCommand.LOCAL_RESTORE_TEMP_DIR_PATH
-        + ": Optional, local path for creating a temporary intermediate directory for restoration, the directory will be deleted after restoration is done\n    "
+        + ": Optional, local path for creating a temporary intermediate directory for restoration, "
+        + "the directory will be deleted after restoration is done\n    "
         + OptionFullCommand.DRY_RUN + " " + OptionLongForm.DRY_RUN
         + ": Optional, no files will be actually copied in a dry run\n    "
         + OptionFullCommand.OVERWRITE + " " + OptionLongForm.OVERWRITE
-        + ": Optional, default false. If true, the destination directories will be overwritten\n";
+        + ": Optional, default false. If true, the destination directories will be overwritten\n    "
+        + "Options for spot restoration only:\n    " + OptionFullCommand.ZNODE_PATH_TO_RESTORE
+        + ": The znode path to restore in the zk server\n    "
+        + OptionFullCommand.ZK_SERVER_CONNECTION_STRING
+        + ": The connection string used to establish a client to server connection "
+        + "in order to do spot restoration on zk server. "
+        + "The format of this string should be host:port, "
+        + "for example: 127.0.0.1:3000\n    "
+        + OptionFullCommand.RECURSIVE_SPOT_RESTORE
+        + ": Optional, default false. If false, the spot restoration will be done on one single node only; "
+        + "if true, it will be done recursively on all of its descendants as well";
   }
 
   @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/RestoreCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/RestoreCommand.java
@@ -185,17 +185,15 @@ public class RestoreCommand extends CliCommand {
         + "For GPFS the format is: gpfs:<config_path>:<backup_path>:<namespace>\n           "
         + "Required for both offline restoration and spot restoration.\n    "
         + OptionFullCommand.SNAP_DESTINATION + ": local destination path for restored snapshots. "
-        + "Required for both offline restoration and spot restoration. "
-        + "For spot restoration, this path should be same as the log destination.\n    "
-        + OptionFullCommand.LOG_DESTINATION + ": local destination path for restored txlogs. "
-        + "Required for both offline restoration and spot restoration.  "
-        + "For spot restoration, this path should be same as the snap destination.\n    "
-        + OptionFullCommand.TIMETABLE_STORAGE_PATH
+        + "Required for offline restoration.\n    " + OptionFullCommand.LOG_DESTINATION
+        + ": local destination path for restored txlogs. "
+        + "Required for both offline restoration.\n    " + OptionFullCommand.TIMETABLE_STORAGE_PATH
         + ": Needed if restore to a timestamp. Backup storage path for timetable files. "
         + "For GPFS the format is: gpfs:<config_path>:<backup_path>:<namespace>. "
         + "If not set, default to be same as backup storage path\n    "
         + OptionFullCommand.LOCAL_RESTORE_TEMP_DIR_PATH
-        + ": Optional, local path for creating a temporary intermediate directory for restoration, "
+        + ": Required for spot restoration, and optional for offline restoration. "
+        + "A local path for creating a temporary intermediate directory for restoration, "
         + "the directory will be deleted after restoration is done\n    "
         + OptionFullCommand.DRY_RUN + " " + OptionLongForm.DRY_RUN
         + ": Optional, no files will be actually copied in a dry run\n    "
@@ -206,8 +204,7 @@ public class RestoreCommand extends CliCommand {
         + OptionFullCommand.ZK_SERVER_CONNECTION_STRING
         + ": The connection string used to establish a client to server connection "
         + "in order to do spot restoration on zk server. "
-        + "The format of this string should be host:port, "
-        + "for example: 127.0.0.1:3000\n    "
+        + "The format of this string should be host:port, " + "for example: 127.0.0.1:3000\n    "
         + OptionFullCommand.RECURSIVE_SPOT_RESTORE
         + ": Optional, default false. If false, the spot restoration will be done on one single node only; "
         + "if true, it will be done recursively on all of its descendants as well";
@@ -223,8 +220,7 @@ public class RestoreCommand extends CliCommand {
     }
     if ((!cl.hasOption(OptionShortForm.RESTORE_ZXID) && !cl
         .hasOption(OptionShortForm.RESTORE_TIMESTAMP)) || !cl
-        .hasOption(OptionShortForm.BACKUP_STORE) || !cl.hasOption(OptionShortForm.SNAP_DESTINATION)
-        || !cl.hasOption(OptionShortForm.LOG_DESTINATION)) {
+        .hasOption(OptionShortForm.BACKUP_STORE)) {
       throw new CliParseException("Missing required argument(s).\n" + getUsageStr());
     }
     return this;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/cli/RestoreCommand.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/cli/RestoreCommand.java
@@ -187,19 +187,20 @@ public class RestoreCommand extends CliCommand {
         + OptionFullCommand.SNAP_DESTINATION + ": local destination path for restored snapshots. "
         + "Required for offline restoration.\n    " + OptionFullCommand.LOG_DESTINATION
         + ": local destination path for restored txlogs. "
-        + "Required for both offline restoration.\n    " + OptionFullCommand.TIMETABLE_STORAGE_PATH
+        + "Required for offline restoration.\n    " + OptionFullCommand.TIMETABLE_STORAGE_PATH
         + ": Needed if restore to a timestamp. Backup storage path for timetable files. "
         + "For GPFS the format is: gpfs:<config_path>:<backup_path>:<namespace>. "
         + "If not set, default to be same as backup storage path\n    "
         + OptionFullCommand.LOCAL_RESTORE_TEMP_DIR_PATH
         + ": Required for spot restoration, and optional for offline restoration. "
-        + "A local path for creating a temporary intermediate directory for restoration, "
-        + "the directory will be deleted after restoration is done\n    "
+        + "The restore tool will use this local path to stage temporary files needed for restoration work, "
+        + "this directory will be deleted after restoration is done\n    "
         + OptionFullCommand.DRY_RUN + " " + OptionLongForm.DRY_RUN
         + ": Optional, no files will be actually copied in a dry run\n    "
         + OptionFullCommand.OVERWRITE + " " + OptionLongForm.OVERWRITE
-        + ": Optional, default false. If true, the destination directories will be overwritten\n    "
-        + "Options for spot restoration only:\n    " + OptionFullCommand.ZNODE_PATH_TO_RESTORE
+        + ": Optional, default false. If true, all existing files will be wiped out and the directories "
+        + "be populated with restored files\n    " + "Options for spot restoration only:\n    "
+        + OptionFullCommand.ZNODE_PATH_TO_RESTORE
         + ": The znode path to restore in the zk server\n    "
         + OptionFullCommand.ZK_SERVER_CONNECTION_STRING
         + ": The connection string used to establish a client to server connection "

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/RestoreFromBackupTool.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/RestoreFromBackupTool.java
@@ -360,7 +360,7 @@ public class RestoreFromBackupTool {
   /**
    * Attempts to perform a restore.
    */
-  public void run() throws IOException {
+  public void run() throws IOException, InterruptedException {
     try {
       if (!findFilesToRestore()) {
         throw new IllegalArgumentException("Failed to find valid snapshot and logs to restore.");
@@ -665,7 +665,7 @@ public class RestoreFromBackupTool {
    * @throws IOException
    */
   @VisibleForTesting
-  protected void performSpotRestorationIfConfigured() throws IOException {
+  protected void performSpotRestorationIfConfigured() throws IOException, InterruptedException {
     if (znodePathToRestore != null) {
       if (zkServerConnectionStr == null) {
         throw new IllegalArgumentException(
@@ -678,6 +678,7 @@ public class RestoreFromBackupTool {
       spotRestorationTool = new SpotRestorationTool(new File(snapLog.getDataDir().getParent()), zk,
           znodePathToRestore, restoreRecursively);
       spotRestorationTool.run();
+      BackupStorageUtil.deleteDirectoryRecursively(snapLog.getDataDir());
     }
   }
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/RestorationToolTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/RestorationToolTest.java
@@ -598,8 +598,11 @@ public class RestorationToolTest extends ZKTestCase {
           throw new IllegalArgumentException(
               "ZK server connection info is not provided. Could not perform spot restoration.");
         }
+        LOG.info("Starting spot restoration for zk path " + znodePathToRestore);
         zk = new ZooKeeper(zkServerConnectionStr, CONNECTION_TIMEOUT, (event) -> {
-          System.out.println("WATCHER::" + event.toString());
+          LOG.info(
+              "WATCHER:: client-server connection event received for spot restoration: " + event
+                  .toString());
         });
         spotRestorationTool =
             new MockSpotRestorationTool(new File(snapLog.getDataDir().getParent()), zk,

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/RestorationToolTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/RestorationToolTest.java
@@ -592,25 +592,16 @@ public class RestorationToolTest extends ZKTestCase {
 
   class MockRestoreFromBackupTool extends RestoreFromBackupTool {
     @Override
-    protected void performSpotRestorationIfConfigured() throws IOException, InterruptedException {
-      if (znodePathToRestore != null) {
-        if (zkServerConnectionStr == null) {
-          throw new IllegalArgumentException(
-              "ZK server connection info is not provided. Could not perform spot restoration.");
-        }
-        LOG.info("Starting spot restoration for zk path " + znodePathToRestore);
-        zk = new ZooKeeper(zkServerConnectionStr, CONNECTION_TIMEOUT, (event) -> {
-          LOG.info(
-              "WATCHER:: client-server connection event received for spot restoration: " + event
-                  .toString());
-        });
-        spotRestorationTool =
-            new MockSpotRestorationTool(new File(snapLog.getDataDir().getParent()), zk,
-                znodePathToRestore, restoreRecursively);
-        spotRestorationTool.run();
-        BackupStorageUtil.deleteDirectoryRecursively(snapLog.getDataDir());
-        Assert.assertFalse(snapLog.getDataDir().exists());
-      }
+    protected void performSpotRestoration(File restoreTempDir)
+        throws IOException, InterruptedException {
+      LOG.info("Starting spot restoration for zk path " + znodePathToRestore);
+      zk = new ZooKeeper(zkServerConnectionStr, CONNECTION_TIMEOUT, (event) -> {
+        LOG.info("WATCHER:: client-server connection event received for spot restoration: " + event
+            .toString());
+      });
+      spotRestorationTool =
+          new MockSpotRestorationTool(restoreTempDir, zk, znodePathToRestore, restoreRecursively);
+      spotRestorationTool.run();
     }
   }
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/RestorationToolTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/backup/RestorationToolTest.java
@@ -550,8 +550,9 @@ public class RestorationToolTest extends ZKTestCase {
     when(cl.hasOption(RestoreCommand.OptionShortForm.RESTORE_ZXID)).thenReturn(false);
     when(cl.hasOption(RestoreCommand.OptionShortForm.RESTORE_TIMESTAMP)).thenReturn(true);
     when(cl.hasOption(RestoreCommand.OptionShortForm.BACKUP_STORE)).thenReturn(true);
-    when(cl.hasOption(RestoreCommand.OptionShortForm.SNAP_DESTINATION)).thenReturn(true);
-    when(cl.hasOption(RestoreCommand.OptionShortForm.LOG_DESTINATION)).thenReturn(true);
+    when(cl.hasOption(RestoreCommand.OptionShortForm.SNAP_DESTINATION)).thenReturn(false);
+    when(cl.hasOption(RestoreCommand.OptionShortForm.LOG_DESTINATION)).thenReturn(false);
+    when(cl.hasOption(RestoreCommand.OptionShortForm.LOCAL_RESTORE_TEMP_DIR_PATH)).thenReturn(true);
     when(cl.hasOption(RestoreCommand.OptionShortForm.TIMETABLE_STORAGE_PATH)).thenReturn(true);
     when(cl.hasOption(RestoreCommand.OptionShortForm.ZNODE_PATH_TO_RESTORE)).thenReturn(true);
     when(cl.hasOption(RestoreCommand.OptionShortForm.ZK_SERVER_CONNECTION_STRING)).thenReturn(true);
@@ -559,10 +560,8 @@ public class RestorationToolTest extends ZKTestCase {
         .thenReturn(String.valueOf(timestampInMiddle));
     when(cl.getOptionValue(RestoreCommand.OptionShortForm.BACKUP_STORE))
         .thenReturn("gpfs::" + backupDir.getPath() + ":" + TEST_NAMESPACE);
-    when(cl.getOptionValue(RestoreCommand.OptionShortForm.SNAP_DESTINATION))
-        .thenReturn(restoreDir.getPath());
-    when(cl.getOptionValue(RestoreCommand.OptionShortForm.LOG_DESTINATION))
-        .thenReturn(restoreDir.getPath());
+    when(cl.getOptionValue(RestoreCommand.OptionShortForm.LOCAL_RESTORE_TEMP_DIR_PATH))
+        .thenReturn(restoreTempDir.getPath());
     when(cl.getOptionValue(RestoreCommand.OptionShortForm.TIMETABLE_STORAGE_PATH))
         .thenReturn(timetableDir.getPath() + "/" + TEST_NAMESPACE);
     // Restore the first node created, so we are sure this node exists at the moment of timestamp provided


### PR DESCRIPTION
This commit integrates the `SpotRestorationTool` to `RestoreFromBackupTool`: when user triggers a restore command using ZK CLI, if a znode path is specific, it will run spot restoration on top of an offline restoration of backup files, the spot restoration will use the restored backup files.

Test: test `testSpotRestorationByCommandLine` is added in `RestorationToolTest`
