### PR TITLE
Add custom authenticator X509ZNodeGroupAclProvider

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/ClientX509Util.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/ClientX509Util.java
@@ -18,33 +18,9 @@
 
 package org.apache.zookeeper.common;
 
-import java.security.cert.CertificateParsingException;
-import java.security.cert.X509Certificate;
-import java.util.Collection;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class ClientX509Util extends X509Util {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ClientX509Util.class);
     private final String sslAuthProviderProperty = getConfigPrefix() + "authProvider";
-    /**
-     * The following System Property keys are used to extract clientId from the client cert.
-     * @see #getClientId(X509Certificate)
-     */
-    public final String sslClientCertIdType = getConfigPrefix() + "clientCertIdType";
-    public final String sslClientCertIdSanMatchType = getConfigPrefix() + "clientCertIdSanMatchType";
-    // Match Regex is used to choose which entry to use
-    public final String sslClientCertIdSanMatchRegex = getConfigPrefix() + "clientCertIdSanMatchRegex";
-    // Extract Regex is used to construct a client ID (acl entity) to return
-    public final String sslClientCertIdSanExtractRegex = getConfigPrefix() + "clientCertIdSanExtractRegex";
-    // Specifies match group index for the extract regex (i in Matcher.group(i))
-    public final String sslClientCertIdSanExtractMatcherGroupIndex = getConfigPrefix() + "clientCertIdSanExtractMatcherGroupIndex";
 
     @Override
     protected String getConfigPrefix() {
@@ -59,95 +35,5 @@ public class ClientX509Util extends X509Util {
     public String getSslAuthProviderProperty() {
         return sslAuthProviderProperty;
     }
-    /**
-     * Determine the string to be used as the remote host session Id for
-     * authorization purposes. Associate this client identifier with a
-     * ServerCnxn that has been authenticated over SSL, and any ACLs that refer
-     * to the authenticated client.
-     *
-     * @param clientCert Authenticated X509Certificate associated with the
-     *                   remote host.
-     * @return Identifier string to be associated with the client.
-     */
-    public String getClientId(X509Certificate clientCert) {
-        String clientCertIdType =
-            System.getProperty(sslClientCertIdType);
-        if (clientCertIdType != null && clientCertIdType.equalsIgnoreCase("SAN")) {
-            try {
-                return matchAndExtractSAN(clientCert);
-            } catch (Exception ce) {
-                LOG.warn("X509AuthenticationProvider::getClientId(): failed to match and extract a"
-                    + " client ID from SAN! Using Subject DN instead...", ce);
-            }
-        }
-        // return Subject DN by default
-        return clientCert.getSubjectX500Principal().getName();
-    }
 
-    private String matchAndExtractSAN(X509Certificate clientCert)
-        throws CertificateParsingException {
-        Integer matchType =
-            Integer.getInteger(sslClientCertIdSanMatchType);
-        String matchRegex =
-            System.getProperty(sslClientCertIdSanMatchRegex);
-        String extractRegex =
-            System.getProperty(sslClientCertIdSanExtractRegex);
-        Integer extractMatcherGroupIndex = Integer.getInteger(
-            sslClientCertIdSanExtractMatcherGroupIndex);
-        LOG.info("X509AuthenticationProvider::matchAndExtractSAN(): Using SAN in the client cert "
-                + "for client ID! matchType: {}, matchRegex: {}, extractRegex: {}, "
-                + "extractMatcherGroupIndex: {}", matchType, matchRegex, extractRegex,
-            extractMatcherGroupIndex);
-        if (matchType == null || matchRegex == null || extractRegex == null || matchType < 0
-            || matchType > 8) {
-            // SAN extension must be in the range of [0, 8].
-            // See GeneralName object defined in RFC 5280 (The ASN.1 definition of the
-            // SubjectAltName extension)
-            String errStr = "X509AuthenticationProvider::matchAndExtractSAN(): ClientCert ID type "
-                + "SAN was provided but matchType or matchRegex given is invalid! matchType: "
-                + matchType + " matchRegex: " + matchRegex;
-            LOG.error(errStr);
-            throw new IllegalArgumentException(errStr);
-        }
-        // filter by match type and match regex
-        LOG.info("X509AuthenticationProvider::matchAndExtractSAN(): number of SAN entries found in"
-            + " clientCert: " + clientCert.getSubjectAlternativeNames().size());
-        Pattern matchPattern = Pattern.compile(matchRegex);
-        Collection<List<?>> matched = clientCert.getSubjectAlternativeNames().stream().filter(
-            list -> list.get(0).equals(matchType) && matchPattern
-                .matcher((CharSequence) list.get(1)).find()).collect(Collectors.toList());
-
-        LOG.info(
-            "X509AuthenticationProvider::matchAndExtractSAN(): number of SAN entries matched: "
-                + matched.size() + ". Printing all matches...");
-        for (List<?> match : matched) {
-            LOG.info("  Match: (" + match.get(0) + ", " + match.get(1) + ")");
-        }
-
-        // if there are more than one match or 0 matches, throw an error
-        if (matched.size() != 1) {
-            String errStr = "X509AuthenticationProvider::matchAndExtractSAN(): 0 or multiple "
-                + "matches found in SAN! Please fix match type and regex so that exactly one match "
-                + "is found.";
-            LOG.error(errStr);
-            throw new IllegalArgumentException(errStr);
-        }
-
-        // Extract a substring from the found match using extractRegex
-        Pattern extractPattern = Pattern.compile(extractRegex);
-        Matcher matcher = extractPattern.matcher(matched.iterator().next().get(1).toString());
-        if (matcher.find()) {
-            // If extractMatcherGroupIndex is not given, return the 1st index by default
-            extractMatcherGroupIndex =
-                extractMatcherGroupIndex == null ? 1 : extractMatcherGroupIndex;
-            String result = matcher.group(extractMatcherGroupIndex);
-            LOG.info("X509AuthenticationProvider::matchAndExtractSAN(): returning extracted "
-                + "client ID: {} using Matcher group index: {}", result, extractMatcherGroupIndex);
-            return result;
-        }
-        String errStr = "X509AuthenticationProvider::matchAndExtractSAN(): failed to find an "
-            + "extract substring! Please review the extract regex!";
-        LOG.error(errStr);
-        throw new IllegalArgumentException(errStr);
-    }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/ClientX509Util.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/ClientX509Util.java
@@ -18,9 +18,33 @@
 
 package org.apache.zookeeper.common;
 
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class ClientX509Util extends X509Util {
 
+    private static final Logger LOG = LoggerFactory.getLogger(ClientX509Util.class);
     private final String sslAuthProviderProperty = getConfigPrefix() + "authProvider";
+    /**
+     * The following System Property keys are used to extract clientId from the client cert.
+     * @see #getClientId(X509Certificate)
+     */
+    public final String sslClientCertIdType = getConfigPrefix() + "clientCertIdType";
+    public final String sslClientCertIdSanMatchType = getConfigPrefix() + "clientCertIdSanMatchType";
+    // Match Regex is used to choose which entry to use
+    public final String sslClientCertIdSanMatchRegex = getConfigPrefix() + "clientCertIdSanMatchRegex";
+    // Extract Regex is used to construct a client ID (acl entity) to return
+    public final String sslClientCertIdSanExtractRegex = getConfigPrefix() + "clientCertIdSanExtractRegex";
+    // Specifies match group index for the extract regex (i in Matcher.group(i))
+    public final String sslClientCertIdSanExtractMatcherGroupIndex = getConfigPrefix() + "clientCertIdSanExtractMatcherGroupIndex";
 
     @Override
     protected String getConfigPrefix() {
@@ -35,5 +59,95 @@ public class ClientX509Util extends X509Util {
     public String getSslAuthProviderProperty() {
         return sslAuthProviderProperty;
     }
+    /**
+     * Determine the string to be used as the remote host session Id for
+     * authorization purposes. Associate this client identifier with a
+     * ServerCnxn that has been authenticated over SSL, and any ACLs that refer
+     * to the authenticated client.
+     *
+     * @param clientCert Authenticated X509Certificate associated with the
+     *                   remote host.
+     * @return Identifier string to be associated with the client.
+     */
+    public String getClientId(X509Certificate clientCert) {
+        String clientCertIdType =
+            System.getProperty(sslClientCertIdType);
+        if (clientCertIdType != null && clientCertIdType.equalsIgnoreCase("SAN")) {
+            try {
+                return matchAndExtractSAN(clientCert);
+            } catch (Exception ce) {
+                LOG.warn("X509AuthenticationProvider::getClientId(): failed to match and extract a"
+                    + " client ID from SAN! Using Subject DN instead...", ce);
+            }
+        }
+        // return Subject DN by default
+        return clientCert.getSubjectX500Principal().getName();
+    }
 
+    private String matchAndExtractSAN(X509Certificate clientCert)
+        throws CertificateParsingException {
+        Integer matchType =
+            Integer.getInteger(sslClientCertIdSanMatchType);
+        String matchRegex =
+            System.getProperty(sslClientCertIdSanMatchRegex);
+        String extractRegex =
+            System.getProperty(sslClientCertIdSanExtractRegex);
+        Integer extractMatcherGroupIndex = Integer.getInteger(
+            sslClientCertIdSanExtractMatcherGroupIndex);
+        LOG.info("X509AuthenticationProvider::matchAndExtractSAN(): Using SAN in the client cert "
+                + "for client ID! matchType: {}, matchRegex: {}, extractRegex: {}, "
+                + "extractMatcherGroupIndex: {}", matchType, matchRegex, extractRegex,
+            extractMatcherGroupIndex);
+        if (matchType == null || matchRegex == null || extractRegex == null || matchType < 0
+            || matchType > 8) {
+            // SAN extension must be in the range of [0, 8].
+            // See GeneralName object defined in RFC 5280 (The ASN.1 definition of the
+            // SubjectAltName extension)
+            String errStr = "X509AuthenticationProvider::matchAndExtractSAN(): ClientCert ID type "
+                + "SAN was provided but matchType or matchRegex given is invalid! matchType: "
+                + matchType + " matchRegex: " + matchRegex;
+            LOG.error(errStr);
+            throw new IllegalArgumentException(errStr);
+        }
+        // filter by match type and match regex
+        LOG.info("X509AuthenticationProvider::matchAndExtractSAN(): number of SAN entries found in"
+            + " clientCert: " + clientCert.getSubjectAlternativeNames().size());
+        Pattern matchPattern = Pattern.compile(matchRegex);
+        Collection<List<?>> matched = clientCert.getSubjectAlternativeNames().stream().filter(
+            list -> list.get(0).equals(matchType) && matchPattern
+                .matcher((CharSequence) list.get(1)).find()).collect(Collectors.toList());
+
+        LOG.info(
+            "X509AuthenticationProvider::matchAndExtractSAN(): number of SAN entries matched: "
+                + matched.size() + ". Printing all matches...");
+        for (List<?> match : matched) {
+            LOG.info("  Match: (" + match.get(0) + ", " + match.get(1) + ")");
+        }
+
+        // if there are more than one match or 0 matches, throw an error
+        if (matched.size() != 1) {
+            String errStr = "X509AuthenticationProvider::matchAndExtractSAN(): 0 or multiple "
+                + "matches found in SAN! Please fix match type and regex so that exactly one match "
+                + "is found.";
+            LOG.error(errStr);
+            throw new IllegalArgumentException(errStr);
+        }
+
+        // Extract a substring from the found match using extractRegex
+        Pattern extractPattern = Pattern.compile(extractRegex);
+        Matcher matcher = extractPattern.matcher(matched.iterator().next().get(1).toString());
+        if (matcher.find()) {
+            // If extractMatcherGroupIndex is not given, return the 1st index by default
+            extractMatcherGroupIndex =
+                extractMatcherGroupIndex == null ? 1 : extractMatcherGroupIndex;
+            String result = matcher.group(extractMatcherGroupIndex);
+            LOG.info("X509AuthenticationProvider::matchAndExtractSAN(): returning extracted "
+                + "client ID: {} using Matcher group index: {}", result, extractMatcherGroupIndex);
+            return result;
+        }
+        String errStr = "X509AuthenticationProvider::matchAndExtractSAN(): failed to find an "
+            + "extract substring! Please review the extract regex!";
+        LOG.error(errStr);
+        throw new IllegalArgumentException(errStr);
+    }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -1028,7 +1028,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
                         rv.add(new ACL(a.getPerms(), cid));
                     }
                 }
-                // If the znode path contains open read access node path prefix, add (world:anyone, r) in addition
+                // If the znode path contains open read access node path prefix, add (world:anyone, r)
                 if (ZNodeGroupAclProperties.getInstance().getOpenReadAccessPathPrefixes().stream()
                     .anyMatch(path::startsWith)) {
                     rv.add(new ACL(ZooDefs.Perms.READ, ZooDefs.Ids.ANYONE_ID_UNSAFE));

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -59,6 +60,7 @@ import org.apache.zookeeper.server.ZooKeeperServer.ChangeRecord;
 import org.apache.zookeeper.server.ZooKeeperServer.PrecalculatedDigest;
 import org.apache.zookeeper.server.auth.ProviderRegistry;
 import org.apache.zookeeper.server.auth.ServerAuthenticationProvider;
+import org.apache.zookeeper.server.auth.znode.groupacl.ZNodeGroupAclUtil;
 import org.apache.zookeeper.server.quorum.LeaderZooKeeperServer;
 import org.apache.zookeeper.server.quorum.QuorumPeer.QuorumServer;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -1027,6 +1029,10 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
                         rv.add(new ACL(a.getPerms(), cid));
                     }
                 }
+                if (Arrays.stream(ZNodeGroupAclUtil.getOpenReadAccessPathPrefixes()).anyMatch(path::contains)) {
+                    rv.add(new ACL(ZooDefs.Perms.READ, ZooDefs.Ids.ANYONE_ID_UNSAFE));
+                };
+
                 if (!authIdValid) {
                     throw new KeeperException.InvalidACLException(path);
                 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
+
 import org.apache.jute.BinaryOutputArchive;
 import org.apache.jute.Record;
 import org.apache.zookeeper.CreateMode;
@@ -1029,8 +1030,8 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
                     }
                 }
                 // If the znode path contains open read access node path prefix, add (world:anyone, r) in addition
-                ZNodeGroupAclProperties zNodeGroupAclProperties = ZNodeGroupAclProperties.getInstance();
-                if (zNodeGroupAclProperties.getOpenReadAccessPathPrefixes().stream().anyMatch(path::contains)) {
+                if (ZNodeGroupAclProperties.getInstance().getOpenReadAccessPathPrefixes().stream()
+                    .anyMatch(path::contains)) {
                     rv.add(new ACL(ZooDefs.Perms.READ, ZooDefs.Ids.ANYONE_ID_UNSAFE));
                 }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -1030,9 +1029,9 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
                     }
                 }
                 // If the znode path contains open read access node path prefix, add (world:anyone, r) in addition
