### PR TITLE
Update AuthInfo of client connections if ZNodeGroupAcl Domains are updated.

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationProvider.java
@@ -97,7 +97,7 @@ public class X509AuthenticationProvider implements AuthenticationProvider {
         String clientId = X509AuthenticationUtil.getClientId(clientCert);
 
         if (clientId.equals(System.getProperty(ZOOKEEPER_X509AUTHENTICATIONPROVIDER_SUPERUSER))) {
-            cnxn.addAuthInfo(new Id("super", clientId));
+            cnxn.addAuthInfo(new Id(X509AuthenticationUtil.SUPERUSER_AUTH_SCHEME, clientId));
             LOG.info("Authenticated Id '{}' as super user", clientId);
         }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationUtil.java
@@ -138,6 +138,9 @@ public class X509AuthenticationUtil extends X509Util {
    * @param clientCert Authenticated X509Certificate associated with the
    *                   remote host.
    * @return Identifier string to be associated with the client.
+   *         The clientId can be any string matched and extracted using regex from Subject Distinguished Name or
+   *         Subject Alternative Name from x509 certificate.
+   *         The clientId string is intended to be an URI for client and map the client to certain domain.
    */
   public static String getClientId(X509Certificate clientCert) {
     String clientCertIdType =
@@ -156,10 +159,13 @@ public class X509AuthenticationUtil extends X509Util {
   }
 
   /**
-   * Authenticate client certificate in the specified server connection object and extract the client Id.
+   * Extract the authenticated client Id from the specified server connection object.
    * @param cnxn Server connection object that contains the certificate.
    * @param trustManager X509 TrustManager for authentication.
-   * @return Client certificate URI as the client Id.
+   * @return Identifier string to be associated with the client.
+   *         The clientId can be any string matched and extracted using regex from Subject Distinguished Name or
+   *         Subject Alternative Name from x509 certificate.
+   *         The clientId string is intended to be an URI for client and map the client to certain domain.
    * @throws KeeperException.AuthFailedException
    */
   public static String getClientId(ServerCnxn cnxn, X509TrustManager trustManager)

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationUtil.java
@@ -59,6 +59,8 @@ public class X509AuthenticationUtil extends X509Util {
   public static final String SSL_X509_CLIENT_CERT_ID_SAN_EXTRACT_MATCHER_GROUP_INDEX =
       "zookeeper.ssl.x509.clientCertIdSanExtractMatcherGroupIndex";
   public static final String SUBJECT_ALTERNATIVE_NAME_SHORT = "SAN";
+  // Super user Auth Id scheme
+  public static final String SUPERUSER_AUTH_SCHEME = "super";
 
   @Override
   protected String getConfigPrefix() {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationUtil.java
@@ -156,6 +156,19 @@ public class X509AuthenticationUtil extends X509Util {
   }
 
   /**
+   * Authenticate client certificate in the specified server connection object and extract the client Id.
+   * @param cnxn Server connection object that contains the certificate.
+   * @param trustManager X509 TrustManager for authentication.
+   * @return Client certificate URI as the client Id.
+   * @throws KeeperException.AuthFailedException
+   */
+  public static String getClientId(ServerCnxn cnxn, X509TrustManager trustManager)
+      throws KeeperException.AuthFailedException {
+    X509Certificate clientCert = X509AuthenticationUtil.getAuthenticatedClientCert(cnxn, trustManager);
+    return X509AuthenticationUtil.getClientId(clientCert);
+  }
+
+  /**
    * Extract SAN field from an X509 certificate
    * @param clientCert Client x509 certificate
    * @return Subject alternative name (SAN) string

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationUtil.java
@@ -168,7 +168,7 @@ public class X509AuthenticationUtil extends X509Util {
    *         The clientId can be any string matched and extracted using regex from Subject Distinguished Name or
    *         Subject Alternative Name from x509 certificate.
    *         The clientId string is intended to be an URI for client and map the client to certain domain.
-   * @throws KeeperException.AuthFailedException
+   * @throws KeeperException.AuthFailedException Failed to authenticate the client certificate
    */
   public static String getClientId(ServerCnxn cnxn, X509TrustManager trustManager)
       throws KeeperException.AuthFailedException {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ClientUriDomainMappingHelper.java
@@ -21,7 +21,6 @@ package org.apache.zookeeper.server.auth.znode.groupacl;
 import java.util.Set;
 import org.apache.zookeeper.server.ServerCnxn;
 
-
 /**
  * Helper class for looking up the domain name for the client connection. It uses the client's
  * Uniform Resource Identifier (URI) to look up the application domain it belongs to.
@@ -45,8 +44,8 @@ public interface ClientUriDomainMappingHelper {
   Set<String> getDomains(String clientUri);
 
   /**
-   * Update the domains in AuthInfo of the specified connection according to the current client URI to domain mapping.
+   * Update the domain-based AuthInfo for the specified connection.
    * @param cnxn Connection to update
    */
-  void updateAuthInfoDomains(ServerCnxn cnxn);
+  void updateDomainBasedAuthInfo(ServerCnxn cnxn);
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ClientUriDomainMappingHelper.java
@@ -19,6 +19,8 @@
 package org.apache.zookeeper.server.auth.znode.groupacl;
 
 import java.util.Set;
+import org.apache.zookeeper.server.ServerCnxn;
+
 
 /**
  * Helper class for looking up the domain name for the client connection. It uses the client's
@@ -41,4 +43,10 @@ public interface ClientUriDomainMappingHelper {
    * @return set of domain names. If not found, returns an empty set.
    */
   Set<String> getDomains(String clientUri);
+
+  /**
+   * Update the domains in AuthInfo of the specified connection according to the current client URI to domain mapping.
+   * @param cnxn Connection to update
+   */
+  void updateAuthInfoDomains(ServerCnxn cnxn);
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ConnectionAuthInfoUpdater.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ConnectionAuthInfoUpdater.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.auth.znode.groupacl;
+
+import java.util.Map;
+import java.util.Set;
+import org.apache.zookeeper.server.ServerCnxn;
+
+/**
+ * Interface that declares method to update connection AuthInfo when the client URI to domain mapping is updated.
+ */
+interface ConnectionAuthInfoUpdater {
+  /**
+   * Update the AuthInfo of all the connections based on the specified client URI to domain information.
+   * @param cnxn connection to be updated.
+   * @param clientUriToDomainNames
+   */
+  void updateAuthInfo(final ServerCnxn cnxn, final Map<String, Set<String>> clientUriToDomainNames);
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
@@ -69,7 +69,6 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
   // Although using "volatile" keyword with double checked locking could prevent the undesired
   //creation of multiple objects; not using here for the consideration of read performance
   private ClientUriDomainMappingHelper uriDomainMappingHelper = null;
-  private static final String ZOOKEEPER_ZNODEGROUPACL_SUPERUSER_AUTH_SCHEME = "super";
 
   public X509ZNodeGroupAclProvider() {
     ZKConfig config = new ZKConfig();
@@ -206,7 +205,7 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
     Set<Id> newAuthIds = new HashSet<>();
     // Check if user belongs to super user group
     if (clientId.equals(superUser) || superUserDomainNames.stream().anyMatch(d -> domains.contains(d))) {
-      newAuthIds.add(new Id(ZOOKEEPER_ZNODEGROUPACL_SUPERUSER_AUTH_SCHEME, clientId));
+      newAuthIds.add(new Id(X509AuthenticationUtil.SUPERUSER_AUTH_SCHEME, clientId));
     } else {
       // Assign Auth Id according to domains
       domains.stream().forEach(d -> newAuthIds.add(new Id(getScheme(), d)));
@@ -232,6 +231,6 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
   }
 
   private boolean isZnodeGroupAclScheme(String scheme) {
-    return scheme.equals(ZOOKEEPER_ZNODEGROUPACL_SUPERUSER_AUTH_SCHEME) || scheme.equals(getScheme());
+    return scheme.equals(X509AuthenticationUtil.SUPERUSER_AUTH_SCHEME) || scheme.equals(getScheme());
   }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
@@ -144,7 +144,7 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
   }
 
   /**
-   * Initialize a new ClientUriDomainMappingHelper instance if no one has been instantiated for the ACL provider.
+   * Initialize a new ClientUriDomainMappingHelper instance if it hasn't been instantiated for the ACL provider.
    * @param zks
    */
   private ClientUriDomainMappingHelper getUriDomainMappingHelper(ZooKeeperServer zks) {
@@ -157,19 +157,19 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
             try {
               String clientId = X509AuthenticationUtil.getClientId(cnxn, trustManager);
               assignAuthInfo(cnxn, clientId,
-                  // If no domain name is found, use cleint Id as default domain name
+                  // If no domain name is found, use client Id as default domain name
                   clientUriToDomainNames.getOrDefault(clientId, Collections.singleton(clientId)));
             } catch (UnsupportedOperationException unsupportedEx) {
               LOG.info(logStrPrefix + "Cannot update AuthInfo for session 0x{} since the operation is not supported.",
                   Long.toHexString(cnxn.getSessionId()));
             } catch (Exception e) {
               LOG.error(logStrPrefix
-                      + "Failed to update AuthInfo for session 0x{}. Revoking all of it's ZNodeGroupAcl AuthInfo.",
+                      + "Failed to update AuthInfo for session 0x{}. Revoking all of its ZNodeGroupAcl AuthInfo.",
                   Long.toHexString(cnxn.getSessionId()), e);
               try {
                 cnxn.getAuthInfo()
                     .stream()
-                    .filter(id -> isNodeGroupAclScheme(id.getScheme()))
+                    .filter(id -> isZnodeGroupAclScheme(id.getScheme()))
                     .forEach(id -> cnxn.removeAuthInfo(id));
               } catch (Exception ex) {
                 LOG.error(logStrPrefix + "Failed to revoke AuthInfo for session 0x{}.",
@@ -216,7 +216,7 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
     Set<Id> currentCnxnAuthIds = new HashSet<>(cnxn.getAuthInfo());
     currentCnxnAuthIds.stream().forEach(id -> {
       // Remove all previously assigned ZNodeGroupAcls that are no longer valid.
-      if (isNodeGroupAclScheme(id.getScheme()) && !newAuthIds.contains(id)) {
+      if (isZnodeGroupAclScheme(id.getScheme()) && !newAuthIds.contains(id)) {
         cnxn.removeAuthInfo(id);
         LOG.info(logStrPrefix + "Authenticated Id '{}' has been removed from session 0x{}.", id,
             Long.toHexString(cnxn.getSessionId()));
@@ -231,7 +231,7 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
     });
   }
 
-  private boolean isNodeGroupAclScheme(String scheme) {
+  private boolean isZnodeGroupAclScheme(String scheme) {
     return scheme.equals(ZOOKEEPER_ZNODEGROUPACL_SUPERUSER_AUTH_SCHEME) || scheme.equals(getScheme());
   }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
@@ -18,7 +18,7 @@
 
 package org.apache.zookeeper.server.auth.znode.groupacl;
 
-import java.security.cert.X509Certificate;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import javax.net.ssl.X509KeyManager;
@@ -33,6 +33,7 @@ import org.apache.zookeeper.server.auth.ServerAuthenticationProvider;
 import org.apache.zookeeper.server.auth.X509AuthenticationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 
 /**
  * A ServerAuthenticationProvider implementation that does both authentication and authorization for protecting znodes from unauthorized access.
@@ -65,10 +66,12 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
   private final String logStrPrefix = this.getClass().getName() + ":: ";
   private final X509TrustManager trustManager;
   private final X509KeyManager keyManager;
-  static final String ZOOKEEPER_ZNODEGROUPACL_SUPERUSER = "zookeeper.znodeGroupAcl.superUser";
+
   // Although using "volatile" keyword with double checked locking could prevent the undesired
   //creation of multiple objects; not using here for the consideration of read performance
   private ClientUriDomainMappingHelper uriDomainMappingHelper = null;
+  private static final String ZOOKEEPER_ZNODEGROUPACL_SUPERUSER_AUTH_SCHEME = "super";
+  static final String ZOOKEEPER_ZNODEGROUPACL_SUPERUSER = "zookeeper.znodeGroupAcl.superUser";
 
   public X509ZNodeGroupAclProvider() {
     ZKConfig config = new ZKConfig();
@@ -83,21 +86,12 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
 
   @Override
   public KeeperException.Code handleAuthentication(ServerObjs serverObjs, byte[] authData) {
+    // Authenticate connection
     ServerCnxn cnxn = serverObjs.getCnxn();
-    X509Certificate clientCert;
     try {
-      clientCert = X509AuthenticationUtil.getAuthenticatedClientCert(cnxn, trustManager);
+      X509AuthenticationUtil.getAuthenticatedClientCert(cnxn, trustManager);
     } catch (KeeperException.AuthFailedException e) {
       return KeeperException.Code.AUTHFAILED;
-    }
-
-    // The clientId can be any string matched and extracted using regex from Subject Distinguished
-    // Name or Subject Alternative Name from x509 certificate.
-    // The clientId string is intended to be an URI for client and map the client to certain domain.
-    //The user can use the properties defined in X509AuthenticationUtil to extract a desired string as clientId.
-    String clientId;
-    try {
-      clientId = X509AuthenticationUtil.getClientId(clientCert);
     } catch (Exception e) {
       // Failed to extract clientId from certificate
       LOG.error(logStrPrefix + "Failed to extract URI from certificate for session 0x{}",
@@ -105,37 +99,19 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
       return KeeperException.Code.OK;
     }
 
-    // User belongs to super user group
-    if (clientId.equals(System.getProperty(ZOOKEEPER_ZNODEGROUPACL_SUPERUSER))) {
-      cnxn.addAuthInfo(new Id("super", clientId));
-      LOG.info("Authenticated Id '{}' as super user", clientId);
-      return KeeperException.Code.OK;
+    try {
+      ClientUriDomainMappingHelper helper = getUriDomainMappingHelper(serverObjs.getZks());
+      // Initially assign AuthInfo to the new connection by triggering the helper update method.
+      // Note the assumption is that the connection has been registered in the ServerCnxnFactory before ZookeeperServer
+      // triggers handleAuthentication call. This is true because first auth request is sent after connection establish
+      // is done. If this design is changed in the future, then triggering overall AuthInfo update for all the "known"
+      // connections won't work.
+      helper.updateAuthInfoDomains(cnxn);
+    } catch (Exception e) {
+      LOG.error(logStrPrefix + "Failed to authorize session 0x{}", Long.toHexString(cnxn.getSessionId()), e);
     }
 
-    // Get authorized domain names for client
-    Set<String> domains = getUriDomainMappingHelper(serverObjs.getZks()).getDomains(clientId);
-    if (domains.isEmpty()) {
-      // If no domain name is found, use URI as domain name
-      domains = new HashSet<>();
-      domains.add(clientId);
-    }
-
-    Set<String> superUserDomainNames =
-        ZNodeGroupAclProperties.getInstance().getSuperUserDomainNames();
-    for (String domain : domains) {
-      // Grant super user privilege to users belong to super user domains
-      if (superUserDomainNames.contains(domain)) {
-        cnxn.addAuthInfo(new Id("super", clientId));
-        LOG.info(
-            logStrPrefix + "Id '{}' belongs to superUser domain '{}', authenticated as super user",
-            clientId, domain);
-      } else {
-        cnxn.addAuthInfo(new Id(getScheme(), domain));
-        LOG.info(logStrPrefix + "Authenticated Id '{}' for Scheme '{}', Domain '{}'.", clientId,
-            getScheme(), domain);
-      }
-    }
-
+    // Authentication is done regardless of whether authorization is done or not.
     return KeeperException.Code.OK;
   }
 
@@ -172,14 +148,87 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
     }
   }
 
+  /**
+   * Initialize a new ClientUriDomainMappingHelper instance if no one has been instantiated for the ACL provider.
+   * @param zks
+   */
   private ClientUriDomainMappingHelper getUriDomainMappingHelper(ZooKeeperServer zks) {
     if (uriDomainMappingHelper == null) {
       synchronized (this) {
         if (uriDomainMappingHelper == null) {
-          uriDomainMappingHelper = new ZkClientUriDomainMappingHelper(zks);
+          ZkClientUriDomainMappingHelper helper = new ZkClientUriDomainMappingHelper(zks);
+          // Set up AuthInfo updater to refresh connection AuthInfo on any client domain changes.
+          helper.setDomainAuthUpdater((cnxn, clientUriToDomainNames) -> {
+            try {
+              String clientId = X509AuthenticationUtil.getClientId(cnxn, trustManager);
+              assignAuthInfo(cnxn, clientId,
+                  // If no domain name is found, use cleint Id as default domain name
+                  clientUriToDomainNames.getOrDefault(clientId, Collections.singleton(clientId)));
+            } catch (UnsupportedOperationException unsupportedEx) {
+              LOG.info(logStrPrefix + "Cannot update AuthInfo for session 0x{} since operations are not supported.",
+                  Long.toHexString(cnxn.getSessionId()));
+            } catch (Exception e) {
+              LOG.error(logStrPrefix + "Failed to update AuthInfo for session 0x{}. Revoking all of it's AuthInfo.",
+                  Long.toHexString(cnxn.getSessionId()), e);
+              try {
+                cnxn.getAuthInfo().stream().forEach(id -> cnxn.removeAuthInfo(id));
+              } catch (Exception ex) {
+                LOG.error(logStrPrefix + "Failed to revoke AuthInfo for session 0x{}.",
+                    Long.toHexString(cnxn.getSessionId()), ex);
+              }
+            }
+          });
+          uriDomainMappingHelper = helper;
+          LOG.info(logStrPrefix + "New UriDomainMappingHelper has been instantiated.");
         }
       }
     }
     return uriDomainMappingHelper;
+  }
+
+  /**
+   * Assign AuthInfo to the specified connection.
+   * Note, do not use this method outside ConnectionAuthInfoUpdater.updateAuthInfo implementation. Otherwise,
+   * concurrency control is required to prevent inconsistent update.
+   *
+   * @param cnxn Client connection to be updated
+   * @param clientId ClientId to be potentially used as the AuthInfo Id if the client is super user.
+   *                 The clientId can be any string matched and extracted using regex from Subject Distinguished
+   *                 Name or Subject Alternative Name from x509 certificate.
+   *                 The clientId string is intended to be an URI for client and map the client to certain domain.
+   *                 The user can use the properties defined in X509AuthenticationUtil to extract a desired string as
+   *                 clientId.
+   * @param domains Domains to be used as the AuthInfo Id.
+   */
+  private void assignAuthInfo(ServerCnxn cnxn, String clientId, Set<String> domains) {
+    Set<String> superUserDomainNames = ZNodeGroupAclProperties.getInstance().getSuperUserDomainNames();
+    String superUser = System.getProperty(ZOOKEEPER_ZNODEGROUPACL_SUPERUSER);
+
+    Set<Id> newAuthIds = new HashSet<>();
+    // Check if user belongs to super user group
+    if (clientId.equals(superUser) || superUserDomainNames.stream().anyMatch(d -> domains.contains(d))) {
+      newAuthIds.add(new Id(ZOOKEEPER_ZNODEGROUPACL_SUPERUSER_AUTH_SCHEME, clientId));
+    }
+    // Assign Auth Id according to domains
+    domains.stream().forEach(d -> newAuthIds.add(new Id(getScheme(), d)));
+
+    // Update the existing connection AuthInfo accordingly.
+    Set<Id> currentCnxnAuthIds = new HashSet<>(cnxn.getAuthInfo());
+    currentCnxnAuthIds.stream().forEach(id -> {
+      if (id.getScheme().equals(ZOOKEEPER_ZNODEGROUPACL_SUPERUSER_AUTH_SCHEME) || id.getScheme().equals(getScheme())) {
+        if (!newAuthIds.contains(id)) {
+          cnxn.removeAuthInfo(id);
+          LOG.info(logStrPrefix + "Authenticated Id '{}' has been removed from session 0x{}.", id,
+              Long.toHexString(cnxn.getSessionId()));
+        }
+      } // else, the Auth Id was not assigned by this provider, don't touch.
+    });
+
+    newAuthIds.stream().forEach(id -> {
+      if (!currentCnxnAuthIds.contains(id)) {
+        cnxn.addAuthInfo(id);
+        LOG.info(logStrPrefix + "Authenticated Id '{}' has been added to session 0x{}.", id, cnxn.getSessionId());
+      }
+    });
   }
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
@@ -146,10 +146,14 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
   public void process(WatchedEvent event) {
     parseZNodeMapping();
     // Update AuthInfo for all the known connections.
+    // TODO Change to read SecureServerCnxnFactory only. The current logic is to support unit test who is not creating
+    // a secured server cnxn factory. It won't cause any problem but is not technically correct.
     ServerCnxnFactory factory =
         zks.getSecureServerCnxnFactory() == null ? zks.getServerCnxnFactory() : zks.getSecureServerCnxnFactory();
-    // TODO Evaluate performance impact and potentially use thread pool to parallelize the AuthInfo update.
-    factory.getConnections().forEach(cnxn -> updateDomainBasedAuthInfo(cnxn));
+    if (factory != null) {
+      // TODO Evaluate performance impact and potentially use thread pool to parallelize the AuthInfo update.
+      factory.getConnections().forEach(cnxn -> updateDomainBasedAuthInfo(cnxn));
+    }
   }
 
   @Override

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
@@ -95,10 +95,9 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
     if (this.updater != null) {
       LOG.error("Client connection ACL updater has been setup. Skip setting up new updater.");
       return false;
-    } else {
-      this.updater = updater;
-      return true;
     }
+    this.updater = updater;
+    return true;
   }
 
   /**
@@ -146,6 +145,7 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
     // Update AuthInfo for all the known connections.
     ServerCnxnFactory factory =
         zks.getSecureServerCnxnFactory() == null ? zks.getServerCnxnFactory() : zks.getSecureServerCnxnFactory();
+    // TODO Evaluate performance impact and potentially use thread pool to parallelize the AuthInfo update.
     factory.getConnections().forEach(cnxn -> updateDomainBasedAuthInfo(cnxn));
   }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
@@ -157,7 +157,7 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
   @Override
   public void updateDomainBasedAuthInfo(ServerCnxn cnxn) {
     if (updater != null && cnxn != null) {
-      // UpdateAuthInfo is triggered on new connection, as well as new domain information.
+      // UpdateAuthInfo is triggered on new connection, as well as any URI-domain map ZNode changes.
       // To prevent inconsistent update, concurrency control is necessary.
       synchronized (updater) {
         updater.updateAuthInfo(cnxn, clientUriToDomainNames);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
@@ -18,11 +18,12 @@
 
 package org.apache.zookeeper.server.auth.znode.groupacl;
 
+import java.net.InetSocketAddress;
 import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
+import java.util.Set;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.PortAssignment;
@@ -32,7 +33,8 @@ import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.Id;
 import org.apache.zookeeper.server.MockServerCnxn;
-import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.apache.zookeeper.server.NIOServerCnxnFactory;
+import org.apache.zookeeper.server.ServerCnxn;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.apache.zookeeper.server.auth.ServerAuthenticationProvider;
 import org.apache.zookeeper.server.auth.X509AuthenticationUtil;
@@ -54,7 +56,7 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
   private static final String CLIENT_CERT_ID_SAN_MATCH_TYPE = "6";
   private static final String SCHEME = "x509";
   private static ZooKeeperServer zks;
-  private ServerCnxnFactory serverCnxnFactory;
+  private TestNIOServerCnxnFactory serverCnxnFactory;
   private ZooKeeper admin;
   private static final String AUTH_PROVIDER_PROPERTY_NAME = "zookeeper.authProvider.x509";
   private static final String CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH = "/_CLIENT_URI_DOMAIN_MAPPING";
@@ -84,7 +86,8 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
     LOG.info("Starting Zk...");
     zks = new ZooKeeperServer(testBaseDir, testBaseDir, 3000);
     final int PORT = Integer.parseInt(HOSTPORT.split(":")[1]);
-    serverCnxnFactory = ServerCnxnFactory.createFactory(PORT, -1);
+    serverCnxnFactory = new TestNIOServerCnxnFactory();
+    serverCnxnFactory.configure(new InetSocketAddress(PORT), -1, -1);
     serverCnxnFactory.startup(zks);
     LOG.info("Waiting for server startup");
     Assert.assertTrue("waiting for server being up ", ClientBase.waitForServerUp(HOSTPORT, 300000));
@@ -165,9 +168,62 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
     Assert.assertEquals("SuperUser", authInfo.get(0).getId());
   }
 
+  @Test
+  public void testAuthInfoAutoUpdate() throws InterruptedException, KeeperException {
+    String clientId = "DomainZUser";
+    X509AuthTest.TestCertificate domainZCert = new X509AuthTest.TestCertificate("CLIENT", clientId);
+    String orgDomain = CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/DomainZ";
+    String newDomain = CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/DomainZN";
+
+    admin.create(orgDomain, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+    admin.create(orgDomain + "/" + clientId, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+
+    // Test with original domain info
+    X509ZNodeGroupAclProvider provider = createProvider(domainZCert);
+    MockServerCnxn cnxn = new MockServerCnxn();
+
+    // Inject the new connection to factory so it's AuthInfo will be auto-refreshed.
+    serverCnxnFactory.getClients().add(cnxn);
+
+    // Check the original status.
+    cnxn.clientChain = new X509Certificate[]{domainZCert};
+    Assert.assertEquals(KeeperException.Code.OK, provider
+        .handleAuthentication(new ServerAuthenticationProvider.ServerObjs(zks, cnxn), new byte[0]));
+    List<Id> authInfo = cnxn.getAuthInfo();
+    Assert.assertEquals(1, authInfo.size());
+    Assert.assertEquals(SCHEME, authInfo.get(0).getScheme());
+    Assert.assertEquals("DomainZ", authInfo.get(0).getId());
+
+    // Add new domain info.
+    admin.create(newDomain, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+    admin.create(newDomain + "/" + clientId, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+    waitFor("AuthInfo is not updated after new domain created.", () -> {
+      return cnxn.getAuthInfo().size() == 2;
+    }, 3);
+
+    // Remove the original domain info
+    admin.delete(orgDomain + "/" + clientId, -1);
+    admin.delete(orgDomain, -1);
+    waitFor("AuthInfo is not updated after old domain removed.", () -> {
+      List<Id> newAuthInfo = cnxn.getAuthInfo();
+      return 1 == newAuthInfo.size() &&
+          SCHEME.equals(newAuthInfo.get(0).getScheme()) &&
+          newAuthInfo.get(0).getId().equals("DomainZN");
+    }, 3);
+  }
+
   private X509ZNodeGroupAclProvider createProvider(X509Certificate trustedCert) {
     return new X509ZNodeGroupAclProvider(new X509AuthTest.TestTrustManager(trustedCert),
         new X509AuthTest.TestKeyManager());
+  }
+
+  /**
+   * Special ServerCnxnFactory which Exposes the client list for testing auto-refresh AuthInfo.
+   */
+  class TestNIOServerCnxnFactory extends NIOServerCnxnFactory {
+    Set<ServerCnxn> getClients() {
+      return cnxns;
+    }
   }
 }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
@@ -172,11 +172,11 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
   public void testAuthInfoAutoUpdate() throws InterruptedException, KeeperException {
     String clientId = "DomainZUser";
     X509AuthTest.TestCertificate domainZCert = new X509AuthTest.TestCertificate("CLIENT", clientId);
-    String orgDomain = CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/DomainZ";
+    String oldDomain = CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/DomainZ";
     String newDomain = CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/DomainZN";
 
-    admin.create(orgDomain, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-    admin.create(orgDomain + "/" + clientId, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+    admin.create(oldDomain, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+    admin.create(oldDomain + "/" + clientId, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
 
     // Test with original domain info
     X509ZNodeGroupAclProvider provider = createProvider(domainZCert);
@@ -202,8 +202,8 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
     }, 3);
 
     // Remove the original domain info
-    admin.delete(orgDomain + "/" + clientId, -1);
-    admin.delete(orgDomain, -1);
+    admin.delete(oldDomain + "/" + clientId, -1);
+    admin.delete(oldDomain, -1);
     waitFor("AuthInfo is not updated after old domain removed.", () -> {
       List<Id> newAuthInfo = cnxn.getAuthInfo();
       return 1 == newAuthInfo.size() &&


### PR DESCRIPTION
This PR aims to introduce an automatic AuthInfo update logic which is triggered on ZNodeGroupAcl domain information change. The update method relies on the internal watcher that listens on the ZNodeGroupAcl domain znode. The additional authorization (as well as the automatic update) logic is executed on top of the authentication logic. Authorization failure won't impact the authentication result.

The new change is covered by X509ZNodeGroupAclProviderTest.testAuthInfoAutoUpdate.

Test result of group-Acl-related tests:
1.20 s X509ZNodeGroupAclProviderTest
    598 ms passed X509ZNodeGroupAclProviderTest.testAuthInfoAutoUpdate
    152 ms passed X509ZNodeGroupAclProviderTest.testUntrustedClient
    152 ms passed X509ZNodeGroupAclProviderTest.testSuperUser
    153 ms passed X509ZNodeGroupAclProviderTest.testAuthorizedClient
    146 ms passed X509ZNodeGroupAclProviderTest.testUnauthorizedClient
2.30 s ZkClientUriDomainMappingHelperTest
    1.14 s passed ZkClientUriDomainMappingHelperTest.testA_ZkClientUriDomainMappingHelper
    1.16 s passed ZkClientUriDomainMappingHelperTest.testB_ZkClientUriDomainMappingHelper