### PR TITLE
Adding X509ZNodeGroupAclProvider support in NettyServerCnxnFactory.

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxnFactory.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxnFactory.java
@@ -71,7 +71,9 @@ import org.apache.zookeeper.common.SSLContextAndOptions;
 import org.apache.zookeeper.common.X509Exception;
 import org.apache.zookeeper.common.X509Exception.SSLContextException;
 import org.apache.zookeeper.server.NettyServerCnxn.HandshakeState;
+import org.apache.zookeeper.server.auth.AuthenticationProvider;
 import org.apache.zookeeper.server.auth.ProviderRegistry;
+import org.apache.zookeeper.server.auth.ServerAuthenticationProvider;
 import org.apache.zookeeper.server.auth.X509AuthenticationProvider;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
 import org.slf4j.Logger;
@@ -423,15 +425,26 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
 
                     String authProviderProp = System.getProperty(x509Util.getSslAuthProviderProperty(), "x509");
 
-                    X509AuthenticationProvider authProvider = (X509AuthenticationProvider) ProviderRegistry.getProvider(authProviderProp);
+                    X509AuthenticationProvider authProvider = null;
+                    ServerAuthenticationProvider serverAuthProvider = null;
+                    try {
+                        authProvider = (X509AuthenticationProvider) ProviderRegistry.getProvider(authProviderProp);
+                    } catch (ClassCastException e) {
+                        serverAuthProvider = ProviderRegistry.getServerProvider(authProviderProp);
+                    }
 
