### PR TITLE
Add more tests for super user domain

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
@@ -65,7 +65,6 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
   private final String logStrPrefix = this.getClass().getName() + ":: ";
   private final X509TrustManager trustManager;
   private final X509KeyManager keyManager;
-  static final String ZOOKEEPER_ZNODEGROUPACL_SUPERUSER = "zookeeper.znodeGroupAcl.superUser";
   // Although using "volatile" keyword with double checked locking could prevent the undesired
   //creation of multiple objects; not using here for the consideration of read performance
   private ClientUriDomainMappingHelper uriDomainMappingHelper = null;
@@ -208,7 +207,7 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
    */
   private void assignAuthInfo(ServerCnxn cnxn, String clientId, Set<String> domains) {
     Set<String> superUserDomainNames = ZNodeGroupAclProperties.getInstance().getSuperUserDomainNames();
-    String superUser = System.getProperty(ZOOKEEPER_ZNODEGROUPACL_SUPERUSER);
+    String superUser = System.getProperty(ZNodeGroupAclProperties.ZOOKEEPER_ZNODEGROUPACL_SUPERUSER);
 
     Set<Id> newAuthIds = new HashSet<>();
     // Check if user belongs to super user group

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclProperties.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclProperties.java
@@ -120,7 +120,8 @@ public class ZNodeGroupAclProperties {
     return superUserDomainNames;
   }
 
-  public static void reset() {
+  @VisibleForTesting
+  public static void clearProperties() {
     synchronized (ZNodeGroupAclProperties.class) {
       instance = null;
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclProperties.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZNodeGroupAclProperties.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
+import com.google.common.annotations.VisibleForTesting;
 
 /**
  * Configured properties for ZNode Group ACL feature
@@ -54,8 +55,11 @@ public class ZNodeGroupAclProperties {
   public static final String SET_X509_CLIENT_ID_AS_ACL =
       ZNODE_GROUP_ACL_CONFIG_PREFIX + "setX509ClientIdAsAcl";
   // A list of domain names that will have super user privilege, separated by ","
-  private static final String SUPER_USER_DOMAIN_NAME =
+  @VisibleForTesting
+  static final String SUPER_USER_DOMAIN_NAME =
       ZNODE_GROUP_ACL_CONFIG_PREFIX + "superUserDomainName";
+  // A defined URI represents a super user
+  static final String ZOOKEEPER_ZNODEGROUPACL_SUPERUSER = "zookeeper.znodeGroupAcl.superUser";
   // A list of znode path prefixes, separated by ","
   // Znode whose path starts with the defined path prefix would have open read access
   // Meaning the znode will have (world:anyone, r) ACL
@@ -114,5 +118,11 @@ public class ZNodeGroupAclProperties {
       }
     }
     return superUserDomainNames;
+  }
+
+  public static void reset() {
+    synchronized (ZNodeGroupAclProperties.class) {
+      instance = null;
+    }
   }
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
@@ -115,7 +115,7 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
 
   @After
   public void cleanUp() throws InterruptedException, KeeperException {
-    ZNodeGroupAclProperties.reset();
+    ZNodeGroupAclProperties.clearProperties();
     ZKUtil.deleteRecursive(admin, CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH);
     zks.shutdown();
     admin.close();

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
@@ -53,6 +53,7 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
   private static X509AuthTest.TestCertificate domainXCert;
   private static X509AuthTest.TestCertificate superCert;
   private static X509AuthTest.TestCertificate unknownCert;
+  private static X509AuthTest.TestCertificate crossDomainCert;
   private static final String CLIENT_CERT_ID_SAN_MATCH_TYPE = "6";
   private static final String SCHEME = "x509";
   private static ZooKeeperServer zks;
@@ -62,21 +63,23 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
   private static final String CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH = "/_CLIENT_URI_DOMAIN_MAPPING";
   private static final String[] MAPPING_PATHS = {CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH,
       CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/CrossDomain",
-      CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/CrossDomain/SuperUser",
+      CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/CrossDomain/CrossDomainUser",
       CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/DomainX",
       CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/DomainX/DomainXUser",
       CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/DomainY",
       CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/DomainY/DomainYUser"};
   private static final Map<String, String> SYSTEM_PROPERTIES = new HashMap<>();
     static {
-      SYSTEM_PROPERTIES.put(X509ZNodeGroupAclProvider.ZOOKEEPER_ZNODEGROUPACL_SUPERUSER, "SuperUser");
+      SYSTEM_PROPERTIES.put(ZNodeGroupAclProperties.ZOOKEEPER_ZNODEGROUPACL_SUPERUSER, "SuperUser");
       SYSTEM_PROPERTIES.put("zookeeper.ssl.keyManager", "org.apache.zookeeper.test.X509AuthTest.TestKeyManager");
       SYSTEM_PROPERTIES.put("zookeeper.ssl.trustManager", "org.apache.zookeeper.test.X509AuthTest.TestTrustManager");
       SYSTEM_PROPERTIES.put(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_TYPE, X509AuthenticationUtil.SUBJECT_ALTERNATIVE_NAME_SHORT);
       SYSTEM_PROPERTIES.put(X509AuthenticationUtil.SSL_X509_CLIENT_CERT_ID_SAN_MATCH_TYPE, CLIENT_CERT_ID_SAN_MATCH_TYPE);
       SYSTEM_PROPERTIES.put(AUTH_PROVIDER_PROPERTY_NAME, X509ZNodeGroupAclProvider.class.getCanonicalName());
       SYSTEM_PROPERTIES.put(ZNodeGroupAclProperties.ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath", CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH);
-  }
+      SYSTEM_PROPERTIES.put(ZNodeGroupAclProperties.SUPER_USER_DOMAIN_NAME, "CrossDomain");
+
+    }
 
   @Before
   public void setUp() throws Exception {
@@ -101,6 +104,7 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
     domainXCert = new X509AuthTest.TestCertificate("CLIENT", "DomainXUser");
     superCert = new X509AuthTest.TestCertificate("SUPER", "SuperUser");
     unknownCert = new X509AuthTest.TestCertificate("UNKNOWN", "UnknownUser");
+    crossDomainCert = new X509AuthTest.TestCertificate("CLIENT", "CrossDomainUser");
 
     // Create Client URI - domain mapping znodes
     for (String path : MAPPING_PATHS) {
@@ -111,6 +115,7 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
 
   @After
   public void cleanUp() throws InterruptedException, KeeperException {
+    ZNodeGroupAclProperties.reset();
     ZKUtil.deleteRecursive(admin, CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH);
     zks.shutdown();
     admin.close();
@@ -157,12 +162,24 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
 
   @Test
   public void testSuperUser() {
-    X509ZNodeGroupAclProvider provider = createProvider(superCert);
+    // Belong to super user domain
+    X509ZNodeGroupAclProvider provider = createProvider(crossDomainCert);
     MockServerCnxn cnxn = new MockServerCnxn();
-    cnxn.clientChain = new X509Certificate[]{superCert};
+    cnxn.clientChain = new X509Certificate[]{crossDomainCert};
     Assert.assertEquals(KeeperException.Code.OK, provider
         .handleAuthentication(new ServerAuthenticationProvider.ServerObjs(zks, cnxn), new byte[0]));
     List<Id> authInfo = cnxn.getAuthInfo();
+    Assert.assertEquals(1, authInfo.size());
+    Assert.assertEquals("super", authInfo.get(0).getScheme());
+    Assert.assertEquals("CrossDomainUser", authInfo.get(0).getId());
+
+    // Directly set in config as super user
+    provider = createProvider(superCert);
+    cnxn = new MockServerCnxn();
+    cnxn.clientChain = new X509Certificate[]{superCert};
+    Assert.assertEquals(KeeperException.Code.OK, provider
+        .handleAuthentication(new ServerAuthenticationProvider.ServerObjs(zks, cnxn), new byte[0]));
+    authInfo = cnxn.getAuthInfo();
     Assert.assertEquals(1, authInfo.size());
     Assert.assertEquals("super", authInfo.get(0).getScheme());
     Assert.assertEquals("SuperUser", authInfo.get(0).getId());


### PR DESCRIPTION
This commit add one more test for super user case for X509ZnodeGroupAclProvider. There are two cases where a user is granted as super user: (1) User URI matches with the super user URI (2) User URI is mapped to a super user domain. The previous test only covers (2), this commits add test for (1).