### PR TITLE
Allow super user to set acl

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -1025,11 +1025,14 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
                     if (cid.getScheme().equals(X509AuthenticationUtil.SUPERUSER_AUTH_SCHEME)) {
                         // No need to check authentication provider because user has "super" scheme
                         authIdValid = true;
-                        if (!cid.getId().equals(
+                        if (cid.getId().equals(
                             X509AuthenticationConfig.getInstance().getZnodeGroupAclSuperUserId())) {
-                            // Allow operation but set domain name as znode ACL for cross domain components
+                            // Allow operation and set the passed-in acl list as znode ACL for super user
+                            rv.add(a);
+                        } else {
+                            // Allow operation and set domain name as znode ACL for cross domain components
                             rv.add(new ACL(a.getPerms(), new Id("x509", cid.getId())));
-                        } // else allow operation but do not set client Id as znode ACL for super user
+                        }
                     } else {
                         ServerAuthenticationProvider ap =
                             ProviderRegistry.getServerProvider(cid.getScheme());

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/TestFixupACL.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/TestFixupACL.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper.server.auth.znode.groupacl;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.data.ACL;
+import org.apache.zookeeper.data.Id;
+import org.apache.zookeeper.server.PrepRequestProcessor;
+import org.apache.zookeeper.server.auth.X509AuthenticationConfig;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * This class test fixupACL method in {@link org.apache.zookeeper.server.PrepRequestProcessor}
+ * under the znode group acl settings
+ */
+public class TestFixupACL {
+  private final List<Id> superUserAuthInfo =
+      Collections.singletonList(new Id("super", "superUserId"));
+  private final List<Id> crossDomainComponentAuthInfo =
+      Collections.singletonList(new Id("super", "crossDomain"));
+  private final List<ACL> aclList =
+      Collections.singletonList(new ACL(ZooDefs.Perms.ALL, new Id("x509", "toBeAdded")));
+  private final String testPath = "/zookeeper/testPath";
+  private static final Map<String, String> SYSTEM_PROPERTIES = new HashMap<>();
+
+  static {
+    SYSTEM_PROPERTIES.put(X509AuthenticationConfig.SET_X509_CLIENT_ID_AS_ACL, "true");
+    SYSTEM_PROPERTIES
+        .put(X509AuthenticationConfig.ZOOKEEPER_ZNODEGROUPACL_SUPERUSER_ID, "superUserId");
+    SYSTEM_PROPERTIES.put(X509AuthenticationConfig.CROSS_DOMAIN_ACCESS_DOMAIN_NAME, "crossDomain");
+  }
+
+  @BeforeClass
+  public static void beforeClass() {
+    SYSTEM_PROPERTIES.forEach(System::setProperty);
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    SYSTEM_PROPERTIES.keySet().forEach(System::clearProperty);
+  }
+
+  @Test
+  public void testCrossDomainComponents() throws KeeperException.InvalidACLException {
+    List<ACL> returnedList =
+        PrepRequestProcessor.fixupACL(testPath, crossDomainComponentAuthInfo, aclList);
+    Assert.assertEquals(1, returnedList.size());
+    Id returnedId = returnedList.get(0).getId();
+    Assert.assertEquals("x509", returnedId.getScheme());
+    Assert.assertEquals("crossDomain", returnedId.getId());
+  }
+
+  @Test
+  public void testSuperUserId() throws KeeperException.InvalidACLException {
+    List<ACL> returnedList =
+        PrepRequestProcessor.fixupACL(testPath, superUserAuthInfo, aclList);
+    Assert.assertEquals(1, returnedList.size());
+    Id returnedId = returnedList.get(0).getId();
+    Assert.assertEquals("x509", returnedId.getScheme());
+    Assert.assertEquals("toBeAdded", returnedId.getId());
+  }
+}


### PR DESCRIPTION
Currently, if `isX509ClientIdAsAclEnabled` is set to true, all the acls passed in by user will be overwritten by the zk server, basically users do not have the right to set acls if znode group acl feature is on. But for super user, it should have the privilege to set acls since usually zk admins will be the super users, and when they manage zk clusters, there's need to manually set acls.
This commit allows super users `superUserId` to set acls.