### PR TITLE
Support Matcher group index for extracting ACL entity from SAN in X509 auth provider

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
@@ -31,7 +31,6 @@ import javax.net.ssl.X509TrustManager;
 import javax.security.auth.x500.X500Principal;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.common.ClientX509Util;
-import org.apache.zookeeper.common.X509Exception;
 import org.apache.zookeeper.common.X509Exception.KeyManagerException;
 import org.apache.zookeeper.common.X509Exception.TrustManagerException;
 import org.apache.zookeeper.common.X509Util;
@@ -61,12 +60,14 @@ public class X509AuthenticationProvider implements AuthenticationProvider {
      * The following System Property keys are used to extract clientId from the client cert.
      * @see #getClientId(X509Certificate)
      */
-    public static final String ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENTCERTIDTYPE = "zookeeper.X509AuthenticationProvider.clientCertIdType";
-    public static final String ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENTCERTIDSANMATCHTYPE = "zookeeper.X509AuthenticationProvider.clientCertIdSanMatchType";
+    public static final String ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_TYPE = "zookeeper.X509AuthenticationProvider.clientCertIdType";
+    public static final String ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_MATCH_TYPE = "zookeeper.X509AuthenticationProvider.clientCertIdSanMatchType";
     // Match Regex is used to choose which entry to use
-    public static final String ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENTCERTIDSANMATCHREGEX = "zookeeper.X509AuthenticationProvider.clientCertIdSanMatchRegex";
+    public static final String ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_MATCH_REGEX = "zookeeper.X509AuthenticationProvider.clientCertIdSanMatchRegex";
     // Extract Regex is used to construct a client ID (acl entity) to return
-    public static final String ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENTCERTIDSANEXTRACTREGEX = "zookeeper.X509AuthenticationProvider.clientCertIdSanExtractRegex";
+    public static final String ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_EXTRACT_REGEX = "zookeeper.X509AuthenticationProvider.clientCertIdSanExtractRegex";
+    // Specifies match group index for the extract regex (i in Matcher.group(i))
+    public static final String ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_EXTRACT_MATCHER_GROUP_INDEX = "zookeeper.X509AuthenticationProvider.clientCertIdSanExtractMatcherGroupIndex";
 
     static final Logger LOG = LoggerFactory.getLogger(X509AuthenticationProvider.class);
     private final X509TrustManager trustManager;
@@ -196,7 +197,7 @@ public class X509AuthenticationProvider implements AuthenticationProvider {
      */
     protected String getClientId(X509Certificate clientCert) {
         String clientCertIdType =
-            System.getProperty(ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENTCERTIDTYPE);
+            System.getProperty(ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_TYPE);
         if (clientCertIdType != null && clientCertIdType.equalsIgnoreCase("SAN")) {
             try {
                 return matchAndExtractSAN(clientCert);
@@ -212,11 +213,14 @@ public class X509AuthenticationProvider implements AuthenticationProvider {
     private String matchAndExtractSAN(X509Certificate clientCert)
         throws CertificateParsingException {
         Integer matchType =
-            Integer.getInteger(ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENTCERTIDSANMATCHTYPE);
+            Integer.getInteger(ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_MATCH_TYPE);
         String matchRegex =
-            System.getProperty(ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENTCERTIDSANMATCHREGEX);
+            System.getProperty(ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_MATCH_REGEX);
         String extractRegex =
-            System.getProperty(ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENTCERTIDSANEXTRACTREGEX);
+            System.getProperty(
+                ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_EXTRACT_REGEX);
+        Integer extractMatcherGroupIndex = Integer.getInteger(
+            ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_EXTRACT_MATCHER_GROUP_INDEX);
         LOG.info("X509AuthenticationProvider::matchAndExtractSAN(): Using SAN in the client cert "
                 + "for client ID! matchType: {}, matchRegex: {}, extractRegex: {}", matchType,
             matchRegex, extractRegex);
@@ -259,9 +263,15 @@ public class X509AuthenticationProvider implements AuthenticationProvider {
         Pattern extractPattern = Pattern.compile(extractRegex);
         Matcher matcher = extractPattern.matcher(matched.iterator().next().get(1).toString());
         if (matcher.find()) {
-            String result = matcher.group();
+            String result;
+            if (extractMatcherGroupIndex != null) {
+                result = matcher.group(extractMatcherGroupIndex);
+            } else {
+                // If extractMatcherGroupIndex is not given, return the 0th index by default
+                result = matcher.group();
+            }
             LOG.info("X509AuthenticationProvider::matchAndExtractSAN(): returning extracted "
-                + "client ID: {}", result);
+                + "client ID: {} using Matcher group index: {}", result, extractMatcherGroupIndex);
             return result;
         }
         String errStr = "X509AuthenticationProvider::matchAndExtractSAN(): failed to find an "

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/X509AuthTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/X509AuthTest.java
@@ -107,6 +107,10 @@ public class X509AuthTest extends ZKTestCase {
         System.setProperty(
             X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_EXTRACT_REGEX,
             ".*");
+        // Get the entire thing by setting the Matcher group index to 0
+        System.setProperty(
+            X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_EXTRACT_MATCHER_GROUP_INDEX,
+            "0");
 
         X509AuthenticationProvider provider = createProvider(clientCert);
         MockServerCnxn cnxn = new MockServerCnxn();
@@ -123,6 +127,8 @@ public class X509AuthTest extends ZKTestCase {
             X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_MATCH_REGEX);
         System.clearProperty(
             X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_EXTRACT_REGEX);
+        System.clearProperty(
+            X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_EXTRACT_MATCHER_GROUP_INDEX);
     }
 
     private static class TestPublicKey implements PublicKey {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/X509AuthTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/X509AuthTest.java
@@ -96,16 +96,16 @@ public class X509AuthTest extends ZKTestCase {
     public void testSANBasedAuth() {
         // Set JVM properties to enable SAN-based client id extraction
         System.setProperty(
-            X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENTCERTIDTYPE,
+            X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_TYPE,
             "SAN");
         System.setProperty(
-            X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENTCERTIDSANMATCHTYPE,
+            X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_MATCH_TYPE,
             "6");
         System.setProperty(
-            X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENTCERTIDSANMATCHREGEX,
+            X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_MATCH_REGEX,
             TestCertificate.TEST_SAN_STR);
         System.setProperty(
-            X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENTCERTIDSANEXTRACTREGEX,
+            X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_EXTRACT_REGEX,
             ".*");
 
         X509AuthenticationProvider provider = createProvider(clientCert);
@@ -116,13 +116,13 @@ public class X509AuthTest extends ZKTestCase {
 
         // Remove JVM properties
         System.clearProperty(
-            X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENTCERTIDTYPE);
+            X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_TYPE);
         System.clearProperty(
-            X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENTCERTIDSANMATCHTYPE);
+            X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_MATCH_TYPE);
         System.clearProperty(
-            X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENTCERTIDSANMATCHREGEX);
+            X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_MATCH_REGEX);
         System.clearProperty(
-            X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENTCERTIDSANEXTRACTREGEX);
+            X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_EXTRACT_REGEX);
     }
 
     private static class TestPublicKey implements PublicKey {


### PR DESCRIPTION
Resolves #55 

In order to allow for greater flexibility in extracting a part of the string given in the SAN in the client certificate in X509AuthenticationProvider, this commit adds another JVM parameter for specifying Java regex Matcher Group index. X509AuthTest still has coverage of this logic.

Also as an addendum,
-  internal enum names have been renamed for better readability (spaced with underscores).
- the test case has been enhanced with a more complicated regex with a Matcher group index

Build result:

> [INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache ZooKeeper 3.6.2:
[INFO]
[INFO] Apache ZooKeeper ................................... SUCCESS [  2.854 s]
[INFO] Apache ZooKeeper - Documentation ................... SUCCESS [  1.233 s]
[INFO] Apache ZooKeeper - Jute ............................ SUCCESS [  6.202 s]
[INFO] Apache ZooKeeper - Server .......................... SUCCESS [ 12.959 s]
[INFO] Apache ZooKeeper - Metrics Providers ............... SUCCESS [  0.233 s]
[INFO] Apache ZooKeeper - Prometheus.io Metrics Provider .. SUCCESS [  1.154 s]
[INFO] Apache ZooKeeper - Client .......................... SUCCESS [  0.220 s]
[INFO] Apache ZooKeeper - Recipes ......................... SUCCESS [  0.263 s]
[INFO] Apache ZooKeeper - Recipes - Election .............. SUCCESS [  0.328 s]
[INFO] Apache ZooKeeper - Recipes - Lock .................. SUCCESS [  0.393 s]
[INFO] Apache ZooKeeper - Recipes - Queue ................. SUCCESS [  0.323 s]
[INFO] Apache ZooKeeper - Assembly ........................ SUCCESS [  4.375 s]
[INFO] Apache ZooKeeper - Compatibility Tests ............. SUCCESS [  0.214 s]
[INFO] Apache ZooKeeper - Compatibility Tests - Curator ... SUCCESS [  0.278 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  31.224 s
[INFO] Finished at: 2021-08-12T10:09:22-04:00
[INFO] ------------------------------------------------------------------------

Test result:

>[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.zookeeper.test.X509AuthTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.136 s - in org.apache.zookeeper.test.X509AuthTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  10.205 s
[INFO] Finished at: 2021-08-12T10:09:53-04:00
[INFO] ------------------------------------------------------------------------