### PR TITLE
Several minor fixes for znode group acl feature

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -1023,13 +1023,13 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
                 for (Id cid : authInfo) {
                     // Special handling for super user / cross domain component use cases when X509ClientIdAsAcl is enabled
                     if (cid.getScheme().equals(X509AuthenticationUtil.SUPERUSER_AUTH_SCHEME)) {
+                        // No need to check authentication provider because user has "super" scheme
                         authIdValid = true;
-                        // Allow operation but do not set client Id as znode ACL for super user
                         if (!cid.getId().equals(
                             X509AuthenticationConfig.getInstance().getZnodeGroupAclSuperUserId())) {
                             // Allow operation but set domain name as znode ACL for cross domain components
-                            rv.add(new ACL(a.getPerms(), new Id("509", cid.getId())));
-                        }
+                            rv.add(new ACL(a.getPerms(), new Id("x509", cid.getId())));
+                        } // else allow operation but do not set client Id as znode ACL for super user
                     } else {
                         ServerAuthenticationProvider ap =
                             ProviderRegistry.getServerProvider(cid.getScheme());

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationConfig.java
@@ -48,21 +48,30 @@ public class X509AuthenticationConfig {
     return instance;
   }
 
+  // The following System Property keys are used to extract clientId from the client cert.
+
   /**
-   * The following System Property keys are used to extract clientId from the client cert.
+   * Config prefix for x509-related config properties.
+   * The property keys start with this prefix apply to both {@link org.apache.zookeeper.server.auth.X509AuthenticationProvider}
+   * and {@link org.apache.zookeeper.server.auth.znode.groupacl.X509ZNodeGroupAclProvider}
    */
   public static final String SSL_X509_CONFIG_PREFIX = "zookeeper.ssl.x509.";
+  /**
+   * Determines which field in the x509 certificate to be used for client Id:
+   * SAN (subject alternative name) or SDN (subject domain name) (default)
+   */
   public static final String SSL_X509_CLIENT_CERT_ID_TYPE =
       SSL_X509_CONFIG_PREFIX + "clientCertIdType";
+  /** The field in SAN to be used for client URI extraction */
   public static final String SSL_X509_CLIENT_CERT_ID_SAN_MATCH_TYPE =
       SSL_X509_CONFIG_PREFIX + "clientCertIdSanMatchType";
-  // Match Regex is used to choose which entry to use, default value ".*"
+  /** Match Regex is used to choose which entry to use, default value ".*" */
   public static final String SSL_X509_CLIENT_CERT_ID_SAN_MATCH_REGEX =
       SSL_X509_CONFIG_PREFIX + "clientCertIdSanMatchRegex";
-  // Extract Regex is used to construct a client ID (acl entity) to return, default value ".*"
+  /** Extract Regex is used to construct a client ID (acl entity) to return, default value ".*" */
   public static final String SSL_X509_CLIENT_CERT_ID_SAN_EXTRACT_REGEX =
       SSL_X509_CONFIG_PREFIX + "clientCertIdSanExtractRegex";
-  // Specifies match group index for the extract regex (i in Matcher.group(i)), default value 0
+  /** Specifies match group index for the extract regex (i in Matcher.group(i)), default value 0 */
   public static final String SSL_X509_CLIENT_CERT_ID_SAN_EXTRACT_MATCHER_GROUP_INDEX =
       SSL_X509_CONFIG_PREFIX + "clientCertIdSanExtractMatcherGroupIndex";
   public static final String SUBJECT_ALTERNATIVE_NAME_SHORT = "SAN";
@@ -73,30 +82,52 @@ public class X509AuthenticationConfig {
   private String clientCertIdSanExtractRegex;
   private int clientCertIdSanExtractMatcherGroupIndex = -1;
 
-  /** ZooKeeper server-side ZNode group ACL feature */
-//   x509ClientIdAsAclEnabled enables/disables whether znodes created by auth'ed clients
-//   should have ACL fields populated with the client Id given by the authentication provider.
-//   Has the same effect as the ZK client using ZooDefs.Ids.CREATOR_ALL_ACL.
+  // ZooKeeper server-side config properties for ZNode group ACL feature
+
+  /**
+   * Config prefix for znode group acl-related config properties
+   */
   public static final String ZNODE_GROUP_ACL_CONFIG_PREFIX = "zookeeper.X509ZNodeGroupAclProvider.";
-  // Enables/disables whether znodes created by auth'ed clients
-  // should have ACL fields populated with the client Id given by the authentication provider.
-  // Has the same effect as the ZK client using ZooDefs.Ids.CREATOR_ALL_ACL.
+
+  /**
+   * Enables/disables whether znodes created by auth'ed clients.
+   * Should be enabled if znode group acl feature is desired; otherwise, it should be disabled.
+   * When this property is enabled:
+   *    1. Should have ACL fields populated with the client Id given by the authentication provider.
+   *    2. Users do not have the right to manually operate on znode ACLs
+   *    3. {@value ZOOKEEPER_ZNODEGROUPACL_SUPERUSER_ID} has the ability to operate on znode ACLs
+   * Has the same effect as the ZK client using ZooDefs.Ids.CREATOR_ALL_ACL.
+   */
   public static final String SET_X509_CLIENT_ID_AS_ACL =
       ZNODE_GROUP_ACL_CONFIG_PREFIX + "setX509ClientIdAsAcl";
-  // A list of domain names that will have cross-domain access privilege, separated by ","
+  /**
+   * A list of domain names that will have cross-domain access privilege, separated by ","
+   */
   public static final String CROSS_DOMAIN_ACCESS_DOMAIN_NAME =
       ZNODE_GROUP_ACL_CONFIG_PREFIX + "crossDomainAccessDomainName";
-  // A defined URI represents a super user, same concept as the original x509 superuser
+  /**
+   * A user-defined URI represents a super user, same concept as the original x509 superuser.
+   * Super user can operate on the znode to set ACLs.
+   */
   public static final String ZOOKEEPER_ZNODEGROUPACL_SUPERUSER_ID =
       ZNODE_GROUP_ACL_CONFIG_PREFIX + "superUserId";
-  // A list of znode path prefixes, separated by ","
-  // Znode whose path starts with the defined path prefix would have open read access
-  // Meaning the znode will have (world:anyone, r) ACL
+  /**
+   * A list of znode path prefixes, separated by ",".
+   * Znode whose path starts with the defined path prefix would have open read access.
+   * Meaning the znode will have (world:anyone, r) ACL.
+   */
   public static final String OPEN_READ_ACCESS_PATH_PREFIX =
       ZNODE_GROUP_ACL_CONFIG_PREFIX + "openReadAccessPathPrefix";
-  // If the server is dedicated for one domain, use this config property to define the domain name,
-  // and enable connection filtering feature for this domain
+  /**
+   * If the server is dedicated for one domain, use this config property to define the domain name,
+   * and enable connection filtering feature for this domain.
+   */
   public static final String DEDICATED_DOMAIN = ZNODE_GROUP_ACL_CONFIG_PREFIX + "dedicatedDomain";
+  /**
+   * The root path for client URI - domain mapping that stored in zk data tree.
+   * Refer to {@link org.apache.zookeeper.server.auth.znode.groupacl.ZkClientUriDomainMappingHelper}
+   * for details about client URI - domain mapping.
+   */
   public static final String CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH =
       ZNODE_GROUP_ACL_CONFIG_PREFIX + "clientUriDomainMappingRootPath";
 
@@ -113,9 +144,8 @@ public class X509AuthenticationConfig {
   private final Object openReadAccessPathPrefixesLock = new Object();
   private final Object crossDomainAccessDomainsLock = new Object();
 
-  /**
-   * Setters for X509 properties
-   */
+  // Setters for X509 properties
+
   public void setClientCertIdType(String clientCertIdType) {
     this.clientCertIdType = clientCertIdType;
   }
@@ -160,9 +190,8 @@ public class X509AuthenticationConfig {
     }
   }
 
-  /**
-   * Setters for X509 Znode Group Acl properties
-   */
+  // Setters for X509 Znode Group Acl properties
+
   public void setX509ClientIdAsAclEnabled(String enabled) {
     x509ClientIdAsAclEnabled = enabled;
   }
@@ -171,7 +200,8 @@ public class X509AuthenticationConfig {
     this.znodeGroupAclSuperUserId = znodeGroupAclSuperUserId;
   }
 
-  public void setZnodeGroupAclCrossDomainAccessDomainNameStr(String znodeGroupAclCrossDomainAccessDomainNameStr) {
+  public void setZnodeGroupAclCrossDomainAccessDomainNameStr(
+      String znodeGroupAclCrossDomainAccessDomainNameStr) {
     this.znodeGroupAclCrossDomainAccessDomainNameStr = znodeGroupAclCrossDomainAccessDomainNameStr;
   }
 
@@ -189,9 +219,8 @@ public class X509AuthenticationConfig {
     this.znodeGroupAclClientUriDomainMappingRootPath = znodeGroupAclClientUriDomainMappingRootPath;
   }
 
-  /**
-   * Getters for X509 properties
-   */
+  // Getters for X509 properties
+
   public String getClientCertIdType() {
     if (clientCertIdType == null) {
       setClientCertIdType(System.getProperty(SSL_X509_CLIENT_CERT_ID_TYPE));
@@ -229,9 +258,8 @@ public class X509AuthenticationConfig {
         : clientCertIdSanExtractMatcherGroupIndex;
   }
 
-  /**
-   * Getters for X509 Znode Group Acl properties
-   */
+  // Getters for X509 Znode Group Acl properties
+
   public boolean isX509ClientIdAsAclEnabled() {
     return Boolean.parseBoolean(x509ClientIdAsAclEnabled) || Boolean
         .parseBoolean(System.getProperty(SET_X509_CLIENT_ID_AS_ACL));

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
@@ -239,9 +239,12 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
       }
     } else {
       domains.forEach(d -> {
+        // For cross domain components, add (super:domainName) in authInfo
+        // "super" scheme gives access to all znodes without checking znode ACL vs authorized domain name
         if (superUserDomainNames.contains(d)) {
           newAuthIds.add(new Id(X509AuthenticationUtil.SUPERUSER_AUTH_SCHEME, d));
         } else {
+          // For other cases, add (x509:domainName) in authInfo
           newAuthIds.add(new Id(getScheme(), d));
         }
       });

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
@@ -219,7 +219,7 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
 
     Set<Id> newAuthIds = new HashSet<>();
     // Check if user belongs to super user group
-    if (clientId.equals(superUser) || superUserDomainNames.stream().anyMatch(d -> domains.contains(d))) {
+    if (clientId.equals(superUser)) {
       newAuthIds.add(new Id(X509AuthenticationUtil.SUPERUSER_AUTH_SCHEME, clientId));
     } else if (X509AuthenticationConfig.getInstance().getZnodeGroupAclServerDedicatedDomain() != null
         && !X509AuthenticationConfig.getInstance().getZnodeGroupAclServerDedicatedDomain().isEmpty()) {
@@ -238,8 +238,13 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
         cnxn.close(ServerCnxn.DisconnectReason.SSL_AUTH_FAILURE);
       }
     } else {
-      // Assign Auth Id according to domains
-      domains.stream().forEach(d -> newAuthIds.add(new Id(getScheme(), d)));
+      domains.forEach(d -> {
+        if (superUserDomainNames.contains(d)) {
+          newAuthIds.add(new Id(X509AuthenticationUtil.SUPERUSER_AUTH_SCHEME, d));
+        } else {
+          newAuthIds.add(new Id(getScheme(), d));
+        }
+      });
     }
 
     // Update the existing connection AuthInfo accordingly.

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
@@ -80,6 +80,8 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
 
     if (zks.getZKDatabase().getNode(rootPath) == null) {
       try {
+        // Create a read-only root path, super user (admins) will need to manually set the correct
+        // ACL to root path in order to add clientUri-domain pairs to the mapping
         zks.getZKDatabase().getDataTree().createNode(rootPath, new byte[0],
             ZooDefs.Ids.READ_ACL_UNSAFE, -1L, -1,
             0L, 0L);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
@@ -79,8 +79,15 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
     }
 
     if (zks.getZKDatabase().getNode(rootPath) == null) {
-      throw new IllegalStateException(
-          "ZkClientUriDomainMappingHelper::ClientUriDomainMapping root path does not exist :" + rootPath);
+      try {
+        zks.getZKDatabase().getDataTree().createNode(rootPath, new byte[0],
+            ZooDefs.Ids.READ_ACL_UNSAFE, -1L, -1,
+            0L, 0L);
+      } catch (Exception e) {
+        LOG.warn(
+            "ZkClientUriDomainMappingHelper::Failed to create client uri domain mapping root path node, exception: ",
+            e);
+      }
     }
 
     addWatches();

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
@@ -171,7 +171,7 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
     List<Id> authInfo = cnxn.getAuthInfo();
     Assert.assertEquals(1, authInfo.size());
     Assert.assertEquals("super", authInfo.get(0).getScheme());
-    Assert.assertEquals("CrossDomainUser", authInfo.get(0).getId());
+    Assert.assertEquals("CrossDomain", authInfo.get(0).getId());
 
     // Directly set in config as super user
     provider = createProvider(superCert);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelperTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelperTest.java
@@ -114,11 +114,13 @@ public class ZkClientUriDomainMappingHelperTest extends ZKTestCase {
   }
 
   /**
-   * Mapping root path hasn't been created - must throw an exception.
+   * Mapping root path hasn't been created - should create the node automatically
    */
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testA_ZkClientUriDomainMappingHelper() {
     new ZkClientUriDomainMappingHelper(zookeeperServer);
+    Assert.assertNotNull(
+        zookeeperServer.getZKDatabase().getNode(CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH));
   }
 
   /**


### PR DESCRIPTION
This PR include fixes:
(1) Create client URI-domain mapping root path node at the instantiation time of ZkClientUriDomainMappingHelper to resolve the problem of ZkClientUriDomainMappingHelper instantiate failure due to missing root path
(2) Change of behavior in `X509ZNodeGroupAclProvider` for authorization on **CrossDomainComponent** cases: 
     - Before this fix: Once authorized, add ("super", clientUri) to authInfo
     - After this fix: Once authorized, add ("super", domainName) to authInfo
(3) Add special handling for **super user / cross domain component** in `PrepRequestProcessor` `fixupACL` method. 
     - Before this fix: The users of these two categories cannot create znodes right now due to the fact that scheme "super" does not have a related AuthenticationProvider, so both cases need special handling.
     - After this fix:
          a. For super user (id) - set the znode that  super user pass in, and set as the znode ACL
          b. For cross domain components -  add the ("x509", domainName) as ACL to the created znodes.