### PR TITLE
Add a feature to auto-add ACL for authenticated clients

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/X509Util.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/X509Util.java
@@ -162,7 +162,7 @@ public abstract class X509Util implements Closeable, AutoCloseable {
     /**
      * Config properties for ZNode group ACL features
      */
-    private static final String ZNODE_GROUP_ACL_CONFIG_PREFIX = "zookeeper.ssl.znodeGroupAcl.";
+    public static final String ZNODE_GROUP_ACL_CONFIG_PREFIX = "zookeeper.ssl.znodeGroupAcl.";
     // Enables/disables whether znodes created by auth'ed clients
     // should have ACL fields populated with the client Id given by the authentication provider.
     // Has the same effect as the ZK client using ZooDefs.Ids.CREATOR_ALL_ACL.

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/X509Util.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/X509Util.java
@@ -159,6 +159,16 @@ public abstract class X509Util implements Closeable, AutoCloseable {
     private String sslClientAuthProperty = getConfigPrefix() + "clientAuth";
     private String sslHandshakeDetectionTimeoutMillisProperty = getConfigPrefix() + "handshakeDetectionTimeoutMillis";
 
+    /**
+     * Config properties for ZNode group ACL features
+     */
+    private static final String ZNODE_GROUP_ACL_CONFIG_PREFIX = "zookeeper.ssl.znodeGroupAcl.";
+    // Enables/disables whether znodes created by auth'ed clients
+    // should have ACL fields populated with the client Id given by the authentication provider.
+    // Has the same effect as the ZK client using ZooDefs.Ids.CREATOR_ALL_ACL.
+    public static final String SET_X509_CLIENT_ID_AS_ACL =
+        ZNODE_GROUP_ACL_CONFIG_PREFIX + "setX509ClientIdAsAcl";
+
     private ZKConfig zkConfig;
     private AtomicReference<SSLContextAndOptions> defaultSSLContextAndOptions = new AtomicReference<>(null);
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/X509Util.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/X509Util.java
@@ -159,16 +159,6 @@ public abstract class X509Util implements Closeable, AutoCloseable {
     private String sslClientAuthProperty = getConfigPrefix() + "clientAuth";
     private String sslHandshakeDetectionTimeoutMillisProperty = getConfigPrefix() + "handshakeDetectionTimeoutMillis";
 
-    /**
-     * Config properties for ZNode group ACL features
-     */
-    public static final String ZNODE_GROUP_ACL_CONFIG_PREFIX = "zookeeper.ssl.znodeGroupAcl.";
-    // Enables/disables whether znodes created by auth'ed clients
-    // should have ACL fields populated with the client Id given by the authentication provider.
-    // Has the same effect as the ZK client using ZooDefs.Ids.CREATOR_ALL_ACL.
-    public static final String SET_X509_CLIENT_ID_AS_ACL =
-        ZNODE_GROUP_ACL_CONFIG_PREFIX + "setX509ClientIdAsAcl";
-
     private ZKConfig zkConfig;
     private AtomicReference<SSLContextAndOptions> defaultSSLContextAndOptions = new AtomicReference<>(null);
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -42,7 +42,6 @@ import org.apache.zookeeper.MultiOperationRecord;
 import org.apache.zookeeper.Op;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooDefs.OpCode;
-import org.apache.zookeeper.common.ClientX509Util;
 import org.apache.zookeeper.common.PathUtils;
 import org.apache.zookeeper.common.StringUtils;
 import org.apache.zookeeper.common.Time;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -1002,7 +1002,6 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
             throw new KeeperException.InvalidACLException(path);
         }
         List<ACL> rv = new ArrayList<>();
-
         for (ACL a : uniqacls) {
             LOG.debug("Processing ACL: {}", a);
             if (a == null) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclUtil.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.zookeeper.server.auth.znode.groupacl;
+
+/**
+ * Util class for ZNode Group ACL. Contains util methods and constants.
+ */
+public class ZNodeGroupAclUtil {
+
+  /**
+   * Property key values (JVM configs) for ZNode group ACL features
+   */
+  public static final String ZNODE_GROUP_ACL_CONFIG_PREFIX = "zookeeper.ssl.znodeGroupAcl.";
+  // Enables/disables whether znodes created by auth'ed clients
+  // should have ACL fields populated with the client Id given by the authentication provider.
+  // Has the same effect as the ZK client using ZooDefs.Ids.CREATOR_ALL_ACL.
+  public static final String SET_X509_CLIENT_ID_AS_ACL =
+      ZNODE_GROUP_ACL_CONFIG_PREFIX + "setX509ClientIdAsAcl";
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
@@ -29,6 +29,7 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.common.X509Util;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,7 +61,7 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
   private static final Logger LOG = LoggerFactory.getLogger(ZkClientUriDomainMappingHelper.class);
 
   private static final String CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH =
-      "zookeeper.ssl.znodeGroupAcl.clientUriDomainMappingRootPath";
+      X509Util.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath";
 
   private final ZooKeeperServer zks;
   private final String rootPath;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
@@ -60,7 +60,7 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
   private static final Logger LOG = LoggerFactory.getLogger(ZkClientUriDomainMappingHelper.class);
 
   private static final String CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH =
-      "zookeeper.znode.groupacl.clientUriDomainMappingRootPath";
+      "zookeeper.ssl.znodeGroupAcl.clientUriDomainMappingRootPath";
 
   private final ZooKeeperServer zks;
   private final String rootPath;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
@@ -61,7 +61,7 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
   private static final Logger LOG = LoggerFactory.getLogger(ZkClientUriDomainMappingHelper.class);
 
   private static final String CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH =
-      X509Util.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath";
+      ZNodeGroupAclUtil.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath";
 
   private final ZooKeeperServer zks;
   private final String rootPath;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -44,10 +44,10 @@ import org.apache.zookeeper.common.AtomicFileWritingIdiom.WriterStatement;
 import org.apache.zookeeper.common.ClientX509Util;
 import org.apache.zookeeper.common.PathUtils;
 import org.apache.zookeeper.common.StringUtils;
-import org.apache.zookeeper.common.X509Util;
 import org.apache.zookeeper.metrics.impl.DefaultMetricsProvider;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.apache.zookeeper.server.auth.ProviderRegistry;
+import org.apache.zookeeper.server.auth.znode.groupacl.ZNodeGroupAclUtil;
 import org.apache.zookeeper.server.backup.BackupConfig;
 import org.apache.zookeeper.server.backup.BackupSystemProperty;
 import org.apache.zookeeper.server.quorum.QuorumPeer.LearnerType;
@@ -120,7 +120,7 @@ public class QuorumPeerConfig {
      * should have ACL fields populated with the client Id given by the authentication provider.
      * Has the same effect as the ZK client using ZooDefs.Ids.CREATOR_ALL_ACL.
      */
-    private static boolean x509ClientIdAsAclEnabled = false;
+    private static boolean setX509ClientIdAsAclEnabled = false;
 
     protected String initialConfig;
 
@@ -386,10 +386,10 @@ public class QuorumPeerConfig {
                 backupConfigBuilder.setTimetableStoragePath(value);
             } else if (key.equals(BackupSystemProperty.BACKUP_TIMETABLE_BACKUP_INTERVAL_MS)) {
                 backupConfigBuilder.setTimetableBackupIntervalInMs(Long.parseLong(value));
-            } else if (key.equals(X509Util.SET_X509_CLIENT_ID_AS_ACL)) {
+            } else if (key.equals(ZNodeGroupAclUtil.SET_X509_CLIENT_ID_AS_ACL)) {
                 // Allow both option of setting it in zoo.cfg and as a JVM argument
                 setSetX509ClientIdAsAclEnabled(Boolean.parseBoolean(value) || Boolean
-                    .getBoolean(X509Util.SET_X509_CLIENT_ID_AS_ACL));
+                    .getBoolean(ZNodeGroupAclUtil.SET_X509_CLIENT_ID_AS_ACL));
             } else if (key.equals("standaloneEnabled")) {
                 if (value.toLowerCase().equals("true")) {
                     setStandaloneEnabled(true);
@@ -1033,10 +1033,10 @@ public class QuorumPeerConfig {
     }
 
     public static boolean isSetX509ClientIdAsAclEnabled() {
-        return x509ClientIdAsAclEnabled;
+        return setX509ClientIdAsAclEnabled;
     }
 
     public static void setSetX509ClientIdAsAclEnabled(boolean enabled) {
-        x509ClientIdAsAclEnabled = enabled;
+        setX509ClientIdAsAclEnabled = enabled;
     }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -44,6 +44,7 @@ import org.apache.zookeeper.common.AtomicFileWritingIdiom.WriterStatement;
 import org.apache.zookeeper.common.ClientX509Util;
 import org.apache.zookeeper.common.PathUtils;
 import org.apache.zookeeper.common.StringUtils;
+import org.apache.zookeeper.common.X509Util;
 import org.apache.zookeeper.metrics.impl.DefaultMetricsProvider;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.apache.zookeeper.server.auth.ProviderRegistry;
@@ -112,6 +113,14 @@ public class QuorumPeerConfig {
     protected boolean backupEnabled = false;
     protected BackupConfig backupConfig;
     protected BackupConfig.Builder backupConfigBuilder = new BackupConfig.Builder();
+
+    // ZooKeeper server-side ZNode group ACL feature
+    /**
+     * x509ClientIdAsAclEnabled enables/disables whether znodes created by auth'ed clients
+     * should have ACL fields populated with the client Id given by the authentication provider.
+     * Has the same effect as the ZK client using ZooDefs.Ids.CREATOR_ALL_ACL.
+     */
+    private static boolean x509ClientIdAsAclEnabled = false;
 
     protected String initialConfig;
 
@@ -377,6 +386,10 @@ public class QuorumPeerConfig {
                 backupConfigBuilder.setTimetableStoragePath(value);
             } else if (key.equals(BackupSystemProperty.BACKUP_TIMETABLE_BACKUP_INTERVAL_MS)) {
                 backupConfigBuilder.setTimetableBackupIntervalInMs(Long.parseLong(value));
+            } else if (key.equals(X509Util.SET_X509_CLIENT_ID_AS_ACL)) {
+                // Allow both option of setting it in zoo.cfg and as a JVM argument
+                setSetX509ClientIdAsAclEnabled(Boolean.parseBoolean(value) || Boolean
+                    .getBoolean(X509Util.SET_X509_CLIENT_ID_AS_ACL));
             } else if (key.equals("standaloneEnabled")) {
                 if (value.toLowerCase().equals("true")) {
                     setStandaloneEnabled(true);
@@ -1017,5 +1030,13 @@ public class QuorumPeerConfig {
 
     public BackupConfig getBackupConfig() {
         return backupConfig;
+    }
+
+    public static boolean isSetX509ClientIdAsAclEnabled() {
+        return x509ClientIdAsAclEnabled;
+    }
+
+    public static void setSetX509ClientIdAsAclEnabled(boolean enabled) {
+        x509ClientIdAsAclEnabled = enabled;
     }
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelperTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelperTest.java
@@ -30,6 +30,7 @@ import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.common.X509Util;
 import org.apache.zookeeper.server.ServerCnxn;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.ZooKeeperServer;
@@ -67,7 +68,7 @@ public class ZkClientUriDomainMappingHelperTest extends ZKTestCase {
 
   @Before
   public void setUp() throws IOException, InterruptedException, KeeperException {
-    System.setProperty("zookeeper.ssl.znodeGroupAcl.clientUriDomainMappingRootPath",
+    System.setProperty(X509Util.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath",
         CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH);
 
     LOG.info("Starting Zk...");
@@ -91,7 +92,7 @@ public class ZkClientUriDomainMappingHelperTest extends ZKTestCase {
       }
     }
 
-    System.clearProperty("zookeeper.ssl.znodeGroupAcl.clientUriDomainMappingRootPath");
+    System.clearProperty(X509Util.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath");
 
     if (zookeeperClientConnection != null) {
       zookeeperClientConnection.close();

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelperTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelperTest.java
@@ -30,7 +30,6 @@ import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
-import org.apache.zookeeper.common.X509Util;
 import org.apache.zookeeper.server.ServerCnxn;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.ZooKeeperServer;
@@ -68,7 +67,8 @@ public class ZkClientUriDomainMappingHelperTest extends ZKTestCase {
 
   @Before
   public void setUp() throws IOException, InterruptedException, KeeperException {
-    System.setProperty(X509Util.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath",
+    System.setProperty(
+        ZNodeGroupAclUtil.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath",
         CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH);
 
     LOG.info("Starting Zk...");
@@ -92,7 +92,8 @@ public class ZkClientUriDomainMappingHelperTest extends ZKTestCase {
       }
     }
 
-    System.clearProperty(X509Util.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath");
+    System.clearProperty(
+        ZNodeGroupAclUtil.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath");
 
     if (zookeeperClientConnection != null) {
       zookeeperClientConnection.close();

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelperTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelperTest.java
@@ -49,7 +49,7 @@ public class ZkClientUriDomainMappingHelperTest extends ZKTestCase {
 
   @Before
   public void setUp() throws IOException, InterruptedException, KeeperException {
-    System.setProperty("zookeeper.znode.groupacl.clientUriDomainMappingRootPath",
+    System.setProperty("zookeeper.ssl.znodeGroupAcl.clientUriDomainMappingRootPath",
         CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH);
 
     LOG.info("Starting Zk...");
@@ -73,7 +73,7 @@ public class ZkClientUriDomainMappingHelperTest extends ZKTestCase {
       }
     }
 
-    System.clearProperty("zookeeper.znode.groupacl.clientUriDomainMappingRootPath");
+    System.clearProperty("zookeeper.ssl.znodeGroupAcl.clientUriDomainMappingRootPath");
 
     if (zookeeperClientConnection != null) {
       zookeeperClientConnection.close();

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelperTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelperTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.zookeeper.server.auth.znode.groupacl;
 
 import java.io.IOException;


### PR DESCRIPTION
For znode group acl, the znodes created by authenticated clients will almost always be given the acl with a scheme x509 and their "owner" client Id (resolved in the authentication provider). This feature allows these znodes to be created with that scheme on the server-side if enabled, so that the clients do not have to explicitly set it using ZooDefs.Ids.CREATOR_ALL_ACL.

Note that this feature has been tested by locally deploying a server with the JVM flag set to `true`. Since this is an existing feature and this commit simply adds a new config, no explicit unit test was added to the codebase.