-                    if (authProvider == null) {
+                    if (authProvider == null && serverAuthProvider == null) {
                         LOG.error("X509 Auth provider not found: {}", authProviderProp);
                         cnxn.close(ServerCnxn.DisconnectReason.AUTH_PROVIDER_NOT_FOUND);
                         return;
                     }
 
-                    KeeperException.Code code = authProvider.handleAuthentication(cnxn, null);
+                    KeeperException.Code code = KeeperException.Code.AUTHFAILED;
+                    if (authProvider != null) {
+                        code = authProvider.handleAuthentication(cnxn, null);
+                    } else if (serverAuthProvider != null) {
+                        code = serverAuthProvider.handleAuthentication(new ServerAuthenticationProvider.ServerObjs(zkServer, cnxn), null);
+                    }
                     if (KeeperException.Code.OK != code) {
                         zkServer.serverStats().incrementAuthFailedCount();
                         LOG.error("Authentication failed for session 0x{}", Long.toHexString(cnxn.getSessionId()));

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxnFactory.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxnFactory.java
@@ -425,6 +425,9 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
 
                     String authProviderProp = System.getProperty(x509Util.getSslAuthProviderProperty(), "x509");
 
+                    // All customer variatoins of AuthenticationProvider should be supported here. Currently
+                    // any variation of X509AuthenticationProvider or ServerAuthenticationProvider is supported with
+                    // backward compatability.
                     X509AuthenticationProvider authProvider = null;
                     ServerAuthenticationProvider serverAuthProvider = null;
                     try {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxnFactory.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxnFactory.java
@@ -425,9 +425,9 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
 
                     String authProviderProp = System.getProperty(x509Util.getSslAuthProviderProperty(), "x509");
 
-                    // All customer variatoins of AuthenticationProvider should be supported here. Currently
-                    // any variation of X509AuthenticationProvider or ServerAuthenticationProvider is supported with
-                    // backward compatability.
+                    // All implementations of the AuthenticationProvider interface should be supported here. Currently
+                    // any custom implementation of X509AuthenticationProvider or ServerAuthenticationProvider is
+                    // supported with backward compatability.
                     X509AuthenticationProvider authProvider = null;
                     ServerAuthenticationProvider serverAuthProvider = null;
                     try {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/ServerAuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/ServerAuthenticationProvider.java
@@ -132,8 +132,7 @@ public abstract class ServerAuthenticationProvider implements AuthenticationProv
      */
     public abstract boolean matches(ServerObjs serverObjs, MatchValues matchValues);
 
-    @Override
-    public final KeeperException.Code handleAuthentication(ServerCnxn cnxn, byte[] authData) {
+    public KeeperException.Code handleAuthentication(ServerCnxn cnxn, byte[] authData) {
         throw new UnsupportedOperationException();
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/ServerAuthenticationProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/ServerAuthenticationProvider.java
@@ -132,7 +132,8 @@ public abstract class ServerAuthenticationProvider implements AuthenticationProv
      */
     public abstract boolean matches(ServerObjs serverObjs, MatchValues matchValues);
 
-    public KeeperException.Code handleAuthentication(ServerCnxn cnxn, byte[] authData) {
+    @Override
+    public final KeeperException.Code handleAuthentication(ServerCnxn cnxn, byte[] authData) {
         throw new UnsupportedOperationException();
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
@@ -72,7 +72,7 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
 
     this.rootPath =
         X509AuthenticationConfig.getInstance().getZnodeGroupAclClientUriDomainMappingRootPath();
-    LOG.debug("ZkClientUriDomainMappingHelper::ClientUriDomainMapping Client URI domain mapping root path: {}", this.rootPath);
+    LOG.info("ZkClientUriDomainMappingHelper::ClientUriDomainMapping Client URI domain mapping root path: {}", this.rootPath);
     if (rootPath == null) {
       throw new IllegalStateException(
           "ZkClientUriDomainMappingHelper::ClientUriDomainMapping root path config is not set!");
@@ -127,7 +127,8 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
           List<String> clientUris =
               zks.getZKDatabase().getChildren(rootPath + "/" + domainName, null, null);
           clientUris.forEach(clientUri -> {
-              LOG.debug("ZkClientUriDomainMappingHelper::parseZNodeMapping(): Adding client uri mapping:{} {}", clientUri, domainName);
+              LOG.info("ZkClientUriDomainMappingHelper::parseZNodeMapping(): Adding client uri mapping: domainName : {},"
+                  + " clientUri: {}", domainName, clientUri);
               newClientUriToDomainNames.computeIfAbsent(clientUri, k -> new HashSet<>()).add(domainName);
           });
         } catch (KeeperException.NoNodeException e) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
@@ -72,6 +72,7 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
 
     this.rootPath =
         X509AuthenticationConfig.getInstance().getZnodeGroupAclClientUriDomainMappingRootPath();
+    LOG.debug("Client URI domain mapping root path: {}", this.rootPath);
     if (rootPath == null) {
       throw new IllegalStateException(
           "ZkClientUriDomainMappingHelper::ClientUriDomainMapping root path config is not set!");
@@ -79,7 +80,7 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
 
     if (zks.getZKDatabase().getNode(rootPath) == null) {
       throw new IllegalStateException(
-          "ZkClientUriDomainMappingHelper::ClientUriDomainMapping root path does not exist!");
+          "ZkClientUriDomainMappingHelper::ClientUriDomainMapping root path does not exist :" + rootPath);
     }
 
     addWatches();
@@ -125,8 +126,10 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
         try {
           List<String> clientUris =
               zks.getZKDatabase().getChildren(rootPath + "/" + domainName, null, null);
-          clientUris.forEach(
-              clientUri -> newClientUriToDomainNames.computeIfAbsent(clientUri, k -> new HashSet<>()).add(domainName));
+          for (String clientUri : clientUris) {
+            LOG.debug("Adding client uri mapping:{} {}", clientUri, domainName);
+            newClientUriToDomainNames.computeIfAbsent(clientUri, k -> new HashSet<>()).add(domainName);
+          }
         } catch (KeeperException.NoNodeException e) {
           LOG.warn(
               "ZkClientUriDomainMappingHelper::parseZNodeMapping(): No clientUri ZNodes found under domain: {}",

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
@@ -72,7 +72,7 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
 
     this.rootPath =
         X509AuthenticationConfig.getInstance().getZnodeGroupAclClientUriDomainMappingRootPath();
-    LOG.debug("Client URI domain mapping root path: {}", this.rootPath);
+    LOG.debug("ZkClientUriDomainMappingHelper::ClientUriDomainMapping Client URI domain mapping root path: {}", this.rootPath);
     if (rootPath == null) {
       throw new IllegalStateException(
           "ZkClientUriDomainMappingHelper::ClientUriDomainMapping root path config is not set!");
@@ -126,10 +126,10 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
         try {
           List<String> clientUris =
               zks.getZKDatabase().getChildren(rootPath + "/" + domainName, null, null);
-          for (String clientUri : clientUris) {
-            LOG.debug("Adding client uri mapping:{} {}", clientUri, domainName);
-            newClientUriToDomainNames.computeIfAbsent(clientUri, k -> new HashSet<>()).add(domainName);
-          }
+          clientUris.forEach(clientUri -> {
+              LOG.debug("ZkClientUriDomainMappingHelper::parseZNodeMapping(): Adding client uri mapping:{} {}", clientUri, domainName);
+              newClientUriToDomainNames.computeIfAbsent(clientUri, k -> new HashSet<>()).add(domainName);
+          });
         } catch (KeeperException.NoNodeException e) {
           LOG.warn(
               "ZkClientUriDomainMappingHelper::parseZNodeMapping(): No clientUri ZNodes found under domain: {}",


### PR DESCRIPTION
Currently NettyServerCnxnFactory only support X509AuthenticationProvider as auth provider but new X509ZNodeGroupAclProvider provides custom authentication and authorization logic. Adding support in NettyServerCnxnFactory so that both auth provider could be provided.

Testing : 
Verified that client is able securely connect to zk server with both auth providers (X509ZNodeGroupAclProvider and X509ZNodeGroupAclProvider)
Verified that client is able to connect to plaintextport after unsetting CLIENT_JVMFLAGS