### PR TITLE
Make statusDir and tmpDir namespaced

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupConfig.java
@@ -72,7 +72,7 @@ public class BackupConfig {
    *       <backupStoragePath>/<namespace>/translog-123456
    */
   private final String namespace;
-  private static final String UNKNOWN_NAMESPACE = "UNKNOWN";
+  private static final String UNKNOWN_NAMESPACE = "UNKNOWN_NAMESPACE";
 
   /*
    * Optional timetable configs

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
@@ -502,12 +502,18 @@ public class BackupManager {
     this.snapDir = snapDir;
     this.dataLogDir = dataLogDir;
     this.backupConfig = backupConfig;
-    this.tmpDir = backupConfig.getTmpDir();
-    this.backupStatus = new BackupStatus(backupConfig.getStatusDir());
+    // Note: tmpDir is namespaced
+    this.tmpDir = new File(String.join(File.separator, backupConfig.getTmpDir().getAbsolutePath(),
+        backupConfig.getNamespace()));
+    // Note: statusDir is namespaced
+    this.backupStatus = new BackupStatus(new File(String
+        .join(File.separator, backupConfig.getStatusDir().getAbsolutePath(),
+            backupConfig.getNamespace())));
     this.backupIntervalInMilliseconds =
         TimeUnit.MINUTES.toMillis(backupConfig.getBackupIntervalInMinutes());
     this.serverId = serverId;
-    this.namespace = backupConfig.getNamespace() == null ? "UNKNOWN" : backupConfig.getNamespace();
+    this.namespace =
+        backupConfig.getNamespace() == null ? "UNKNOWN_NAMESPACE" : backupConfig.getNamespace();
     try {
       backupStorage = BackupUtil.createStorageProviderImpl(backupConfig);
     } catch (ReflectiveOperationException e) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/backup/BackupManager.java
@@ -512,8 +512,7 @@ public class BackupManager {
     this.backupIntervalInMilliseconds =
         TimeUnit.MINUTES.toMillis(backupConfig.getBackupIntervalInMinutes());
     this.serverId = serverId;
-    this.namespace =
-        backupConfig.getNamespace() == null ? "UNKNOWN_NAMESPACE" : backupConfig.getNamespace();
+    this.namespace = backupConfig.getNamespace();
     try {
       backupStorage = BackupUtil.createStorageProviderImpl(backupConfig);
     } catch (ReflectiveOperationException e) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/BackupManagerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/BackupManagerTest.java
@@ -153,7 +153,9 @@ public class BackupManagerTest extends ZKTestCase implements Watcher {
     Assert.assertFalse("No files should have been backed up.", backupDir.list() == null);
     Assert.assertFalse("No temporary files should have been created.",
         backupTmpDir.list() == null);
-    BackupStatus bs = new BackupStatus(dataDir);
+    BackupStatus bs = new BackupStatus(new File(String
+        .join(File.separator, backupConfig.getStatusDir().getAbsolutePath(),
+            backupConfig.getNamespace())));
     BackupPoint bp = bs.read();
     Assert.assertEquals("backupStatus should be set to min for log",
         bp.getLogZxid(), BackupUtil.INVALID_LOG_ZXID);


### PR DESCRIPTION
To achieve parity with other paths/dirs (such as storageDir), this commit makes statusDir and tmpDir namespaced. The following is the example:
statusDir: /zkbackup/statusDir -> /zkbackup/statusDir/<namespace>
When the namespace is not given, the paths will be namespaced with a string "UNKNOWN_NAMESPACE".

Test:
```
% mvn test -Dtest=BackupManagerTest,BackupBeanTest,BackupConfigTest

[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.zookeeper.test.BackupManagerTest
[INFO] Running org.apache.zookeeper.server.backup.BackupBeanTest
[INFO] Running org.apache.zookeeper.server.backup.BackupConfigTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.119 s - in org.apache.zookeeper.server.backup.BackupConfigTest
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 19.563 s - in org.apache.zookeeper.test.BackupManagerTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 123.947 s - in org.apache.zookeeper.server.backup.BackupBeanTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:14 min
[INFO] Finished at: 2021-06-14T10:44:37-07:00
[INFO] ------------------------------------------------------------------------
```