### PR TITLE
Fixing ZNodeGroupAclProvider matches implementation for NPE for connection object

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
@@ -118,14 +118,9 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
 
   @Override
   public boolean matches(ServerObjs serverObjs, MatchValues matchValues) {
-    for (Id id : serverObjs.getCnxn().getAuthInfo()) {
-      // Not checking for super user here because the check is already covered
-      // in checkAcl() in ZookeeperServer.class
-      if (id.getId().equals(matchValues.getAclExpr())) {
-        return true;
-      }
-    }
-    return false;
+    // Not checking for super user here because the check is already covered
+    // in checkAcl() in ZookeeperServer.class
+    return matchValues.getId().equals(matchValues.getAclExpr());
   }
 
   @Override


### PR DESCRIPTION
Issue : In checkACL method if the quorum packet is forwarded to any learner then request object would not have connection object. Hence current way of matching auth id in ZNodeGroupAclProvider would give null pointer exception. 

Fix : Actually ServerAuthenticationProvider MatchValues object does have all the necessary auth info. It is created with ids passed by client and parent ACL's ids. So we can just match these two ids and pass/fail the request.

Test:
Verified that it works for helix-controller-cho ensemble setup.