-                if (Arrays.stream(ZNodeGroupAclUtil.getOpenReadAccessPathPrefixes()).anyMatch(path::startsWith)) {
+                if (ZNodeGroupAclUtil.getOpenReadAccessPathPrefixes().stream().anyMatch(path::contains)) {
                     rv.add(new ACL(ZooDefs.Perms.READ, ZooDefs.Ids.ANYONE_ID_UNSAFE));
-                };
+                }
 
                 if (!authIdValid) {
                     throw new KeeperException.InvalidACLException(path);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -59,7 +59,7 @@ import org.apache.zookeeper.server.ZooKeeperServer.ChangeRecord;
 import org.apache.zookeeper.server.ZooKeeperServer.PrecalculatedDigest;
 import org.apache.zookeeper.server.auth.ProviderRegistry;
 import org.apache.zookeeper.server.auth.ServerAuthenticationProvider;
-import org.apache.zookeeper.server.auth.znode.groupacl.ZNodeGroupAclUtil;
+import org.apache.zookeeper.server.auth.znode.groupacl.ZNodeGroupAclProperties;
 import org.apache.zookeeper.server.quorum.LeaderZooKeeperServer;
 import org.apache.zookeeper.server.quorum.QuorumPeer.QuorumServer;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -1029,7 +1029,8 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
                     }
                 }
                 // If the znode path contains open read access node path prefix, add (world:anyone, r) in addition
-                if (ZNodeGroupAclUtil.getOpenReadAccessPathPrefixes().stream().anyMatch(path::contains)) {
+                ZNodeGroupAclProperties zNodeGroupAclProperties = ZNodeGroupAclProperties.getInstance();
+                if (zNodeGroupAclProperties.getOpenReadAccessPathPrefixes().stream().anyMatch(path::contains)) {
                     rv.add(new ACL(ZooDefs.Perms.READ, ZooDefs.Ids.ANYONE_ID_UNSAFE));
                 }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -1029,7 +1029,8 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
                         rv.add(new ACL(a.getPerms(), cid));
                     }
                 }
-                if (Arrays.stream(ZNodeGroupAclUtil.getOpenReadAccessPathPrefixes()).anyMatch(path::contains)) {
+                // If the znode path contains open read access node path prefix, add (world:anyone, r) in addition
+                if (Arrays.stream(ZNodeGroupAclUtil.getOpenReadAccessPathPrefixes()).anyMatch(path::startsWith)) {
                     rv.add(new ACL(ZooDefs.Perms.READ, ZooDefs.Ids.ANYONE_ID_UNSAFE));
                 };
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
-
 import org.apache.jute.BinaryOutputArchive;
 import org.apache.jute.Record;
 import org.apache.zookeeper.CreateMode;
@@ -1031,7 +1030,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
                 }
                 // If the znode path contains open read access node path prefix, add (world:anyone, r) in addition
                 if (ZNodeGroupAclProperties.getInstance().getOpenReadAccessPathPrefixes().stream()
-                    .anyMatch(path::contains)) {
+                    .anyMatch(path::startsWith)) {
                     rv.add(new ACL(ZooDefs.Perms.READ, ZooDefs.Ids.ANYONE_ID_UNSAFE));
                 }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
@@ -19,13 +19,7 @@
 package org.apache.zookeeper.server.auth;
 
 import java.security.cert.CertificateException;
