### PR TITLE
Add ClientUriDomainMappingHelper and a ZK-based implementation

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ClientUriDomainMappingHelper.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.auth.znode.groupacl;
+
+import java.util.List;
+
+/**
+ * Helper class for looking up the domain name for the client connection. It uses the client's
+ * Uniform Resource Identifier (URI) to look up the application domain it belongs to.
+ *
+ * This class is to be used for ZNode group-based security where one or more clients can be
+ * "authorized" to be given clientId that matches the application domain name.
+ *
+ * To illustrate ZNode group-based security, ZNodes written by a host of "foo" applications will
+ * have "foo" as an ACL entity with all accesses (rwcd). Then all ZooKeeper clients belonging to
+ * "foo" application will be "authorized" as "foo", as in at TLS handshake/auth time, they will be
+ * given "foo" as the clientId. These clients will present their client X509 certificates with their
+ * URIs, and this ClientUriDomainMappingHelper will be used at auth time to convert the extracted
+ * URI to the appropriate domain name "foo".
+ */
+public interface ClientUriDomainMappingHelper {
+  /**
+   * Return a set of application domain names that the given clientUri maps to.
+   * @param clientUri
+   * @return set of domain names. If not found, returns an empty set.
+   */
+  List<String> getDomains(String clientUri);
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ClientUriDomainMappingHelper.java
@@ -18,7 +18,7 @@
 
 package org.apache.zookeeper.server.auth.znode.groupacl;
 
-import java.util.List;
+import java.util.Set;
 
 /**
  * Helper class for looking up the domain name for the client connection. It uses the client's
@@ -40,5 +40,5 @@ public interface ClientUriDomainMappingHelper {
    * @param clientUri
    * @return set of domain names. If not found, returns an empty set.
    */
-  List<String> getDomains(String clientUri);
+  Set<String> getDomains(String clientUri);
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.auth.znode.groupacl;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.server.ZooKeeperServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An implementation of ClientUriDomainMappingHelper that stores the mapping inside the ZK server
+ * as a hierarchy of ZNodes.
+ *
+ * Note that the mapping metadata itself will be stored in ZKDatabase as a ZNode tree and will also
+ * be cached inside this helper object. This helper object watches the clientUri-domain ZNodes and
+ * updates the internal Map accordingly.
+ *
+ * The following illustrates the ZNode hierarchy:
+ * . (root)
+ * └── _CLIENT_URI_DOMAIN_MAPPING (mapping root path)
+ *     ├── bar (application domain)
+ *     │   ├── bar0 (client URI)
+ *     │   └── bar1 (client URI)
+ *     └── foo (application domain)
+ *         ├── foo1 (client URI)
+ *         ├── foo2 (client URI)
+ *         └── foo3 (client URI)
+ *
+ * Note: It is not expected that there would be too many distinct client URIs so as to overwhelm
+ * heap usage.
+ */
+public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainMappingHelper {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ZkClientUriDomainMappingHelper.class);
+
+  private static final String CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH =
+      "zookeeper.znode.groupacl.clientUriDomainMappingRootPath";
+
+  private final ZooKeeperServer zks;
+  private final String rootPath;
+  private final Map<String, List<String>> clientUriToDomainNames = new HashMap<>();
+
+  public ZkClientUriDomainMappingHelper(ZooKeeperServer zks) {
+    this.zks = zks;
+
+    this.rootPath = System.getProperty(CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH);
+    if (rootPath == null) {
+      throw new IllegalStateException(
+          "ZkClientUriDomainMappingHelper::ClientUriDomainMapping root path is not set!");
+    }
+
+    addWatches();
+  }
+
+  /**
+   * Install a persistent recursive watch on the root path.
+   */
+  private void addWatches() {
+    zks.getZKDatabase().addWatch(rootPath, this, ZooDefs.AddWatchModes.persistentRecursive);
+  }
+
+  /**
+   * Read ZNodes under the root path and populates clientUriToDomainNames.
+   * Note: this is not thread-safe nor atomic; however, we do not need such strong guarantee with
+   * this read operation.
+   *
+   * Also, note that this is a purely in-memory operation, so re-parsing the entire tree should not
+   * be a big overhead considering how infrequently the mapping is supposed to be changed.
+   */
+  private void parseZNodeMapping() {
+    clientUriToDomainNames.clear();
+    try {
+      List<String> domainNames = zks.getZKDatabase().getChildren(rootPath, null, null);
+      domainNames.forEach(domainName -> {
+        try {
+          List<String> clientUris =
+              zks.getZKDatabase().getChildren(rootPath + "/" + domainName, null, null);
+          clientUriToDomainNames.put(domainName, clientUris);
+        } catch (KeeperException.NoNodeException e) {
+          LOG.warn(
+              "ZkClientUriDomainMappingHelper::parseZNodeMapping(): No clientUri ZNodes found under domain: {}",
+              domainName);
+        }
+      });
+    } catch (KeeperException.NoNodeException e) {
+      LOG.warn(
+          "ZkClientUriDomainMappingHelper::parseZNodeMapping(): No application domain ZNodes found in root path: {}",
+          rootPath);
+    }
+  }
+
+  @Override
+  public void process(WatchedEvent event) {
+    parseZNodeMapping();
+  }
+
+  @Override
+  public List<String> getDomains(String clientUri) {
+    return clientUriToDomainNames.getOrDefault(clientUri, Collections.emptyList());
+  }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelperTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelperTest.java
@@ -1,0 +1,152 @@
+package org.apache.zookeeper.server.auth.znode.groupacl;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.DummyWatcher;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.ZKTestCase;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.server.ServerCnxn;
+import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.apache.zookeeper.server.ZooKeeperServer;
+import org.apache.zookeeper.test.ClientBase;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class ZkClientUriDomainMappingHelperTest extends ZKTestCase {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ZkClientUriDomainMappingHelperTest.class);
+  private static final String HOSTPORT = "127.0.0.1:" + PortAssignment.unique();
+  private static final String CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH = "/_CLIENT_URI_DOMAIN_MAPPING";
+  private static final int CONNECTION_TIMEOUT = 300000;
+  private static final String[] MAPPING_PATHS = {
+      CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH,
+      CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/bar",
+      CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/bar/bar0",
+      CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/bar/bar1",
+      CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/foo",
+      CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/foo/foo1",
+      CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/foo/foo2",
+      CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/foo/bar1"
+  };
+
+  private ZooKeeperServer zookeeperServer;
+  private ZooKeeper zookeeperClientConnection;
+  private ServerCnxnFactory serverCnxnFactory;
+
+  @Before
+  public void setUp() throws IOException, InterruptedException, KeeperException {
+    System.setProperty("zookeeper.znode.groupacl.clientUriDomainMappingRootPath",
+        CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH);
+
+    LOG.info("Starting Zk...");
+    zookeeperServer = new ZooKeeperServer(testBaseDir, testBaseDir, 3000);
+    final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
+    serverCnxnFactory = ServerCnxnFactory.createFactory(PORT, -1);
+    serverCnxnFactory.startup(zookeeperServer);
+
+    LOG.info("Waiting for server startup");
+    Assert.assertTrue("waiting for server being up ",
+        ClientBase.waitForServerUp(HOSTPORT, CONNECTION_TIMEOUT));
+    zookeeperClientConnection = new ZooKeeper(HOSTPORT, CONNECTION_TIMEOUT, DummyWatcher.INSTANCE);
+  }
+
+  @After
+  public void cleanUp() throws InterruptedException, IOException, KeeperException {
+    // Delete mapping znodes if they exist
+    for (int i = MAPPING_PATHS.length - 1; i >= 0; i--) {
+      if (zookeeperClientConnection.exists(MAPPING_PATHS[i], null) != null) {
+        zookeeperClientConnection.delete(MAPPING_PATHS[i], -1);
+      }
+    }
+
+    System.clearProperty("zookeeper.znode.groupacl.clientUriDomainMappingRootPath");
+
+    if (zookeeperClientConnection != null) {
+      zookeeperClientConnection.close();
+      zookeeperClientConnection = null;
+    }
+    if (serverCnxnFactory != null) {
+      serverCnxnFactory.closeAll(ServerCnxn.DisconnectReason.SERVER_SHUTDOWN);
+      serverCnxnFactory.shutdown();
+      serverCnxnFactory = null;
+    }
+    if (zookeeperServer != null) {
+      zookeeperServer.getZKDatabase().close();
+      zookeeperServer.shutdown();
+      zookeeperServer = null;
+    }
+    Assert.assertTrue("waiting for ZK server to shutdown",
+        ClientBase.waitForServerDown(HOSTPORT, CONNECTION_TIMEOUT));
+  }
+
+  /**
+   * Mapping root path hasn't been created - must throw an exception.
+   */
+  @Test(expected = IllegalStateException.class)
+  public void testA_ZkClientUriDomainMappingHelper() {
+    new ZkClientUriDomainMappingHelper(zookeeperServer);
+  }
+
+  /**
+   * Create a dummy mapping and verify that the helper correctly updates changes to the mapping
+   * stored in ZNodes.
+   *
+   * The following mapping will be used
+   * . (root)
+   * └── _CLIENT_URI_DOMAIN_MAPPING (mapping root path)
+   *     ├── bar (application domain)
+   *     │   ├── bar0 (client URI)
+   *     │   └── bar1 (client URI)
+   *     └── foo (application domain)
+   *         ├── foo1 (client URI)
+   *         ├── foo2 (client URI)
+   *         └── bar1 (client URI)
+   */
+  @Test
+  public void testB_ZkClientUriDomainMappingHelper() throws KeeperException, InterruptedException {
+    for (String path : MAPPING_PATHS) {
+      zookeeperClientConnection
+          .create(path, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+    }
+
+    ClientUriDomainMappingHelper helper = new ZkClientUriDomainMappingHelper(zookeeperServer);
+
+    // For bar0, we should only get foo
+    Assert.assertEquals(Collections.singleton("bar"), helper.getDomains("bar0"));
+
+    // For bar1, we should get bar and foo
+    Assert.assertEquals(new HashSet<>(Arrays.asList("bar", "foo")), helper.getDomains("bar1"));
+
+    // Add a new application domain and add bar1 to it
+    zookeeperClientConnection
+        .create(CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/new", null, ZooDefs.Ids.OPEN_ACL_UNSAFE,
+            CreateMode.PERSISTENT);
+    zookeeperClientConnection.create(CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/new/bar1", null,
+        ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+
+    // For bar1, we should get bar, foo, and new
+    Assert
+        .assertEquals(new HashSet<>(Arrays.asList("bar", "foo", "new")), helper.getDomains("bar1"));
+
+    // Remove the application domain and bar1
+    zookeeperClientConnection.delete(CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/new/bar1", -1);
+    zookeeperClientConnection.delete(CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/new", -1);
+
+    // For bar1, we should get bar and foo
+    Assert.assertEquals(new HashSet<>(Arrays.asList("bar", "foo")), helper.getDomains("bar1"));
+  }
+}


### PR DESCRIPTION
This commit adds a helper class for looking up the domain name for the client connection. It uses the client's Uniform Resource Identifier (URI) to look up the application domain it belongs to. It also implements a ZK-based helper where the mapping is stored within ZKDatabase itself so that the owners can read it from ZK and update as needed.