-import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
-import java.util.Collection;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 import javax.security.auth.x500.X500Principal;
@@ -55,19 +49,7 @@ import org.slf4j.LoggerFactory;
  */
 public class X509AuthenticationProvider implements AuthenticationProvider {
 
-    static final String ZOOKEEPER_X509AUTHENTICATIONPROVIDER_SUPERUSER = "zookeeper.X509AuthenticationProvider.superUser";
-    /**
-     * The following System Property keys are used to extract clientId from the client cert.
-     * @see #getClientId(X509Certificate)
-     */
-    public static final String ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_TYPE = "zookeeper.X509AuthenticationProvider.clientCertIdType";
-    public static final String ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_MATCH_TYPE = "zookeeper.X509AuthenticationProvider.clientCertIdSanMatchType";
-    // Match Regex is used to choose which entry to use
-    public static final String ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_MATCH_REGEX = "zookeeper.X509AuthenticationProvider.clientCertIdSanMatchRegex";
-    // Extract Regex is used to construct a client ID (acl entity) to return
-    public static final String ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_EXTRACT_REGEX = "zookeeper.X509AuthenticationProvider.clientCertIdSanExtractRegex";
-    // Specifies match group index for the extract regex (i in Matcher.group(i))
-    public static final String ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_EXTRACT_MATCHER_GROUP_INDEX = "zookeeper.X509AuthenticationProvider.clientCertIdSanExtractMatcherGroupIndex";
+    public static final String ZOOKEEPER_X509AUTHENTICATIONPROVIDER_SUPERUSER = "zookeeper.X509AuthenticationProvider.superUser";
 
     static final Logger LOG = LoggerFactory.getLogger(X509AuthenticationProvider.class);
     private final X509TrustManager trustManager;
@@ -171,7 +153,8 @@ public class X509AuthenticationProvider implements AuthenticationProvider {
             return KeeperException.Code.AUTHFAILED;
         }
 
-        String clientId = getClientId(clientCert);
+        ClientX509Util x509Util = new ClientX509Util();
+        String clientId = x509Util.getClientId(clientCert);
 
         if (clientId.equals(System.getProperty(ZOOKEEPER_X509AUTHENTICATIONPROVIDER_SUPERUSER))) {
             cnxn.addAuthInfo(new Id("super", clientId));
@@ -185,98 +168,6 @@ public class X509AuthenticationProvider implements AuthenticationProvider {
         return KeeperException.Code.OK;
     }
 
-    /**
-     * Determine the string to be used as the remote host session Id for
-     * authorization purposes. Associate this client identifier with a
-     * ServerCnxn that has been authenticated over SSL, and any ACLs that refer
-     * to the authenticated client.
-     *
-     * @param clientCert Authenticated X509Certificate associated with the
-     *                   remote host.
-     * @return Identifier string to be associated with the client.
-     */
-    protected String getClientId(X509Certificate clientCert) {
-        String clientCertIdType =
-            System.getProperty(ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_TYPE);
-        if (clientCertIdType != null && clientCertIdType.equalsIgnoreCase("SAN")) {
-            try {
-                return matchAndExtractSAN(clientCert);
-            } catch (Exception ce) {
-                LOG.warn("X509AuthenticationProvider::getClientId(): failed to match and extract a"
-                    + " client ID from SAN! Using Subject DN instead...", ce);
-            }
-        }
-        // return Subject DN by default
-        return clientCert.getSubjectX500Principal().getName();
-    }
-
-    private String matchAndExtractSAN(X509Certificate clientCert)
-        throws CertificateParsingException {
-        Integer matchType =
-            Integer.getInteger(ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_MATCH_TYPE);
-        String matchRegex =
-            System.getProperty(ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_MATCH_REGEX);
-        String extractRegex =
-            System.getProperty(
-                ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_EXTRACT_REGEX);
-        Integer extractMatcherGroupIndex = Integer.getInteger(
-            ZOOKEEPER_X509AUTHENTICATIONPROVIDER_CLIENT_CERT_ID_SAN_EXTRACT_MATCHER_GROUP_INDEX);
-        LOG.info("X509AuthenticationProvider::matchAndExtractSAN(): Using SAN in the client cert "
-                + "for client ID! matchType: {}, matchRegex: {}, extractRegex: {}, "
-                + "extractMatcherGroupIndex: {}", matchType, matchRegex, extractRegex,
-            extractMatcherGroupIndex);
-        if (matchType == null || matchRegex == null || extractRegex == null || matchType < 0
-            || matchType > 8) {
-            // SAN extension must be in the range of [0, 8].
-            // See GeneralName object defined in RFC 5280 (The ASN.1 definition of the
-            // SubjectAltName extension)
-            String errStr = "X509AuthenticationProvider::matchAndExtractSAN(): ClientCert ID type "
-                + "SAN was provided but matchType or matchRegex given is invalid! matchType: "
-                + matchType + " matchRegex: " + matchRegex;
-            LOG.error(errStr);
-            throw new IllegalArgumentException(errStr);
-        }
-        // filter by match type and match regex
-        LOG.info("X509AuthenticationProvider::matchAndExtractSAN(): number of SAN entries found in"
-            + " clientCert: " + clientCert.getSubjectAlternativeNames().size());
-        Pattern matchPattern = Pattern.compile(matchRegex);
-        Collection<List<?>> matched = clientCert.getSubjectAlternativeNames().stream().filter(
-            list -> list.get(0).equals(matchType) && matchPattern
-                .matcher((CharSequence) list.get(1)).find()).collect(Collectors.toList());
-
-        LOG.info(
-            "X509AuthenticationProvider::matchAndExtractSAN(): number of SAN entries matched: "
-                + matched.size() + ". Printing all matches...");
-        for (List<?> match : matched) {
-            LOG.info("  Match: (" + match.get(0) + ", " + match.get(1) + ")");
-        }
-
-        // if there are more than one match or 0 matches, throw an error
-        if (matched.size() != 1) {
-            String errStr = "X509AuthenticationProvider::matchAndExtractSAN(): 0 or multiple "
-                + "matches found in SAN! Please fix match type and regex so that exactly one match "
-                + "is found.";
-            LOG.error(errStr);
-            throw new IllegalArgumentException(errStr);
-        }
-
-        // Extract a substring from the found match using extractRegex
-        Pattern extractPattern = Pattern.compile(extractRegex);
-        Matcher matcher = extractPattern.matcher(matched.iterator().next().get(1).toString());
-        if (matcher.find()) {
-            // If extractMatcherGroupIndex is not given, return the 1st index by default
-            extractMatcherGroupIndex =
-                extractMatcherGroupIndex == null ? 1 : extractMatcherGroupIndex;
-            String result = matcher.group(extractMatcherGroupIndex);
-            LOG.info("X509AuthenticationProvider::matchAndExtractSAN(): returning extracted "
-                + "client ID: {} using Matcher group index: {}", result, extractMatcherGroupIndex);
-            return result;
-        }
-        String errStr = "X509AuthenticationProvider::matchAndExtractSAN(): failed to find an "
-            + "extract substring! Please review the extract regex!";
-        LOG.error(errStr);
-        throw new IllegalArgumentException(errStr);
-    }
 
     @Override
     public boolean matches(String id, String aclExpr) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
@@ -24,14 +24,11 @@ import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 import javax.security.auth.x500.X500Principal;
 import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.common.ClientX509Util;
 import org.apache.zookeeper.common.X509Exception.KeyManagerException;
 import org.apache.zookeeper.common.X509Exception.TrustManagerException;
-import org.apache.zookeeper.common.X509Util;
 import org.apache.zookeeper.common.ZKConfig;
 import org.apache.zookeeper.data.Id;
 import org.apache.zookeeper.server.ServerCnxn;
-import org.apache.zookeeper.server.auth.znode.groupacl.ZNodeGroupAclUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
@@ -31,6 +31,7 @@ import org.apache.zookeeper.common.X509Util;
 import org.apache.zookeeper.common.ZKConfig;
 import org.apache.zookeeper.data.Id;
 import org.apache.zookeeper.server.ServerCnxn;
+import org.apache.zookeeper.server.auth.znode.groupacl.ZNodeGroupAclUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +50,7 @@ import org.slf4j.LoggerFactory;
  */
 public class X509AuthenticationProvider implements AuthenticationProvider {
 
-    public static final String ZOOKEEPER_X509AUTHENTICATIONPROVIDER_SUPERUSER = "zookeeper.X509AuthenticationProvider.superUser";
+    static final String ZOOKEEPER_X509AUTHENTICATIONPROVIDER_SUPERUSER = "zookeeper.X509AuthenticationProvider.superUser";
 
     static final Logger LOG = LoggerFactory.getLogger(X509AuthenticationProvider.class);
     private final X509TrustManager trustManager;
@@ -65,50 +66,8 @@ public class X509AuthenticationProvider implements AuthenticationProvider {
      */
     public X509AuthenticationProvider() {
         ZKConfig config = new ZKConfig();
-        try (X509Util x509Util = new ClientX509Util()) {
-            String keyStoreLocation = config.getProperty(x509Util.getSslKeystoreLocationProperty(), "");
-            String keyStorePassword = config.getProperty(x509Util.getSslKeystorePasswdProperty(), "");
-            String keyStoreTypeProp = config.getProperty(x509Util.getSslKeystoreTypeProperty());
-
-            boolean crlEnabled = Boolean.parseBoolean(config.getProperty(x509Util.getSslCrlEnabledProperty()));
-            boolean ocspEnabled = Boolean.parseBoolean(config.getProperty(x509Util.getSslOcspEnabledProperty()));
-            boolean hostnameVerificationEnabled = Boolean.parseBoolean(config.getProperty(x509Util.getSslHostnameVerificationEnabledProperty()));
-
-            X509KeyManager km = null;
-            X509TrustManager tm = null;
-            if (keyStoreLocation.isEmpty()) {
-                LOG.warn("keystore not specified for client connection");
-            } else {
-                try {
-                    km = X509Util.createKeyManager(keyStoreLocation, keyStorePassword, keyStoreTypeProp);
-                } catch (KeyManagerException e) {
-                    LOG.error("Failed to create key manager", e);
-                }
-            }
-
-            String trustStoreLocation = config.getProperty(x509Util.getSslTruststoreLocationProperty(), "");
-            String trustStorePassword = config.getProperty(x509Util.getSslTruststorePasswdProperty(), "");
-            String trustStoreTypeProp = config.getProperty(x509Util.getSslTruststoreTypeProperty());
-
-            if (trustStoreLocation.isEmpty()) {
-                LOG.warn("Truststore not specified for client connection");
-            } else {
-                try {
-                    tm = X509Util.createTrustManager(
-                        trustStoreLocation,
-                        trustStorePassword,
-                        trustStoreTypeProp,
-                        crlEnabled,
-                        ocspEnabled,
-                        hostnameVerificationEnabled,
-                        false);
-                } catch (TrustManagerException e) {
-                    LOG.error("Failed to create trust manager", e);
-                }
-            }
-            this.keyManager = km;
-            this.trustManager = tm;
-        }
+        this.keyManager = X509AuthenticationUtil.createKeyManager(config);
+        this.trustManager = X509AuthenticationUtil.createTrustManager(config);
     }
 
     /**
@@ -153,8 +112,7 @@ public class X509AuthenticationProvider implements AuthenticationProvider {
             return KeeperException.Code.AUTHFAILED;
         }
 
-        ClientX509Util x509Util = new ClientX509Util();
-        String clientId = x509Util.getClientId(clientCert);
+        String clientId = X509AuthenticationUtil.getClientId(clientCert);
 
         if (clientId.equals(System.getProperty(ZOOKEEPER_X509AUTHENTICATIONPROVIDER_SUPERUSER))) {
             cnxn.addAuthInfo(new Id("super", clientId));
@@ -167,7 +125,6 @@ public class X509AuthenticationProvider implements AuthenticationProvider {
         LOG.info("Authenticated Id '{}' for Scheme '{}'", authInfo.getId(), authInfo.getScheme());
         return KeeperException.Code.OK;
     }
-
 
     @Override
     public boolean matches(String id, String aclExpr) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
@@ -89,7 +89,7 @@ public class X509AuthenticationProvider implements AuthenticationProvider {
     public KeeperException.Code handleAuthentication(ServerCnxn cnxn, byte[] authData) {
         X509Certificate clientCert;
         try {
-            clientCert = X509AuthenticationUtil.getAndAuthenticateClientCert(cnxn, trustManager);
+            clientCert = X509AuthenticationUtil.getAuthenticatedClientCert(cnxn, trustManager);
         } catch (KeeperException.AuthFailedException e) {
             return KeeperException.Code.AUTHFAILED;
         }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationUtil.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.zookeeper.server.auth;
 
 import java.security.cert.CertificateParsingException;
@@ -9,12 +27,10 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
-
 import org.apache.zookeeper.common.ClientX509Util;
 import org.apache.zookeeper.common.X509Exception;
 import org.apache.zookeeper.common.X509Util;
 import org.apache.zookeeper.common.ZKConfig;
-import org.apache.zookeeper.server.auth.znode.groupacl.ZNodeGroupAclUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +55,7 @@ public class X509AuthenticationUtil extends X509Util {
   // Specifies match group index for the extract regex (i in Matcher.group(i)), default value 0
   public static final String SSL_X509_CLIENT_CERT_ID_SAN_EXTRACT_MATCHER_GROUP_INDEX =
       "zookeeper.ssl.x509.clientCertIdSanExtractMatcherGroupIndex";
+  public static final String SUBJECT_ALTERNATIVE_NAME_SHORT = "SAN";
 
   @Override
   protected String getConfigPrefix() {
@@ -112,7 +129,7 @@ public class X509AuthenticationUtil extends X509Util {
   public static String getClientId(X509Certificate clientCert) {
     String clientCertIdType =
         System.getProperty(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_TYPE);
-    if (clientCertIdType != null && clientCertIdType.equalsIgnoreCase(ZNodeGroupAclUtil.SUBJECT_ALTERNATIVE_NAME_SHORT)) {
+    if (clientCertIdType != null && clientCertIdType.equalsIgnoreCase(SUBJECT_ALTERNATIVE_NAME_SHORT)) {
       try {
         return X509AuthenticationUtil.matchAndExtractSAN(clientCert);
       } catch (Exception ce) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationUtil.java
@@ -28,7 +28,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
-
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.common.ClientX509Util;
 import org.apache.zookeeper.common.X509Exception;
@@ -232,7 +231,7 @@ public class X509AuthenticationUtil extends X509Util {
    * @return The authenticated client certificate
    * @throws KeeperException.AuthFailedException Failed to authenticate the client certificate
    */
-  public static X509Certificate getAndAuthenticateClientCert(ServerCnxn cnxn, X509TrustManager trustManager)
+  public static X509Certificate getAuthenticatedClientCert(ServerCnxn cnxn, X509TrustManager trustManager)
       throws KeeperException.AuthFailedException {
     X509Certificate[] certChain = (X509Certificate[]) cnxn.getClientCertificateChain();
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationUtil.java
@@ -1,0 +1,188 @@
+package org.apache.zookeeper.server.auth;
+
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
+
+import org.apache.zookeeper.common.ClientX509Util;
+import org.apache.zookeeper.common.X509Exception;
+import org.apache.zookeeper.common.X509Util;
+import org.apache.zookeeper.common.ZKConfig;
+import org.apache.zookeeper.server.auth.znode.groupacl.ZNodeGroupAclUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Util class for x509 certificate-based authentication providers.
+ */
+public class X509AuthenticationUtil extends X509Util {
+
+  private static final Logger LOG = LoggerFactory.getLogger(X509AuthenticationUtil.class);
+  /**
+   * The following System Property keys are used to extract clientId from the client cert.
+   */
+  public static final String SSL_X509_CLIENT_CERT_ID_TYPE = "zookeeper.ssl.x509.clientCertIdType";
+  public static final String SSL_X509_CLIENT_CERT_ID_SAN_MATCH_TYPE =
+      "zookeeper.ssl.x509.clientCertIdSanMatchType";
+  // Match Regex is used to choose which entry to use, default value ".*"
+  public static final String SSL_X509_CLIENT_CERT_ID_SAN_MATCH_REGEX =
+      "zookeeper.ssl.x509.clientCertIdSanMatchRegex";
+  // Extract Regex is used to construct a client ID (acl entity) to return, default value ".*"
+  public static final String SSL_X509_CLIENT_CERT_ID_SAN_EXTRACT_REGEX =
+      "zookeeper.ssl.x509.clientCertIdSanExtractRegex";
+  // Specifies match group index for the extract regex (i in Matcher.group(i)), default value 0
+  public static final String SSL_X509_CLIENT_CERT_ID_SAN_EXTRACT_MATCHER_GROUP_INDEX =
+      "zookeeper.ssl.x509.clientCertIdSanExtractMatcherGroupIndex";
+
+  @Override
+  protected String getConfigPrefix() {
+    return "zookeeper.ssl.x509.";
+  }
+
+  @Override
+  protected boolean shouldVerifyClientHostname() {
+    return false;
+  }
+
+  public static X509KeyManager createKeyManager(ZKConfig config) {
+    try (X509Util x509Util = new ClientX509Util()) {
+      String keyStoreLocation = config.getProperty(x509Util.getSslKeystoreLocationProperty(), "");
+      String keyStorePassword = config.getProperty(x509Util.getSslKeystorePasswdProperty(), "");
+      String keyStoreTypeProp = config.getProperty(x509Util.getSslKeystoreTypeProperty());
+
+      X509KeyManager km = null;
+      if (keyStoreLocation.isEmpty()) {
+        LOG.warn("X509AuthenticationUtil::keystore not specified for client connection");
+      } else {
+        try {
+          km = X509Util.createKeyManager(keyStoreLocation, keyStorePassword, keyStoreTypeProp);
+        } catch (X509Exception.KeyManagerException e) {
+          LOG.error("X509AuthenticationUtil::Failed to create key manager", e);
+        }
+      }
+      return km;
+    }
+  }
+
+  public static X509TrustManager createTrustManager(ZKConfig config) {
+    try (X509Util x509Util = new ClientX509Util()) {
+      boolean crlEnabled =
+          Boolean.parseBoolean(config.getProperty(x509Util.getSslCrlEnabledProperty()));
+      boolean ocspEnabled =
+          Boolean.parseBoolean(config.getProperty(x509Util.getSslOcspEnabledProperty()));
+      boolean hostnameVerificationEnabled = Boolean
+          .parseBoolean(config.getProperty(x509Util.getSslHostnameVerificationEnabledProperty()));
+      String trustStoreLocation =
+          config.getProperty(x509Util.getSslTruststoreLocationProperty(), "");
+      String trustStorePassword = config.getProperty(x509Util.getSslTruststorePasswdProperty(), "");
+      String trustStoreTypeProp = config.getProperty(x509Util.getSslTruststoreTypeProperty());
+
+      X509TrustManager tm = null;
+      if (trustStoreLocation.isEmpty()) {
+        LOG.warn("X509AuthenticationUtil::Truststore not specified for client connection");
+      } else {
+        try {
+          tm = X509Util
+              .createTrustManager(trustStoreLocation, trustStorePassword, trustStoreTypeProp,
+                  crlEnabled, ocspEnabled, hostnameVerificationEnabled, false);
+        } catch (X509Exception.TrustManagerException e) {
+          LOG.error("X509AuthenticationUtil::Failed to create trust manager", e);
+        }
+      }
+      return tm;
+    }
+  }
+
+  /**
+   * Determine the string to be used as the remote host session Id for
+   * authorization purposes. Associate this client identifier with a
+   * ServerCnxn that has been authenticated over SSL, and any ACLs that refer
+   * to the authenticated client.
+   *
+   * @param clientCert Authenticated X509Certificate associated with the
+   *                   remote host.
+   * @return Identifier string to be associated with the client.
+   */
+  public static String getClientId(X509Certificate clientCert) {
+    String clientCertIdType =
+        System.getProperty(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_TYPE);
+    if (clientCertIdType != null && clientCertIdType.equalsIgnoreCase(ZNodeGroupAclUtil.SUBJECT_ALTERNATIVE_NAME_SHORT)) {
+      try {
+        return X509AuthenticationUtil.matchAndExtractSAN(clientCert);
+      } catch (Exception ce) {
+        LOG.warn("X509AuthenticationUtil::getClientId(): failed to match and extract a"
+            + " client ID from SAN! Using Subject DN instead...", ce);
+      }
+    }
+    // return Subject DN by default
+    return clientCert.getSubjectX500Principal().getName();
+  }
+
+  private static String matchAndExtractSAN(X509Certificate clientCert)
+      throws CertificateParsingException {
+    Integer matchType = Integer.getInteger(SSL_X509_CLIENT_CERT_ID_SAN_MATCH_TYPE);
+    String matchRegex = System.getProperty(SSL_X509_CLIENT_CERT_ID_SAN_MATCH_REGEX, ".*");
+    String extractRegex = System.getProperty(SSL_X509_CLIENT_CERT_ID_SAN_EXTRACT_REGEX, ".*");
+    Integer extractMatcherGroupIndex =
+        Integer.getInteger(SSL_X509_CLIENT_CERT_ID_SAN_EXTRACT_MATCHER_GROUP_INDEX);
+    LOG.info("X509AuthenticationUtil::matchAndExtractSAN(): Using SAN in the client cert "
+            + "for client ID! matchType: {}, matchRegex: {}, extractRegex: {}, "
+            + "extractMatcherGroupIndex: {}", matchType, matchRegex, extractRegex,
+        extractMatcherGroupIndex);
+    if (matchType == null || matchRegex == null || extractRegex == null || matchType < 0
+        || matchType > 8) {
+      // SAN extension must be in the range of [0, 8].
+      // See GeneralName object defined in RFC 5280 (The ASN.1 definition of the
+      // SubjectAltName extension)
+      String errStr = "X509AuthenticationUtil::matchAndExtractSAN(): ClientCert ID type "
+          + "SAN was provided but matchType or matchRegex given is invalid! matchType: " + matchType
+          + " matchRegex: " + matchRegex;
+      LOG.error(errStr);
+      throw new IllegalArgumentException(errStr);
+    }
+    // filter by match type and match regex
+    LOG.info("X509AuthenticationUtil::matchAndExtractSAN(): number of SAN entries found in" + " clientCert: " + clientCert
+        .getSubjectAlternativeNames().size());
+    Pattern matchPattern = Pattern.compile(matchRegex);
+    Collection<List<?>> matched = clientCert.getSubjectAlternativeNames().stream().filter(
+        list -> list.get(0).equals(matchType) && matchPattern.matcher((CharSequence) list.get(1))
+            .find()).collect(Collectors.toList());
+
+    LOG.info("X509AuthenticationUtil::matchAndExtractSAN(): number of SAN entries matched: " + matched.size()
+        + ". Printing all matches...");
+    for (List<?> match : matched) {
+      LOG.info("  Match: (" + match.get(0) + ", " + match.get(1) + ")");
+    }
+
+    // if there are more than one match or 0 matches, throw an error
+    if (matched.size() != 1) {
+      String errStr = "X509AuthenticationUtil::matchAndExtractSAN(): 0 or multiple "
+          + "matches found in SAN! Please fix match type and regex so that exactly one match "
+          + "is found.";
+      LOG.error(errStr);
+      throw new IllegalArgumentException(errStr);
+    }
+
+    // Extract a substring from the found match using extractRegex
+    Pattern extractPattern = Pattern.compile(extractRegex);
+    Matcher matcher = extractPattern.matcher(matched.iterator().next().get(1).toString());
+    if (matcher.find()) {
+      // If extractMatcherGroupIndex is not given, return the 1st index by default
+      extractMatcherGroupIndex = extractMatcherGroupIndex == null ? 0 : extractMatcherGroupIndex;
+      String result = matcher.group(extractMatcherGroupIndex);
+      LOG.info("X509AuthenticationUtil::matchAndExtractSAN(): returning extracted "
+          + "client ID: {} using Matcher group index: {}", result, extractMatcherGroupIndex);
+      return result;
+    }
+    String errStr = "X509AuthenticationUtil::matchAndExtractSAN(): failed to find an "
+        + "extract substring! Please review the extract regex!";
+    LOG.error(errStr);
+    throw new IllegalArgumentException(errStr);
+  }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
@@ -20,6 +20,7 @@ package org.apache.zookeeper.server.auth.znode.groupacl;
 
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.HashSet;
 import java.util.Set;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
@@ -110,6 +111,7 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
     Set<String> domains = uriDomainMappingHelper.getDomains(uri);
     if (domains.isEmpty()) {
       // If no domain name is found, use URI as domain name
+      domains = new HashSet<>();
       domains.add(uri);
     }
 
@@ -118,7 +120,7 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
       // Grant cross domain components super user privilege
       if (superUserDomainNames.contains(domain)) {
         cnxn.addAuthInfo(new Id("super", uri));
-        LOG.info(logStrPrefix + "Id '{}' belongs to domain '{}', authenticated as super user", uri,
+        LOG.info(logStrPrefix + "Id '{}' belongs to superUser domain '{}', authenticated as super user", uri,
             domain);
       } else {
         cnxn.addAuthInfo(new Id(getScheme(), domain));

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.auth.znode.groupacl;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Set;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
+import javax.security.auth.x500.X500Principal;
+
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.common.ClientX509Util;
+import org.apache.zookeeper.common.X509Exception;
+import org.apache.zookeeper.data.Id;
+import org.apache.zookeeper.server.ServerCnxn;
+import org.apache.zookeeper.server.auth.ServerAuthenticationProvider;
+import org.apache.zookeeper.server.auth.X509AuthenticationProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A ServerAuthenticationProvider implementation that does both authentication and authorization for protecting znodes from unauthorized access.
+ * Znodes are grouped into domains according to their ownership, and clients are granted access permission to domains.
+ * Authentication mechanism is same as in X509AuthenticationProvider.
+ * Authorization is done by checking with clients' URI (uniform resource identifier) in ACL metadata for matched domains.
+ */
+public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
+
+  private static final Logger LOG = LoggerFactory.getLogger(X509ZNodeGroupAclProvider.class);
+  private final String logStrPrefix = this.getClass().getName() + ":: ";
+  private final X509TrustManager trustManager;
+  private final X509KeyManager keyManager;
+
+  public X509ZNodeGroupAclProvider()
+      throws X509Exception.KeyManagerException, X509Exception.TrustManagerException {
+    // Reuse logic in X509AuthenticationProvider
+    X509AuthenticationProvider authProvider = new X509AuthenticationProvider();
+    this.keyManager = authProvider.getKeyManager();
+    this.trustManager = authProvider.getTrustManager();
+  }
+
+  public X509ZNodeGroupAclProvider(X509TrustManager trustManager, X509KeyManager keyManager) {
+    this.trustManager = trustManager;
+    this.keyManager = keyManager;
+  }
+
+  @Override
+  public KeeperException.Code handleAuthentication(ServerObjs serverObjs, byte[] authData) {
+    // Get x509 certificate
+    ServerCnxn cnxn = serverObjs.getCnxn();
+    X509Certificate[] certChain = (X509Certificate[]) cnxn.getClientCertificateChain();
+    if (certChain == null || certChain.length == 0) {
+      LOG.error(logStrPrefix + "No x509 certificate is found.");
+      return KeeperException.Code.AUTHFAILED;
+    }
+    X509Certificate clientCert = certChain[0];
+
+    if (trustManager == null) {
+      LOG.error(logStrPrefix + "No trust manager available to authenticate session 0x{}",
+          Long.toHexString(cnxn.getSessionId()));
+      return KeeperException.Code.AUTHFAILED;
+    }
+
+    try {
+      // Authenticate client certificate
+      trustManager.checkClientTrusted(certChain, clientCert.getPublicKey().getAlgorithm());
+    } catch (CertificateException ce) {
+      LOG.error(logStrPrefix + "Failed to trust certificate for session 0x{}",
+          Long.toHexString(cnxn.getSessionId()), ce);
+      return KeeperException.Code.AUTHFAILED;
+    }
+
+    // Extract URI from certificate
+    String clientId;
+    try (ClientX509Util x509Util = new ClientX509Util()) {
+      clientId = x509Util.getClientId(clientCert);
+    } catch (Exception e) {
+      // Failed to extract URI from certificate
+      LOG.error(logStrPrefix + "Failed to extract URI from certificate for session 0x{}",
+          Long.toHexString(cnxn.getSessionId()), e);
+      return KeeperException.Code.OK;
+    }
+
+    // User belongs to super user group
+    if (clientId.equals(System
+        .getProperty(X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_SUPERUSER))) {
+      cnxn.addAuthInfo(new Id("super", clientId));
+      LOG.info("Authenticated Id '{}' as super user", clientId);
+
+      return KeeperException.Code.OK;
+    }
+
+    // Get authorized domain names for client
+    ClientUriDomainMappingHelper uriDomainMappingHelper =
+        new ZkClientUriDomainMappingHelper(serverObjs.getZks());
+    Set<String> domains = uriDomainMappingHelper.getDomains(clientId);
+    if (domains.isEmpty()) {
+      // If no domain name is found, use URI as domain name
+      domains.add(clientId);
+    }
+
+    Set<String> superUserDomainNames = ZNodeGroupAclUtil.getSuperUserDomainNames();
+    for (String domain : domains) {
+      // Grant cross domain components super user privilege
+      if (superUserDomainNames.contains(domain)) {
+        cnxn.addAuthInfo(new Id("super", clientId));
+        LOG.info(logStrPrefix + "Authenticated Id '{}' as super user", clientId);
+      } else {
+        cnxn.addAuthInfo(new Id(getScheme(), domain));
+        LOG.info(logStrPrefix + "Authenticated Id '{}' for Scheme '{}', Domain '{}'.", clientId,
+            getScheme(), domain);
+      }
+    }
+
+    return KeeperException.Code.OK;
+  }
+
+  @Override
+  public boolean matches(ServerObjs serverObjs, MatchValues matchValues) {
+    for (Id id : serverObjs.getCnxn().getAuthInfo()) {
+      if (id.getId().equals(matchValues.getAclExpr()) || id.getId().equals(System.getProperty(
+          X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_SUPERUSER))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public String getScheme() {
+    return "x509";
+  }
+
+  @Override
+  public boolean isAuthenticated() {
+    return true;
+  }
+
+  @Override
+  public boolean isValid(String id) {
+    try {
+      new X500Principal(id);
+      return true;
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
@@ -106,7 +106,7 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
       domains.add(uri);
     }
 
-    Set<String> superUserDomainNames = ZNodeGroupAclUtil.getSuperUserDomainNames();
+    Set<String> superUserDomainNames = ZNodeGroupAclProperties.getInstance().getSuperUserDomainNames();
     for (String domain : domains) {
       // Grant cross domain components super user privilege
       if (superUserDomainNames.contains(domain)) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclProperties.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclProperties.java
@@ -25,9 +25,22 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Util class for ZNode Group ACL. Contains util methods and constants.
+ * Configured properties for ZNode Group ACL feature
  */
-public class ZNodeGroupAclUtil {
+public class ZNodeGroupAclProperties {
+  private static ZNodeGroupAclProperties instance = null;
+
+  private ZNodeGroupAclProperties() {
+    openReadAccessPathPrefixes = loadOpenReadAccessPathPrefixes();
+    superUserDomainNames = loadSuperUserDomainNames();
+  }
+
+  public static ZNodeGroupAclProperties getInstance() {
+    if (instance == null) {
+      instance = new ZNodeGroupAclProperties();
+    }
+    return instance;
+  }
 
   /**
    * Property key values (JVM configs) for ZNode group ACL features
@@ -39,47 +52,47 @@ public class ZNodeGroupAclUtil {
   public static final String SET_X509_CLIENT_ID_AS_ACL =
       ZNODE_GROUP_ACL_CONFIG_PREFIX + "setX509ClientIdAsAcl";
   // A list of domain names that will have super user privilege, separated by ","
-  public static final String SUPER_USER_DOMAIN_NAME =
+  private static final String SUPER_USER_DOMAIN_NAME =
       ZNODE_GROUP_ACL_CONFIG_PREFIX + "superUserDomainName";
   // A list of znode path prefixes, separated by ","
   // Znode whose path starts with the defined path prefix would have open read access
   // Meaning the znode will have (world:anyone, r) ACL
-  public static final String OPEN_READ_ACCESS_PATH_PREFIX =
+  private static final String OPEN_READ_ACCESS_PATH_PREFIX =
       ZNODE_GROUP_ACL_CONFIG_PREFIX + "openReadAccessPathPrefix";
-  private static Set<String> openReadAccessPathPrefixes = null;
-  private static Set<String> superUserDomainNames = null;
+  private final Set<String> openReadAccessPathPrefixes;
+  private final Set<String> superUserDomainNames;
 
   /**
    * Get open read access path prefixes from config
    * @return A set of path prefixes
    */
-  public static Set<String> getOpenReadAccessPathPrefixes() {
-    if (openReadAccessPathPrefixes == null) {
-      String openReadAccessPathPrefixesStr = System.getProperty(OPEN_READ_ACCESS_PATH_PREFIX);
-      if (openReadAccessPathPrefixesStr == null || openReadAccessPathPrefixesStr.isEmpty()) {
-        return Collections.emptySet();
-      }
-      openReadAccessPathPrefixes =
-          Arrays.stream(openReadAccessPathPrefixesStr.split(",")).filter(str -> str.length() > 0)
-              .collect(Collectors.toSet());
+  public Set<String> loadOpenReadAccessPathPrefixes() {
+    String openReadAccessPathPrefixesStr = System.getProperty(OPEN_READ_ACCESS_PATH_PREFIX);
+    if (openReadAccessPathPrefixesStr == null || openReadAccessPathPrefixesStr.isEmpty()) {
+      return Collections.emptySet();
     }
-    return openReadAccessPathPrefixes;
+    return Arrays.stream(openReadAccessPathPrefixesStr.split(",")).filter(str -> str.length() > 0)
+        .collect(Collectors.toSet());
   }
 
   /**
    * Get the domain names that are mapped to super user access privilege
    * @return A set of domain names
    */
-  public static Set<String> getSuperUserDomainNames() {
-    if (superUserDomainNames == null) {
-      String superUserDomainNameStr = System.getProperty(ZNodeGroupAclUtil.SUPER_USER_DOMAIN_NAME);
-      if (superUserDomainNameStr == null || superUserDomainNameStr.isEmpty()) {
-        return Collections.emptySet();
-      }
-      superUserDomainNames =
-          Arrays.stream(superUserDomainNameStr.split(",")).filter(str -> str.length() > 0)
-              .collect(Collectors.toSet());
+  public Set<String> loadSuperUserDomainNames() {
+    String superUserDomainNameStr = System.getProperty(SUPER_USER_DOMAIN_NAME);
+    if (superUserDomainNameStr == null || superUserDomainNameStr.isEmpty()) {
+      return Collections.emptySet();
     }
+    return Arrays.stream(superUserDomainNameStr.split(",")).filter(str -> str.length() > 0)
+        .collect(Collectors.toSet());
+  }
+
+  public Set<String> getOpenReadAccessPathPrefixes() {
+    return openReadAccessPathPrefixes;
+  }
+
+  public Set<String> getSuperUserDomainNames() {
     return superUserDomainNames;
   }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclProperties.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclProperties.java
@@ -30,10 +30,7 @@ import java.util.stream.Collectors;
 public class ZNodeGroupAclProperties {
   private static ZNodeGroupAclProperties instance = null;
 
-  private ZNodeGroupAclProperties() {
-    openReadAccessPathPrefixes = loadOpenReadAccessPathPrefixes();
-    superUserDomainNames = loadSuperUserDomainNames();
-  }
+  private ZNodeGroupAclProperties() { }
 
   public static ZNodeGroupAclProperties getInstance() {
     if (instance == null) {
@@ -59,14 +56,14 @@ public class ZNodeGroupAclProperties {
   // Meaning the znode will have (world:anyone, r) ACL
   private static final String OPEN_READ_ACCESS_PATH_PREFIX =
       ZNODE_GROUP_ACL_CONFIG_PREFIX + "openReadAccessPathPrefix";
-  private final Set<String> openReadAccessPathPrefixes;
-  private final Set<String> superUserDomainNames;
+  private Set<String> openReadAccessPathPrefixes;
+  private Set<String> superUserDomainNames;
 
   /**
    * Get open read access path prefixes from config
    * @return A set of path prefixes
    */
-  public Set<String> loadOpenReadAccessPathPrefixes() {
+  private Set<String> loadOpenReadAccessPathPrefixes() {
     String openReadAccessPathPrefixesStr = System.getProperty(OPEN_READ_ACCESS_PATH_PREFIX);
     if (openReadAccessPathPrefixesStr == null || openReadAccessPathPrefixesStr.isEmpty()) {
       return Collections.emptySet();
@@ -79,7 +76,7 @@ public class ZNodeGroupAclProperties {
    * Get the domain names that are mapped to super user access privilege
    * @return A set of domain names
    */
-  public Set<String> loadSuperUserDomainNames() {
+  private Set<String> loadSuperUserDomainNames() {
     String superUserDomainNameStr = System.getProperty(SUPER_USER_DOMAIN_NAME);
     if (superUserDomainNameStr == null || superUserDomainNameStr.isEmpty()) {
       return Collections.emptySet();
@@ -89,10 +86,16 @@ public class ZNodeGroupAclProperties {
   }
 
   public Set<String> getOpenReadAccessPathPrefixes() {
+    if (openReadAccessPathPrefixes == null) {
+      openReadAccessPathPrefixes = loadOpenReadAccessPathPrefixes();
+    }
     return openReadAccessPathPrefixes;
   }
 
   public Set<String> getSuperUserDomainNames() {
+    if (superUserDomainNames == null) {
+      superUserDomainNames = loadSuperUserDomainNames();
+    }
     return superUserDomainNames;
   }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclProperties.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclProperties.java
@@ -61,8 +61,12 @@ public class ZNodeGroupAclProperties {
   // Meaning the znode will have (world:anyone, r) ACL
   private static final String OPEN_READ_ACCESS_PATH_PREFIX =
       ZNODE_GROUP_ACL_CONFIG_PREFIX + "openReadAccessPathPrefix";
+  // Although using "volatile" keyword with double checked locking could prevent the undesired
+  //creation of multiple objects; not using here for the consideration of read performance
   private Set<String> openReadAccessPathPrefixes;
   private Set<String> superUserDomainNames;
+  private final Object openReadAccessPathPrefixesLock = new Object();
+  private final Object superUserDomainNamesLock = new Object();
 
   /**
    * Get open read access path prefixes from config
@@ -92,7 +96,7 @@ public class ZNodeGroupAclProperties {
 
   public Set<String> getOpenReadAccessPathPrefixes() {
     if (openReadAccessPathPrefixes == null) {
-      synchronized (ZNodeGroupAclProperties.class) {
+      synchronized (openReadAccessPathPrefixesLock) {
         if (openReadAccessPathPrefixes == null) {
           openReadAccessPathPrefixes = loadOpenReadAccessPathPrefixes();
         }
@@ -103,7 +107,7 @@ public class ZNodeGroupAclProperties {
 
   public Set<String> getSuperUserDomainNames() {
     if (superUserDomainNames == null) {
-      synchronized (ZNodeGroupAclProperties.class) {
+      synchronized (superUserDomainNamesLock) {
         if (superUserDomainNames == null) {
           superUserDomainNames = loadSuperUserDomainNames();
         }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclProperties.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclProperties.java
@@ -30,11 +30,16 @@ import java.util.stream.Collectors;
 public class ZNodeGroupAclProperties {
   private static ZNodeGroupAclProperties instance = null;
 
-  private ZNodeGroupAclProperties() { }
+  private ZNodeGroupAclProperties() {
+  }
 
   public static ZNodeGroupAclProperties getInstance() {
     if (instance == null) {
-      instance = new ZNodeGroupAclProperties();
+      synchronized (ZNodeGroupAclProperties.class) {
+        if (instance == null) {
+          instance = new ZNodeGroupAclProperties();
+        }
+      }
     }
     return instance;
   }
@@ -87,14 +92,22 @@ public class ZNodeGroupAclProperties {
 
   public Set<String> getOpenReadAccessPathPrefixes() {
     if (openReadAccessPathPrefixes == null) {
-      openReadAccessPathPrefixes = loadOpenReadAccessPathPrefixes();
+      synchronized (ZNodeGroupAclProperties.class) {
+        if (openReadAccessPathPrefixes == null) {
+          openReadAccessPathPrefixes = loadOpenReadAccessPathPrefixes();
+        }
+      }
     }
     return openReadAccessPathPrefixes;
   }
 
   public Set<String> getSuperUserDomainNames() {
     if (superUserDomainNames == null) {
-      superUserDomainNames = loadSuperUserDomainNames();
+      synchronized (ZNodeGroupAclProperties.class) {
+        if (superUserDomainNames == null) {
+          superUserDomainNames = loadSuperUserDomainNames();
+        }
+      }
     }
     return superUserDomainNames;
   }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclUtil.java
@@ -46,18 +46,24 @@ public class ZNodeGroupAclUtil {
   // Meaning the znode will have (world:anyone, r) ACL
   public static final String OPEN_READ_ACCESS_PATH_PREFIX =
       ZNODE_GROUP_ACL_CONFIG_PREFIX + "openReadAccessPathPrefix";
+  private static Set<String> openReadAccessPathPrefixes = null;
+  private static Set<String> superUserDomainNames = null;
 
   /**
    * Get open read access path prefixes from config
    * @return A set of path prefixes
    */
   public static Set<String> getOpenReadAccessPathPrefixes() {
-    String openReadAccessPathPrefixesStr = System.getProperty(OPEN_READ_ACCESS_PATH_PREFIX);
-    if (openReadAccessPathPrefixesStr == null || openReadAccessPathPrefixesStr.isEmpty()) {
-      return Collections.emptySet();
+    if (openReadAccessPathPrefixes == null) {
+      String openReadAccessPathPrefixesStr = System.getProperty(OPEN_READ_ACCESS_PATH_PREFIX);
+      if (openReadAccessPathPrefixesStr == null || openReadAccessPathPrefixesStr.isEmpty()) {
+        return Collections.emptySet();
+      }
+      openReadAccessPathPrefixes =
+          Arrays.stream(openReadAccessPathPrefixesStr.split(",")).filter(str -> str.length() > 0)
+              .collect(Collectors.toSet());
     }
-    return Arrays.stream(openReadAccessPathPrefixesStr.split(",")).filter(str -> str.length() > 0)
-        .collect(Collectors.toSet());
+    return openReadAccessPathPrefixes;
   }
 
   /**
@@ -65,12 +71,15 @@ public class ZNodeGroupAclUtil {
    * @return A set of domain names
    */
   public static Set<String> getSuperUserDomainNames() {
-    String superUserDomainNameStr =
-        System.getProperty(ZNodeGroupAclUtil.SUPER_USER_DOMAIN_NAME);
-    if (superUserDomainNameStr == null || superUserDomainNameStr.isEmpty()) {
-      return Collections.emptySet();
+    if (superUserDomainNames == null) {
+      String superUserDomainNameStr = System.getProperty(ZNodeGroupAclUtil.SUPER_USER_DOMAIN_NAME);
+      if (superUserDomainNameStr == null || superUserDomainNameStr.isEmpty()) {
+        return Collections.emptySet();
+      }
+      superUserDomainNames =
+          Arrays.stream(superUserDomainNameStr.split(",")).filter(str -> str.length() > 0)
+              .collect(Collectors.toSet());
     }
-    return Arrays.stream(superUserDomainNameStr.split(",")).filter(str -> str.length() > 0)
-        .collect(Collectors.toSet());
+    return superUserDomainNames;
   }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclUtil.java
@@ -19,6 +19,10 @@
 
 package org.apache.zookeeper.server.auth.znode.groupacl;
 
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 /**
  * Util class for ZNode Group ACL. Contains util methods and constants.
  */
@@ -33,4 +37,24 @@ public class ZNodeGroupAclUtil {
   // Has the same effect as the ZK client using ZooDefs.Ids.CREATOR_ALL_ACL.
   public static final String SET_X509_CLIENT_ID_AS_ACL =
       ZNODE_GROUP_ACL_CONFIG_PREFIX + "setX509ClientIdAsAcl";
+  public static final String SUPER_USER_DOMAIN_NAME =
+      ZNODE_GROUP_ACL_CONFIG_PREFIX + "superUserDomainName";
+  public static final String OPEN_READ_ACCESS_PATH_PREFIX =
+      ZNODE_GROUP_ACL_CONFIG_PREFIX + "openReadAccessPathPrefix";
+  public static final String CONFIG_VALUE_LIST_DELIMITER =
+      ZNODE_GROUP_ACL_CONFIG_PREFIX + "configValueListDelimiter";
+
+  public static String[] getOpenReadAccessPathPrefixes() {
+    String configValListDelimiter = System.getProperty(CONFIG_VALUE_LIST_DELIMITER, ",");
+    String openReadAccessPathPrefixesStr = System.getProperty(OPEN_READ_ACCESS_PATH_PREFIX, "");
+    return openReadAccessPathPrefixesStr.split(configValListDelimiter);
+  }
+
+  public static Set<String> getSuperUserDomainNames() {
+    String configValListDelimiter = System.getProperty(CONFIG_VALUE_LIST_DELIMITER, ",");
+    String superUserDomainNameStr =
+        System.getProperty(ZNodeGroupAclUtil.SUPER_USER_DOMAIN_NAME, "");
+    return Arrays.stream(superUserDomainNameStr.split(configValListDelimiter))
+        .filter(str -> str.length() > 0).collect(Collectors.toSet());
+  }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclUtil.java
@@ -22,7 +22,6 @@ package org.apache.zookeeper.server.auth.znode.groupacl;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 /**
  * Util class for ZNode Group ACL. Contains util methods and constants.
  */
@@ -46,11 +45,20 @@ public class ZNodeGroupAclUtil {
   public static final String OPEN_READ_ACCESS_PATH_PREFIX =
       ZNODE_GROUP_ACL_CONFIG_PREFIX + "openReadAccessPathPrefix";
 
-  public static String[] getOpenReadAccessPathPrefixes() {
+  /**
+   * Get open read access path prefixes from config
+   * @return A set of path prefixes
+   */
+  public static Set<String> getOpenReadAccessPathPrefixes() {
     String openReadAccessPathPrefixesStr = System.getProperty(OPEN_READ_ACCESS_PATH_PREFIX, "");
-    return openReadAccessPathPrefixesStr == null ? new String[0] : openReadAccessPathPrefixesStr.split(",");
+    return Arrays.stream(openReadAccessPathPrefixesStr.split(","))
+        .filter(str -> str.length() > 0).collect(Collectors.toSet());
   }
 
+  /**
+   * Get the domain names that are mapped to super user access privilege
+   * @return A set of domain names
+   */
   public static Set<String> getSuperUserDomainNames() {
     String superUserDomainNameStr =
         System.getProperty(ZNodeGroupAclUtil.SUPER_USER_DOMAIN_NAME, "");

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclUtil.java
@@ -45,7 +45,6 @@ public class ZNodeGroupAclUtil {
   // Meaning the znode will have (world:anyone, r) ACL
   public static final String OPEN_READ_ACCESS_PATH_PREFIX =
       ZNODE_GROUP_ACL_CONFIG_PREFIX + "openReadAccessPathPrefix";
-  public static final String SUBJECT_ALTERNATIVE_NAME_SHORT = "SAN";
 
   public static String[] getOpenReadAccessPathPrefixes() {
     String openReadAccessPathPrefixesStr = System.getProperty(OPEN_READ_ACCESS_PATH_PREFIX, "");

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclUtil.java
@@ -37,24 +37,25 @@ public class ZNodeGroupAclUtil {
   // Has the same effect as the ZK client using ZooDefs.Ids.CREATOR_ALL_ACL.
   public static final String SET_X509_CLIENT_ID_AS_ACL =
       ZNODE_GROUP_ACL_CONFIG_PREFIX + "setX509ClientIdAsAcl";
+  // A list of domain names that will have super user privilege, separated by ","
   public static final String SUPER_USER_DOMAIN_NAME =
       ZNODE_GROUP_ACL_CONFIG_PREFIX + "superUserDomainName";
+  // A list of znode path prefixes, separated by ","
+  // Znode whose path starts with the defined path prefix would have open read access
+  // Meaning the znode will have (world:anyone, r) ACL
   public static final String OPEN_READ_ACCESS_PATH_PREFIX =
       ZNODE_GROUP_ACL_CONFIG_PREFIX + "openReadAccessPathPrefix";
-  public static final String CONFIG_VALUE_LIST_DELIMITER =
-      ZNODE_GROUP_ACL_CONFIG_PREFIX + "configValueListDelimiter";
+  public static final String SUBJECT_ALTERNATIVE_NAME_SHORT = "SAN";
 
   public static String[] getOpenReadAccessPathPrefixes() {
-    String configValListDelimiter = System.getProperty(CONFIG_VALUE_LIST_DELIMITER, ",");
     String openReadAccessPathPrefixesStr = System.getProperty(OPEN_READ_ACCESS_PATH_PREFIX, "");
-    return openReadAccessPathPrefixesStr.split(configValListDelimiter);
+    return openReadAccessPathPrefixesStr == null ? new String[0] : openReadAccessPathPrefixesStr.split(",");
   }
 
   public static Set<String> getSuperUserDomainNames() {
-    String configValListDelimiter = System.getProperty(CONFIG_VALUE_LIST_DELIMITER, ",");
     String superUserDomainNameStr =
         System.getProperty(ZNodeGroupAclUtil.SUPER_USER_DOMAIN_NAME, "");
-    return Arrays.stream(superUserDomainNameStr.split(configValListDelimiter))
+    return Arrays.stream(superUserDomainNameStr.split(","))
         .filter(str -> str.length() > 0).collect(Collectors.toSet());
   }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclUtil.java
@@ -20,8 +20,10 @@
 package org.apache.zookeeper.server.auth.znode.groupacl;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 /**
  * Util class for ZNode Group ACL. Contains util methods and constants.
  */
@@ -50,9 +52,12 @@ public class ZNodeGroupAclUtil {
    * @return A set of path prefixes
    */
   public static Set<String> getOpenReadAccessPathPrefixes() {
-    String openReadAccessPathPrefixesStr = System.getProperty(OPEN_READ_ACCESS_PATH_PREFIX, "");
-    return Arrays.stream(openReadAccessPathPrefixesStr.split(","))
-        .filter(str -> str.length() > 0).collect(Collectors.toSet());
+    String openReadAccessPathPrefixesStr = System.getProperty(OPEN_READ_ACCESS_PATH_PREFIX);
+    if (openReadAccessPathPrefixesStr == null || openReadAccessPathPrefixesStr.isEmpty()) {
+      return Collections.emptySet();
+    }
+    return Arrays.stream(openReadAccessPathPrefixesStr.split(",")).filter(str -> str.length() > 0)
+        .collect(Collectors.toSet());
   }
 
   /**
@@ -61,8 +66,11 @@ public class ZNodeGroupAclUtil {
    */
   public static Set<String> getSuperUserDomainNames() {
     String superUserDomainNameStr =
-        System.getProperty(ZNodeGroupAclUtil.SUPER_USER_DOMAIN_NAME, "");
-    return Arrays.stream(superUserDomainNameStr.split(","))
-        .filter(str -> str.length() > 0).collect(Collectors.toSet());
+        System.getProperty(ZNodeGroupAclUtil.SUPER_USER_DOMAIN_NAME);
+    if (superUserDomainNameStr == null || superUserDomainNameStr.isEmpty()) {
+      return Collections.emptySet();
+    }
+    return Arrays.stream(superUserDomainNameStr.split(",")).filter(str -> str.length() > 0)
+        .collect(Collectors.toSet());
   }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
@@ -18,18 +18,16 @@
 
 package org.apache.zookeeper.server.auth.znode.groupacl;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
+import com.google.common.collect.Sets;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooDefs;
-import org.apache.zookeeper.common.X509Util;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -131,6 +129,6 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
 
   @Override
   public Set<String> getDomains(String clientUri) {
-    return clientUriToDomainNames.getOrDefault(clientUri, Collections.emptySet());
+    return clientUriToDomainNames.getOrDefault(clientUri, Sets.newHashSet());
   }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
@@ -29,7 +29,6 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooDefs;
-import org.apache.zookeeper.common.X509Util;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,7 +60,7 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
   private static final Logger LOG = LoggerFactory.getLogger(ZkClientUriDomainMappingHelper.class);
 
   private static final String CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH =
-      ZNodeGroupAclUtil.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath";
+      ZNodeGroupAclProperties.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath";
 
   private final ZooKeeperServer zks;
   private final String rootPath;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
@@ -18,16 +18,18 @@
 
 package org.apache.zookeeper.server.auth.znode.groupacl;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import com.google.common.collect.Sets;
+
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.common.X509Util;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -129,6 +131,6 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
 
   @Override
   public Set<String> getDomains(String clientUri) {
-    return clientUriToDomainNames.getOrDefault(clientUri, Sets.newHashSet());
+    return clientUriToDomainNames.getOrDefault(clientUri, Collections.emptySet());
   }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -47,7 +47,7 @@ import org.apache.zookeeper.common.StringUtils;
 import org.apache.zookeeper.metrics.impl.DefaultMetricsProvider;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.apache.zookeeper.server.auth.ProviderRegistry;
-import org.apache.zookeeper.server.auth.znode.groupacl.ZNodeGroupAclUtil;
+import org.apache.zookeeper.server.auth.znode.groupacl.ZNodeGroupAclProperties;
 import org.apache.zookeeper.server.backup.BackupConfig;
 import org.apache.zookeeper.server.backup.BackupSystemProperty;
 import org.apache.zookeeper.server.quorum.QuorumPeer.LearnerType;
@@ -386,10 +386,10 @@ public class QuorumPeerConfig {
                 backupConfigBuilder.setTimetableStoragePath(value);
             } else if (key.equals(BackupSystemProperty.BACKUP_TIMETABLE_BACKUP_INTERVAL_MS)) {
                 backupConfigBuilder.setTimetableBackupIntervalInMs(Long.parseLong(value));
-            } else if (key.equals(ZNodeGroupAclUtil.SET_X509_CLIENT_ID_AS_ACL)) {
+            } else if (key.equals(ZNodeGroupAclProperties.SET_X509_CLIENT_ID_AS_ACL)) {
                 // Allow both option of setting it in zoo.cfg and as a JVM argument
                 setSetX509ClientIdAsAclEnabled(Boolean.parseBoolean(value) || Boolean
-                    .getBoolean(ZNodeGroupAclUtil.SET_X509_CLIENT_ID_AS_ACL));
+                    .getBoolean(ZNodeGroupAclProperties.SET_X509_CLIENT_ID_AS_ACL));
             } else if (key.equals("standaloneEnabled")) {
                 if (value.toLowerCase().equals("true")) {
                     setStandaloneEnabled(true);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
@@ -1,11 +1,7 @@
 package org.apache.zookeeper.server.auth.znode.groupacl;
 
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.PortAssignment;
@@ -13,14 +9,12 @@ import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZKUtil;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
-import org.apache.zookeeper.common.ClientX509Util;
-import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Id;
 import org.apache.zookeeper.server.MockServerCnxn;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.apache.zookeeper.server.auth.ServerAuthenticationProvider;
-import org.apache.zookeeper.server.auth.X509AuthenticationProvider;
+import org.apache.zookeeper.server.auth.X509AuthenticationUtil;
 import org.apache.zookeeper.test.ClientBase;
 import org.apache.zookeeper.test.X509AuthTest;
 import org.junit.After;
@@ -30,8 +24,6 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.zookeeper.ZooDefs.Ids.OPEN_ACL_UNSAFE;
-
 public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
   private static final Logger LOG = LoggerFactory.getLogger(X509ZNodeGroupAclProviderTest.class);
   private static final String HOSTPORT = "127.0.0.1:" + PortAssignment.unique();
@@ -40,41 +32,31 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
   private static X509AuthTest.TestCertificate unknownCert;
   private static final String CLIENT_CERT_ID_TYPE = "SAN";
   private static final String CLIENT_CERT_ID_SAN_MATCH_TYPE = "6";
+  private static final String SCHEME = "x509";
   private static ZooKeeperServer zks;
   private ServerCnxnFactory serverCnxnFactory;
   private ZooKeeper admin;
-  //  private ServerCnxn cnxn;
-  private static final String AUTH_PROVIDER_PROPERTY_NAME = "zookeeper.authProvider";
+  private static final String AUTH_PROVIDER_PROPERTY_NAME = "zookeeper.authProvider.x509";
   private static final String CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH = "/_CLIENT_URI_DOMAIN_MAPPING";
   private static final String[] MAPPING_PATHS = {CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH,
       CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/CrossDomain",
-      CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/CrossDomain/CrossDomainApp",
+      CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/CrossDomain/SuperUser",
       CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/DomainX",
       CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/DomainX/DomainXUser",
       CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/DomainY",
       CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/DomainY/DomainYUser"};
-  private static final Map<String, String> NODE_PATHS_AND_ACLS;
-
-  static {
-    NODE_PATHS_AND_ACLS = new HashMap<>();
-    NODE_PATHS_AND_ACLS.put("/node/domainX", "DomainX");
-    NODE_PATHS_AND_ACLS.put("/node/domainY", "DomainY");
-    NODE_PATHS_AND_ACLS.put("/node/public", "");
-    NODE_PATHS_AND_ACLS.put("/node/open_read_access", "DomainX");
-  }
 
   @Before
   public void setUp() throws Exception {
-    ClientX509Util util = new ClientX509Util();
-    System.setProperty(X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_SUPERUSER,
-        "CN=SUPER");
+    System.setProperty(X509ZNodeGroupAclProvider.ZOOKEEPER_ZNODEGROUPACL_SUPERUSER, "SuperUser");
     System.setProperty("zookeeper.ssl.keyManager",
         "org.apache.zookeeper.test.X509AuthTest.TestKeyManager");
     System.setProperty("zookeeper.ssl.trustManager",
         "org.apache.zookeeper.test.X509AuthTest.TestTrustManager");
-    System.setProperty(util.sslClientCertIdType, CLIENT_CERT_ID_TYPE);
-    System.setProperty(util.sslClientCertIdSanMatchType, CLIENT_CERT_ID_SAN_MATCH_TYPE);
-    System.setProperty(AUTH_PROVIDER_PROPERTY_NAME, X509ZNodeGroupAclProvider.class.getName());
+    System.setProperty(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_TYPE, CLIENT_CERT_ID_TYPE);
+    System.setProperty(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_SAN_MATCH_TYPE,
+        CLIENT_CERT_ID_SAN_MATCH_TYPE);
+    System.setProperty(AUTH_PROVIDER_PROPERTY_NAME, X509ZNodeGroupAclProvider.class.getCanonicalName());
     System.setProperty(
         ZNodeGroupAclUtil.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath",
         CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH);
@@ -86,27 +68,20 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
     LOG.info("Waiting for server startup");
     Assert.assertTrue("waiting for server being up ", ClientBase.waitForServerUp(HOSTPORT, 300000));
     admin = ClientBase.createZKClient(HOSTPORT);
-//      cnxn = serverCnxnFactory.getConnections().iterator().next();
-    domainXCert = new X509AuthTest.TestCertificate("CLIENT", "DomainXUser");
-    superCert = new X509AuthTest.TestCertificate("SUPER", "CrossDomainApp");
-    unknownCert = new X509AuthTest.TestCertificate("UNKNOWN", "UnknownUser");
-
-    for (String path : MAPPING_PATHS) {
-      // Create ACL metadata
-      admin.create(path, null, OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+    try {
+      ZKUtil.deleteRecursive(admin, CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH);
+    } catch (Exception ignored) {
     }
 
-    // Create node with ACL to be accessed
-    for (Map.Entry<String, String> znode : NODE_PATHS_AND_ACLS.entrySet()) {
-      List<ACL> acl;
-      if (znode.getValue().isEmpty()) {
-        acl = OPEN_ACL_UNSAFE;
-      } else {
-        acl = new ArrayList<>();
-        acl.add(new ACL(ZooDefs.Perms.ALL, new Id("x509", znode.getValue())));
-      }
-      admin.create(znode.getKey(), null, acl, CreateMode.PERSISTENT);
+    // Create test client certificates
+    domainXCert = new X509AuthTest.TestCertificate("CLIENT", "DomainXUser");
+    superCert = new X509AuthTest.TestCertificate("SUPER", "SuperUser");
+    unknownCert = new X509AuthTest.TestCertificate("UNKNOWN", "UnknownUser");
 
+    // Create Client URI - domain mapping znodes
+    for (String path : MAPPING_PATHS) {
+      // Create ACL metadata
+      admin.create(path, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
     }
   }
 
@@ -116,48 +91,60 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
     zks.shutdown();
     admin.close();
     serverCnxnFactory.shutdown();
-    ClientX509Util util = new ClientX509Util();
-    System.clearProperty(X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_SUPERUSER);
-    System.clearProperty(util.sslClientCertIdType);
-    System.clearProperty(util.sslClientCertIdSanMatchType);
+    System.clearProperty(X509ZNodeGroupAclProvider.ZOOKEEPER_ZNODEGROUPACL_SUPERUSER);
+    System.clearProperty(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_TYPE);
+    System.clearProperty(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_SAN_MATCH_TYPE);
     System.clearProperty(AUTH_PROVIDER_PROPERTY_NAME);
     System.clearProperty(
         ZNodeGroupAclUtil.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath");
   }
 
-  @Test(expected = KeeperException.AuthFailedException.class)
+  @Test
   public void testUntrustedClient() {
-    X509ZNodeGroupAclProvider provider = createProvider(unknownCert);
+    X509ZNodeGroupAclProvider provider = createProvider(domainXCert);
     MockServerCnxn cnxn = new MockServerCnxn();
     cnxn.clientChain = new X509Certificate[]{unknownCert};
-    try {
-      provider.handleAuthentication(new ServerAuthenticationProvider.ServerObjs(zks, cnxn),
-          new byte[0]);
-    } catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains("Failed to trust certificate"));
-      throw e;
-    }
+    Assert.assertEquals(KeeperException.Code.AUTHFAILED, provider
+        .handleAuthentication(new ServerAuthenticationProvider.ServerObjs(zks, cnxn), new byte[0]));
   }
 
   @Test
   public void testAuthorizedClient() {
     X509ZNodeGroupAclProvider provider = createProvider(domainXCert);
-//    cnxn.setClientCertificateChain(new Certificate[]{domainXCert});
+    MockServerCnxn cnxn = new MockServerCnxn();
+    cnxn.clientChain = new X509Certificate[]{domainXCert};
+    Assert.assertEquals(KeeperException.Code.OK, provider
+        .handleAuthentication(new ServerAuthenticationProvider.ServerObjs(zks, cnxn), new byte[0]));
+    List<Id> authInfo = cnxn.getAuthInfo();
+    Assert.assertEquals(1, authInfo.size());
+    Assert.assertEquals(SCHEME, authInfo.get(0).getScheme());
+    Assert.assertEquals("DomainX", authInfo.get(0).getId());
   }
 
   @Test
   public void testUnauthorizedClient() {
-//    cnxn.setClientCertificateChain(new Certificate[]{domainXCert});
+    X509ZNodeGroupAclProvider provider = createProvider(unknownCert);
+    MockServerCnxn cnxn = new MockServerCnxn();
+    cnxn.clientChain = new X509Certificate[]{unknownCert};
+    Assert.assertEquals(KeeperException.Code.OK, provider
+        .handleAuthentication(new ServerAuthenticationProvider.ServerObjs(zks, cnxn), new byte[0]));
+    List<Id> authInfo = cnxn.getAuthInfo();
+    Assert.assertEquals(1, authInfo.size());
+    Assert.assertEquals(SCHEME, authInfo.get(0).getScheme());
+    Assert.assertEquals("UnknownUser", authInfo.get(0).getId());
   }
 
   @Test
   public void testSuperUser() {
-//    cnxn.setClientCertificateChain(new Certificate[]{superCert});
-  }
-
-  @Test
-  public void testOpenReadAccess() {
-//    cnxn.setClientCertificateChain(new Certificate[]{unknownCert});
+    X509ZNodeGroupAclProvider provider = createProvider(superCert);
+    MockServerCnxn cnxn = new MockServerCnxn();
+    cnxn.clientChain = new X509Certificate[]{superCert};
+    Assert.assertEquals(KeeperException.Code.OK, provider
+        .handleAuthentication(new ServerAuthenticationProvider.ServerObjs(zks, cnxn), new byte[0]));
+    List<Id> authInfo = cnxn.getAuthInfo();
+    Assert.assertEquals(1, authInfo.size());
+    Assert.assertEquals("super", authInfo.get(0).getScheme());
+    Assert.assertEquals("SuperUser", authInfo.get(0).getId());
   }
 
   private X509ZNodeGroupAclProvider createProvider(X509Certificate trustedCert) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
@@ -77,7 +77,7 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
     System.setProperty(AUTH_PROVIDER_PROPERTY_NAME,
         X509ZNodeGroupAclProvider.class.getCanonicalName());
     System.setProperty(
-        ZNodeGroupAclUtil.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath",
+        ZNodeGroupAclProperties.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath",
         CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH);
     LOG.info("Starting Zk...");
     zks = new ZooKeeperServer(testBaseDir, testBaseDir, 3000);
@@ -115,7 +115,7 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
     System.clearProperty(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_SAN_MATCH_TYPE);
     System.clearProperty(AUTH_PROVIDER_PROPERTY_NAME);
     System.clearProperty(
-        ZNodeGroupAclUtil.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath");
+        ZNodeGroupAclProperties.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath");
   }
 
   @Test

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
@@ -1,0 +1,168 @@
+package org.apache.zookeeper.server.auth.znode.groupacl;
+
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.ZKTestCase;
+import org.apache.zookeeper.ZKUtil;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.common.ClientX509Util;
+import org.apache.zookeeper.data.ACL;
+import org.apache.zookeeper.data.Id;
+import org.apache.zookeeper.server.MockServerCnxn;
+import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.apache.zookeeper.server.ZooKeeperServer;
+import org.apache.zookeeper.server.auth.ServerAuthenticationProvider;
+import org.apache.zookeeper.server.auth.X509AuthenticationProvider;
+import org.apache.zookeeper.test.ClientBase;
+import org.apache.zookeeper.test.X509AuthTest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.zookeeper.ZooDefs.Ids.OPEN_ACL_UNSAFE;
+
+public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
+  private static final Logger LOG = LoggerFactory.getLogger(X509ZNodeGroupAclProviderTest.class);
+  private static final String HOSTPORT = "127.0.0.1:" + PortAssignment.unique();
+  private static X509AuthTest.TestCertificate domainXCert;
+  private static X509AuthTest.TestCertificate superCert;
+  private static X509AuthTest.TestCertificate unknownCert;
+  private static final String CLIENT_CERT_ID_TYPE = "SAN";
+  private static final String CLIENT_CERT_ID_SAN_MATCH_TYPE = "6";
+  private static ZooKeeperServer zks;
+  private ServerCnxnFactory serverCnxnFactory;
+  private ZooKeeper admin;
+  //  private ServerCnxn cnxn;
+  private static final String AUTH_PROVIDER_PROPERTY_NAME = "zookeeper.authProvider";
+  private static final String CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH = "/_CLIENT_URI_DOMAIN_MAPPING";
+  private static final String[] MAPPING_PATHS = {CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH,
+      CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/CrossDomain",
+      CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/CrossDomain/CrossDomainApp",
+      CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/DomainX",
+      CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/DomainX/DomainXUser",
+      CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/DomainY",
+      CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/DomainY/DomainYUser"};
+  private static final Map<String, String> NODE_PATHS_AND_ACLS;
+
+  static {
+    NODE_PATHS_AND_ACLS = new HashMap<>();
+    NODE_PATHS_AND_ACLS.put("/node/domainX", "DomainX");
+    NODE_PATHS_AND_ACLS.put("/node/domainY", "DomainY");
+    NODE_PATHS_AND_ACLS.put("/node/public", "");
+    NODE_PATHS_AND_ACLS.put("/node/open_read_access", "DomainX");
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    ClientX509Util util = new ClientX509Util();
+    System.setProperty(X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_SUPERUSER,
+        "CN=SUPER");
+    System.setProperty("zookeeper.ssl.keyManager",
+        "org.apache.zookeeper.test.X509AuthTest.TestKeyManager");
+    System.setProperty("zookeeper.ssl.trustManager",
+        "org.apache.zookeeper.test.X509AuthTest.TestTrustManager");
+    System.setProperty(util.sslClientCertIdType, CLIENT_CERT_ID_TYPE);
+    System.setProperty(util.sslClientCertIdSanMatchType, CLIENT_CERT_ID_SAN_MATCH_TYPE);
+    System.setProperty(AUTH_PROVIDER_PROPERTY_NAME, X509ZNodeGroupAclProvider.class.getName());
+    System.setProperty(
+        ZNodeGroupAclUtil.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath",
+        CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH);
+    LOG.info("Starting Zk...");
+    zks = new ZooKeeperServer(testBaseDir, testBaseDir, 3000);
+    final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
+    serverCnxnFactory = ServerCnxnFactory.createFactory(PORT, -1);
+    serverCnxnFactory.startup(zks);
+    LOG.info("Waiting for server startup");
+    Assert.assertTrue("waiting for server being up ", ClientBase.waitForServerUp(HOSTPORT, 300000));
+    admin = ClientBase.createZKClient(HOSTPORT);
+//      cnxn = serverCnxnFactory.getConnections().iterator().next();
+    domainXCert = new X509AuthTest.TestCertificate("CLIENT", "DomainXUser");
+    superCert = new X509AuthTest.TestCertificate("SUPER", "CrossDomainApp");
+    unknownCert = new X509AuthTest.TestCertificate("UNKNOWN", "UnknownUser");
+
+    for (String path : MAPPING_PATHS) {
+      // Create ACL metadata
+      admin.create(path, null, OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+    }
+
+    // Create node with ACL to be accessed
+    for (Map.Entry<String, String> znode : NODE_PATHS_AND_ACLS.entrySet()) {
+      List<ACL> acl;
+      if (znode.getValue().isEmpty()) {
+        acl = OPEN_ACL_UNSAFE;
+      } else {
+        acl = new ArrayList<>();
+        acl.add(new ACL(ZooDefs.Perms.ALL, new Id("x509", znode.getValue())));
+      }
+      admin.create(znode.getKey(), null, acl, CreateMode.PERSISTENT);
+
+    }
+  }
+
+  @After
+  public void cleanUp() throws InterruptedException, KeeperException {
+    ZKUtil.deleteRecursive(admin, CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH);
+    zks.shutdown();
+    admin.close();
+    serverCnxnFactory.shutdown();
+    ClientX509Util util = new ClientX509Util();
+    System.clearProperty(X509AuthenticationProvider.ZOOKEEPER_X509AUTHENTICATIONPROVIDER_SUPERUSER);
+    System.clearProperty(util.sslClientCertIdType);
+    System.clearProperty(util.sslClientCertIdSanMatchType);
+    System.clearProperty(AUTH_PROVIDER_PROPERTY_NAME);
+    System.clearProperty(
+        ZNodeGroupAclUtil.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath");
+  }
+
+  @Test(expected = KeeperException.AuthFailedException.class)
+  public void testUntrustedClient() {
+    X509ZNodeGroupAclProvider provider = createProvider(unknownCert);
+    MockServerCnxn cnxn = new MockServerCnxn();
+    cnxn.clientChain = new X509Certificate[]{unknownCert};
+    try {
+      provider.handleAuthentication(new ServerAuthenticationProvider.ServerObjs(zks, cnxn),
+          new byte[0]);
+    } catch (Exception e) {
+      Assert.assertTrue(e.getMessage().contains("Failed to trust certificate"));
+      throw e;
+    }
+  }
+
+  @Test
+  public void testAuthorizedClient() {
+    X509ZNodeGroupAclProvider provider = createProvider(domainXCert);
+//    cnxn.setClientCertificateChain(new Certificate[]{domainXCert});
+  }
+
+  @Test
+  public void testUnauthorizedClient() {
+//    cnxn.setClientCertificateChain(new Certificate[]{domainXCert});
+  }
+
+  @Test
+  public void testSuperUser() {
+//    cnxn.setClientCertificateChain(new Certificate[]{superCert});
+  }
+
+  @Test
+  public void testOpenReadAccess() {
+//    cnxn.setClientCertificateChain(new Certificate[]{unknownCert});
+  }
+
+  private X509ZNodeGroupAclProvider createProvider(X509Certificate trustedCert) {
+    return new X509ZNodeGroupAclProvider(new X509AuthTest.TestTrustManager(trustedCert),
+        new X509AuthTest.TestKeyManager());
+  }
+}
+

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
@@ -19,7 +19,10 @@
 package org.apache.zookeeper.server.auth.znode.groupacl;
 
 import java.security.cert.X509Certificate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.PortAssignment;
@@ -62,23 +65,22 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
       CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/DomainX/DomainXUser",
       CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/DomainY",
       CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/DomainY/DomainYUser"};
+  private static final Map<String, String> SYSTEM_PROPERTIES = new HashMap<>();
+    static {
+      SYSTEM_PROPERTIES.put(X509ZNodeGroupAclProvider.ZOOKEEPER_ZNODEGROUPACL_SUPERUSER, "SuperUser");
+      SYSTEM_PROPERTIES.put("zookeeper.ssl.keyManager", "org.apache.zookeeper.test.X509AuthTest.TestKeyManager");
+      SYSTEM_PROPERTIES.put("zookeeper.ssl.trustManager", "org.apache.zookeeper.test.X509AuthTest.TestTrustManager");
+      SYSTEM_PROPERTIES.put(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_TYPE, X509AuthenticationUtil.SUBJECT_ALTERNATIVE_NAME_SHORT);
+      SYSTEM_PROPERTIES.put(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_SAN_MATCH_TYPE, CLIENT_CERT_ID_SAN_MATCH_TYPE);
+      SYSTEM_PROPERTIES.put(AUTH_PROVIDER_PROPERTY_NAME, X509ZNodeGroupAclProvider.class.getCanonicalName());
+      SYSTEM_PROPERTIES.put(ZNodeGroupAclProperties.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath", CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH);
+  }
 
   @Before
   public void setUp() throws Exception {
-    System.setProperty(X509ZNodeGroupAclProvider.ZOOKEEPER_ZNODEGROUPACL_SUPERUSER, "SuperUser");
-    System.setProperty("zookeeper.ssl.keyManager",
-        "org.apache.zookeeper.test.X509AuthTest.TestKeyManager");
-    System.setProperty("zookeeper.ssl.trustManager",
-        "org.apache.zookeeper.test.X509AuthTest.TestTrustManager");
-    System.setProperty(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_TYPE,
-        X509AuthenticationUtil.SUBJECT_ALTERNATIVE_NAME_SHORT);
-    System.setProperty(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_SAN_MATCH_TYPE,
-        CLIENT_CERT_ID_SAN_MATCH_TYPE);
-    System.setProperty(AUTH_PROVIDER_PROPERTY_NAME,
-        X509ZNodeGroupAclProvider.class.getCanonicalName());
-    System.setProperty(
-        ZNodeGroupAclProperties.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath",
-        CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH);
+    for (Map.Entry<String, String> property : SYSTEM_PROPERTIES.entrySet()) {
+      System.setProperty(property.getKey(), property.getValue());
+    }
     LOG.info("Starting Zk...");
     zks = new ZooKeeperServer(testBaseDir, testBaseDir, 3000);
     final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
@@ -110,12 +112,9 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
     zks.shutdown();
     admin.close();
     serverCnxnFactory.shutdown();
-    System.clearProperty(X509ZNodeGroupAclProvider.ZOOKEEPER_ZNODEGROUPACL_SUPERUSER);
-    System.clearProperty(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_TYPE);
-    System.clearProperty(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_SAN_MATCH_TYPE);
-    System.clearProperty(AUTH_PROVIDER_PROPERTY_NAME);
-    System.clearProperty(
-        ZNodeGroupAclProperties.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath");
+    for (Map.Entry<String, String> property : SYSTEM_PROPERTIES.entrySet()) {
+      System.clearProperty(property.getKey());
+    }
   }
 
   @Test

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.zookeeper.server.auth.znode.groupacl;
 
 import java.security.cert.X509Certificate;
@@ -30,7 +48,6 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
   private static X509AuthTest.TestCertificate domainXCert;
   private static X509AuthTest.TestCertificate superCert;
   private static X509AuthTest.TestCertificate unknownCert;
-  private static final String CLIENT_CERT_ID_TYPE = "SAN";
   private static final String CLIENT_CERT_ID_SAN_MATCH_TYPE = "6";
   private static final String SCHEME = "x509";
   private static ZooKeeperServer zks;
@@ -53,10 +70,12 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
         "org.apache.zookeeper.test.X509AuthTest.TestKeyManager");
     System.setProperty("zookeeper.ssl.trustManager",
         "org.apache.zookeeper.test.X509AuthTest.TestTrustManager");
-    System.setProperty(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_TYPE, CLIENT_CERT_ID_TYPE);
+    System.setProperty(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_TYPE,
+        X509AuthenticationUtil.SUBJECT_ALTERNATIVE_NAME_SHORT);
     System.setProperty(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_SAN_MATCH_TYPE,
         CLIENT_CERT_ID_SAN_MATCH_TYPE);
-    System.setProperty(AUTH_PROVIDER_PROPERTY_NAME, X509ZNodeGroupAclProvider.class.getCanonicalName());
+    System.setProperty(AUTH_PROVIDER_PROPERTY_NAME,
+        X509ZNodeGroupAclProvider.class.getCanonicalName());
     System.setProperty(
         ZNodeGroupAclUtil.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath",
         CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelperTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelperTest.java
@@ -68,7 +68,7 @@ public class ZkClientUriDomainMappingHelperTest extends ZKTestCase {
   @Before
   public void setUp() throws IOException, InterruptedException, KeeperException {
     System.setProperty(
-        ZNodeGroupAclUtil.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath",
+        ZNodeGroupAclProperties.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath",
         CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH);
 
     LOG.info("Starting Zk...");
@@ -93,7 +93,7 @@ public class ZkClientUriDomainMappingHelperTest extends ZKTestCase {
     }
 
     System.clearProperty(
-        ZNodeGroupAclUtil.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath");
+        ZNodeGroupAclProperties.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath");
 
     if (zookeeperClientConnection != null) {
       zookeeperClientConnection.close();

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/X509AuthTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/X509AuthTest.java
@@ -47,9 +47,9 @@ import javax.security.auth.x500.X500Principal;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZKTestCase;
-import org.apache.zookeeper.common.ClientX509Util;
 import org.apache.zookeeper.server.MockServerCnxn;
 import org.apache.zookeeper.server.auth.X509AuthenticationProvider;
+import org.apache.zookeeper.server.auth.X509AuthenticationUtil;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -110,12 +110,11 @@ public class X509AuthTest extends ZKTestCase {
         String expectedClientIdFromSANExtraction = "d";
 
     // Set JVM properties to enable SAN-based client id extraction
-    ClientX509Util util = new ClientX509Util();
-    System.setProperty(util.sslClientCertIdType, clientCertIdType);
-    System.setProperty(util.sslClientCertIdSanMatchType, clientCertIdSANMatchType);
-    System.setProperty(util.sslClientCertIdSanMatchRegex, clientCertIdSANMatchRegex);
-    System.setProperty(util.sslClientCertIdSanExtractRegex, clientCertIdSANExtractRegex);
-    System.setProperty(util.sslClientCertIdSanExtractMatcherGroupIndex,
+    System.setProperty(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_TYPE, clientCertIdType);
+    System.setProperty(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_SAN_MATCH_TYPE, clientCertIdSANMatchType);
+    System.setProperty(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_SAN_MATCH_REGEX, clientCertIdSANMatchRegex);
+    System.setProperty(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_SAN_EXTRACT_REGEX, clientCertIdSANExtractRegex);
+    System.setProperty(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_SAN_EXTRACT_MATCHER_GROUP_INDEX,
         clientCertIdSANExtractMatcherGroupIndex);
 
         X509AuthenticationProvider provider = createProvider(clientCert);
@@ -125,11 +124,11 @@ public class X509AuthTest extends ZKTestCase {
         assertEquals(expectedClientIdFromSANExtraction, cnxn.getAuthInfo().get(0).getId());
 
     // Remove JVM properties so they don't interfere with other tests
-    System.clearProperty(util.sslClientCertIdType);
-    System.clearProperty(util.sslClientCertIdSanMatchType);
-    System.clearProperty(util.sslClientCertIdSanMatchRegex);
-    System.clearProperty(util.sslClientCertIdSanExtractRegex);
-    System.clearProperty(util.sslClientCertIdSanExtractMatcherGroupIndex);
+    System.clearProperty(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_TYPE);
+    System.clearProperty(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_SAN_MATCH_TYPE);
+    System.clearProperty(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_SAN_MATCH_REGEX);
+    System.clearProperty(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_SAN_EXTRACT_REGEX);
+    System.clearProperty(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_SAN_EXTRACT_MATCHER_GROUP_INDEX);
   }
 
   protected static class TestPublicKey implements PublicKey {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/X509AuthTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/X509AuthTest.java
@@ -149,170 +149,136 @@ public class X509AuthTest extends ZKTestCase {
 
     }
 
-  public static class TestCertificate extends X509Certificate {
-      @VisibleForTesting
-      static final String TEST_SAN_STR = "a:b:c(d;e;f)";
-      private byte[] encoded;
-      private X500Principal principal;
-      private PublicKey publicKey;
-      private String subjectAlternativeName;
+    public static class TestCertificate extends X509Certificate {
+        @VisibleForTesting
+        static final String TEST_SAN_STR = "a:b:c(d;e;f)";
+        private byte[] encoded;
+        private X500Principal principal;
+        private PublicKey publicKey;
+        private String subjectAlternativeName;
 
-      public TestCertificate(String name) {
-        this(name, TEST_SAN_STR);
-      }
+        public TestCertificate(String name) {
+          this(name, TEST_SAN_STR);
+        }
 
-      public TestCertificate(String name, String sanVal) {
-        encoded = name.getBytes();
-        principal = new X500Principal("CN=" + name);
-        publicKey = new TestPublicKey();
-        subjectAlternativeName = sanVal;
-      }
-
-      @Override
-      public boolean hasUnsupportedCriticalExtension() {
-        return false;
-      }
-
-      @Override
-      public Set<String> getCriticalExtensionOIDs() {
-        return null;
-      }
-
-      @Override
-      public Set<String> getNonCriticalExtensionOIDs() {
-        return null;
-      }
-
-      @Override
-      public byte[] getExtensionValue(String oid) {
-        return null;
-      }
-
-      @Override
-      public void checkValidity()
-          throws CertificateExpiredException, CertificateNotYetValidException {
-      }
-
-      @Override
-      public void checkValidity(Date date)
-          throws CertificateExpiredException, CertificateNotYetValidException {
-      }
-
-      @Override
-      public int getVersion() {
-        return 0;
-      }
-
-      @Override
-      public BigInteger getSerialNumber() {
-        return null;
-      }
-
-      @Override
-      public Principal getIssuerDN() {
-        return null;
-      }
-
-      @Override
-      public Principal getSubjectDN() {
-        return null;
-      }
-
-      @Override
-      public Date getNotBefore() {
-        return null;
-      }
-
-      @Override
-      public Date getNotAfter() {
-        return null;
-      }
-
-      @Override
-      public byte[] getTBSCertificate() throws CertificateEncodingException {
-        return null;
-      }
-
-      @Override
-      public byte[] getSignature() {
-        return null;
-      }
-
-      @Override
-      public String getSigAlgName() {
-        return null;
-      }
-
-      @Override
-      public String getSigAlgOID() {
-        return null;
-      }
-
-      @Override
-      public byte[] getSigAlgParams() {
-        return null;
-      }
-
-      @Override
-      public boolean[] getIssuerUniqueID() {
-        return null;
-      }
-
-      @Override
-      public boolean[] getSubjectUniqueID() {
-        return null;
-      }
-
-      @Override
-      public boolean[] getKeyUsage() {
-        return null;
-      }
-
-      @Override
-      public int getBasicConstraints() {
-        return 0;
-      }
-
-      @Override
-      public byte[] getEncoded() throws CertificateEncodingException {
-        return encoded;
-      }
-
-      @Override
-      public void verify(PublicKey key)
-          throws CertificateException, NoSuchAlgorithmException, InvalidKeyException,
-                 NoSuchProviderException, SignatureException {
-      }
-
-      @Override
-      public void verify(PublicKey key, String sigProvider)
-          throws CertificateException, NoSuchAlgorithmException, InvalidKeyException,
-                 NoSuchProviderException, SignatureException {
-      }
-
-      @Override
-      public String toString() {
-        return null;
-      }
-
-      @Override
-      public PublicKey getPublicKey() {
-        return publicKey;
-      }
-
-      @Override
-      public X500Principal getSubjectX500Principal() {
-        return principal;
-      }
-
-      @Override
-      public Collection<List<?>> getSubjectAlternativeNames() {
-        List<Object> subjectAlternativeNamePair = new ArrayList<>();
-        subjectAlternativeNamePair.add(6);
-        subjectAlternativeNamePair.add(subjectAlternativeName);
-        return Collections.singletonList(subjectAlternativeNamePair);
-      }
-  }
+        public TestCertificate(String name, String sanVal) {
+          encoded = name.getBytes();
+          principal = new X500Principal("CN=" + name);
+          publicKey = new TestPublicKey();
+          subjectAlternativeName = sanVal;
+        }
+          @Override
+        public boolean hasUnsupportedCriticalExtension() {
+            return false;
+        }
+        @Override
+        public Set<String> getCriticalExtensionOIDs() {
+            return null;
+        }
+        @Override
+        public Set<String> getNonCriticalExtensionOIDs() {
+            return null;
+        }
+        @Override
+        public byte[] getExtensionValue(String oid) {
+            return null;
+        }
+        @Override
+        public void checkValidity() throws CertificateExpiredException, CertificateNotYetValidException {
+        }
+        @Override
+        public void checkValidity(Date date) throws CertificateExpiredException, CertificateNotYetValidException {
+        }
+        @Override
+        public int getVersion() {
+            return 0;
+        }
+        @Override
+        public BigInteger getSerialNumber() {
+            return null;
+        }
+        @Override
+        public Principal getIssuerDN() {
+            return null;
+        }
+        @Override
+        public Principal getSubjectDN() {
+            return null;
+        }
+        @Override
+        public Date getNotBefore() {
+            return null;
+        }
+        @Override
+        public Date getNotAfter() {
+            return null;
+        }
+        @Override
+        public byte[] getTBSCertificate() throws CertificateEncodingException {
+            return null;
+        }
+        @Override
+        public byte[] getSignature() {
+            return null;
+        }
+        @Override
+        public String getSigAlgName() {
+            return null;
+        }
+        @Override
+        public String getSigAlgOID() {
+            return null;
+        }
+        @Override
+        public byte[] getSigAlgParams() {
+            return null;
+        }
+        @Override
+        public boolean[] getIssuerUniqueID() {
+            return null;
+        }
+        @Override
+        public boolean[] getSubjectUniqueID() {
+            return null;
+        }
+        @Override
+        public boolean[] getKeyUsage() {
+            return null;
+        }
+        @Override
+        public int getBasicConstraints() {
+            return 0;
+        }
+        @Override
+        public byte[] getEncoded() throws CertificateEncodingException {
+            return encoded;
+        }
+        @Override
+        public void verify(PublicKey key) throws CertificateException, NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException, SignatureException {
+        }
+        @Override
+        public void verify(PublicKey key, String sigProvider) throws CertificateException, NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException, SignatureException {
+        }
+        @Override
+        public String toString() {
+            return null;
+        }
+        @Override
+        public PublicKey getPublicKey() {
+            return publicKey;
+        }
+        @Override
+        public X500Principal getSubjectX500Principal() {
+            return principal;
+        }
+        @Override
+        public Collection<List<?>> getSubjectAlternativeNames() {
+            List<Object> subjectAlternativeNamePair = new ArrayList<>();
+            subjectAlternativeNamePair.add(6);
+            subjectAlternativeNamePair.add(subjectAlternativeName);
+            return Collections.singletonList(subjectAlternativeNamePair);
+        }
+    }
 
     public static class TestKeyManager implements X509KeyManager {
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/X509AuthTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/X509AuthTest.java
@@ -150,134 +150,168 @@ public class X509AuthTest extends ZKTestCase {
     }
 
   public static class TestCertificate extends X509Certificate {
-    @VisibleForTesting
-    static final String TEST_SAN_STR = "a:b:c(d;e;f)";
-    private byte[] encoded;
-    private X500Principal principal;
-    private PublicKey publicKey;
-    private String subjectAlternativeName;
+      @VisibleForTesting
+      static final String TEST_SAN_STR = "a:b:c(d;e;f)";
+      private byte[] encoded;
+      private X500Principal principal;
+      private PublicKey publicKey;
+      private String subjectAlternativeName;
 
-    public TestCertificate(String name) {
-      this(name, TEST_SAN_STR);
-    }
+      public TestCertificate(String name) {
+        this(name, TEST_SAN_STR);
+      }
 
-    public TestCertificate(String name, String sanVal) {
-      encoded = name.getBytes();
-      principal = new X500Principal("CN=" + name);
-      publicKey = new TestPublicKey();
-      subjectAlternativeName = sanVal;
-    }
-    @Override
-    public boolean hasUnsupportedCriticalExtension() {
-      return false;
-    }
-    @Override
-    public Set<String> getCriticalExtensionOIDs() {
-      return null;
-    }
-    @Override
-    public Set<String> getNonCriticalExtensionOIDs() {
-      return null;
-    }
-    @Override
-    public byte[] getExtensionValue(String oid) {
-      return null;
-    }
-    @Override
-    public void checkValidity() throws CertificateExpiredException, CertificateNotYetValidException {
-    }
-    @Override
-    public void checkValidity(Date date) throws CertificateExpiredException, CertificateNotYetValidException {
-    }
-    @Override
-    public int getVersion() {
-      return 0;
-    }
-    @Override
-    public BigInteger getSerialNumber() {
-      return null;
-    }
-    @Override
-    public Principal getIssuerDN() {
-      return null;
-    }
-    @Override
-    public Principal getSubjectDN() {
-      return null;
-    }
-    @Override
-    public Date getNotBefore() {
-      return null;
-    }
-    @Override
-    public Date getNotAfter() {
-      return null;
-    }
-    @Override
-    public byte[] getTBSCertificate() throws CertificateEncodingException {
-      return null;
-    }
-    @Override
-    public byte[] getSignature() {
-      return null;
-    }
-    @Override
-    public String getSigAlgName() {
-      return null;
-    }
-    @Override
-    public String getSigAlgOID() {
-      return null;
-    }
-    @Override
-    public byte[] getSigAlgParams() {
-      return null;
-    }
-    @Override
-    public boolean[] getIssuerUniqueID() {
-      return null;
-    }
-    @Override
-    public boolean[] getSubjectUniqueID() {
-      return null;
-    }
-    @Override
-    public boolean[] getKeyUsage() {
-      return null;
-    }
-    @Override
-    public int getBasicConstraints() {
-      return 0;
-    }
-    @Override
-    public byte[] getEncoded() throws CertificateEncodingException {
-      return encoded;
-    }
-    @Override
-    public void verify(PublicKey key) throws CertificateException, NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException, SignatureException {
-    }
-    @Override
-    public void verify(PublicKey key, String sigProvider) throws CertificateException, NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException, SignatureException {
-    }
-    @Override
-    public String toString() {
-      return null;
-    }
-    @Override
-    public PublicKey getPublicKey() {
-      return publicKey;
-    }
-    @Override
-    public X500Principal getSubjectX500Principal() {
-      return principal;
-    }
-    @Override
-    public Collection<List<?>> getSubjectAlternativeNames() {
-      List<Object> subjectAlternativeNamePair = new ArrayList<>();
-      subjectAlternativeNamePair.add(6);
-      subjectAlternativeNamePair.add(subjectAlternativeName);
-      return Collections.singletonList(subjectAlternativeNamePair);
-    }
+      public TestCertificate(String name, String sanVal) {
+        encoded = name.getBytes();
+        principal = new X500Principal("CN=" + name);
+        publicKey = new TestPublicKey();
+        subjectAlternativeName = sanVal;
+      }
+
+      @Override
+      public boolean hasUnsupportedCriticalExtension() {
+        return false;
+      }
+
+      @Override
+      public Set<String> getCriticalExtensionOIDs() {
+        return null;
+      }
+
+      @Override
+      public Set<String> getNonCriticalExtensionOIDs() {
+        return null;
+      }
+
+      @Override
+      public byte[] getExtensionValue(String oid) {
+        return null;
+      }
+
+      @Override
+      public void checkValidity()
+          throws CertificateExpiredException, CertificateNotYetValidException {
+      }
+
+      @Override
+      public void checkValidity(Date date)
+          throws CertificateExpiredException, CertificateNotYetValidException {
+      }
+
+      @Override
+      public int getVersion() {
+        return 0;
+      }
+
+      @Override
+      public BigInteger getSerialNumber() {
+        return null;
+      }
+
+      @Override
+      public Principal getIssuerDN() {
+        return null;
+      }
+
+      @Override
+      public Principal getSubjectDN() {
+        return null;
+      }
+
+      @Override
+      public Date getNotBefore() {
+        return null;
+      }
+
+      @Override
+      public Date getNotAfter() {
+        return null;
+      }
+
+      @Override
+      public byte[] getTBSCertificate() throws CertificateEncodingException {
+        return null;
+      }
+
+      @Override
+      public byte[] getSignature() {
+        return null;
+      }
+
+      @Override
+      public String getSigAlgName() {
+        return null;
+      }
+
+      @Override
+      public String getSigAlgOID() {
+        return null;
+      }
+
+      @Override
+      public byte[] getSigAlgParams() {
+        return null;
+      }
+
+      @Override
+      public boolean[] getIssuerUniqueID() {
+        return null;
+      }
+
+      @Override
+      public boolean[] getSubjectUniqueID() {
+        return null;
+      }
+
+      @Override
+      public boolean[] getKeyUsage() {
+        return null;
+      }
+
+      @Override
+      public int getBasicConstraints() {
+        return 0;
+      }
+
+      @Override
+      public byte[] getEncoded() throws CertificateEncodingException {
+        return encoded;
+      }
+
+      @Override
+      public void verify(PublicKey key)
+          throws CertificateException, NoSuchAlgorithmException, InvalidKeyException,
+                 NoSuchProviderException, SignatureException {
+      }
+
+      @Override
+      public void verify(PublicKey key, String sigProvider)
+          throws CertificateException, NoSuchAlgorithmException, InvalidKeyException,
+                 NoSuchProviderException, SignatureException {
+      }
+
+      @Override
+      public String toString() {
+        return null;
+      }
+
+      @Override
+      public PublicKey getPublicKey() {
+        return publicKey;
+      }
+
+      @Override
+      public X500Principal getSubjectX500Principal() {
+        return principal;
+      }
+
+      @Override
+      public Collection<List<?>> getSubjectAlternativeNames() {
+        List<Object> subjectAlternativeNamePair = new ArrayList<>();
+        subjectAlternativeNamePair.add(6);
+        subjectAlternativeNamePair.add(subjectAlternativeName);
+        return Collections.singletonList(subjectAlternativeNamePair);
+      }
   }
 
     public static class TestKeyManager implements X509KeyManager {


### PR DESCRIPTION
New class: X509ZNodeGroupAclProvider, X509AuthenticationUtil
Added test: X509ZNodeGroupAclProviderTest
Added an x509-based ServerAuthenticationProvider implementation that does both authentication and authorization for protecting znodes from unauthorized access. Znodes are grouped into domains according to their ownership, and clients are granted access permission to domains.