### PR TITLE
Modify fixupACL for znode group acl use cases

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -1036,7 +1036,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
             }
             if (isProcessed) { // Only for users who are handled by the above logic, return the result,
                 // for others should continue to original fixupACL logic. This variable is necessary
-                // because if path is open read path, its open read ACL will be add to the list,
+                // because if path is open read path, its open read ACL will be added to the list,
                 // regardless of user category, so rv's size won't be a good indicator here.
                 return rv;
             }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -1016,7 +1016,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
         // Examples that will not be handled by the "following logic" are:
         //      x509 super user, plaintext port clients, any user when dedicated server is enabled
         //      -> will go through original zk fixupACL logic
-        boolean isUserProvidedAclOverrode = false;
+        boolean isUserProvidedAclOverriden = false;
         if (X509AuthenticationConfig.getInstance().isX509ClientIdAsAclEnabled()
             && X509AuthenticationConfig.getInstance().isX509ZnodeGroupAclEnabled()
             && !X509AuthenticationConfig.getInstance().isZnodeGroupAclDedicatedServerEnabled()) {
@@ -1029,7 +1029,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
                 if (isX509 || isX509CrossDomainComponent) {
                     rv.add(new ACL(ZooDefs.Perms.ALL,
                         new Id(X509AuthenticationUtil.X509_SCHEME, id.getId())));
-                    isUserProvidedAclOverrode = true;
+                    isUserProvidedAclOverriden = true;
                 }
             }
             // If the znode path contains open read access node path prefix, add (world:anyone, r)
@@ -1037,7 +1037,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
                 .stream().anyMatch(path::startsWith)) {
                 rv.add(new ACL(ZooDefs.Perms.READ, ZooDefs.Ids.ANYONE_ID_UNSAFE));
             }
-            if (isUserProvidedAclOverrode) {
+            if (isUserProvidedAclOverriden) {
                 // Only for users who are handled by the above logic, return the result,
                 // for others should continue to original fixupACL logic. This variable is necessary
                 // because if path is open read path, its open read ACL will be added to the list,

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationConfig.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.zookeeper.server.auth.znode.groupacl.X509ZNodeGroupAclProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -343,9 +344,23 @@ public class X509AuthenticationConfig {
         .filter(str -> str.length() > 0).collect(Collectors.toSet());
   }
 
-  public boolean isDedicatedServerEnabled() {
+  /**
+   * Check if server dedicated domain config property is set
+   * This check is only meaningful when x509 znode group acl feature is enabled
+   * @return true if a domain is set as the server's dedicated domain; false if not set
+   */
+  public boolean isZnodeGroupAclDedicatedServerEnabled() {
     return getZnodeGroupAclServerDedicatedDomain() != null
         && !getZnodeGroupAclServerDedicatedDomain().isEmpty();
+  }
+
+  /**
+   * Check if x509 znode group acl feature is enabled
+   * @return true if enabled; false if not
+   */
+  public boolean isX509ZnodeGroupAclEnabled() {
+    return ProviderRegistry
+        .getServerProvider(X509AuthenticationUtil.X509_SCHEME) instanceof X509ZNodeGroupAclProvider;
   }
 
   @VisibleForTesting

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationConfig.java
@@ -343,6 +343,11 @@ public class X509AuthenticationConfig {
         .filter(str -> str.length() > 0).collect(Collectors.toSet());
   }
 
+  public boolean isDedicatedServerEnabled() {
+    return getZnodeGroupAclServerDedicatedDomain() != null
+        && !getZnodeGroupAclServerDedicatedDomain().isEmpty();
+  }
+
   @VisibleForTesting
   public static void reset() {
     synchronized (X509AuthenticationConfig.class) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationConfig.java
@@ -350,7 +350,7 @@ public class X509AuthenticationConfig {
    * @return true if a domain is set as the server's dedicated domain; false if not set
    */
   public boolean isZnodeGroupAclDedicatedServerEnabled() {
-    return getZnodeGroupAclServerDedicatedDomain() != null
+    return isX509ClientIdAsAclEnabled() && getZnodeGroupAclServerDedicatedDomain() != null
         && !getZnodeGroupAclServerDedicatedDomain().isEmpty();
   }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationUtil.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationUtil.java
@@ -46,6 +46,7 @@ public class X509AuthenticationUtil extends X509Util {
 
   // Super user Auth Id scheme
   public static final String SUPERUSER_AUTH_SCHEME = "super";
+  public static final String X509_SCHEME = "x509";
 
   @Override
   protected String getConfigPrefix() {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
@@ -139,8 +139,11 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
     // Id can be of multiple format since it can be either a domain or a client URI,
     // so the check on Id format can be expensive.
     // For users, the Id to be set is extracted by server therefore it must be of valid format.
+    // Validity of client URI is checked in X509AuthenticationUtil.getClientId when authentication
+    // is done; validity of domain names are checked when client URI - domain pairs are set in
+    // ClientUriDomainMapping.
     // Only superusers can manually set ACL, who we should trust.
-    // Therefore it doesn't seem necessary to perform this check.
+    // Therefore it is necessary to perform this check.
     return true;
   }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
@@ -136,7 +136,11 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
 
   @Override
   public boolean isValid(String id) {
-    // Id can be of multiple format since it can be either a domain or a client URI
+    // Id can be of multiple format since it can be either a domain or a client URI,
+    // so the check on Id format can be expensive.
+    // For users, the Id to be set is extracted by server therefore it must be of valid format.
+    // Only superusers can manually set ACL, who we should trust.
+    // Therefore it doesn't seem necessary to perform this check.
     return true;
   }
 
@@ -212,7 +216,7 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
     // Check if user belongs to super user group
     if (clientId.equals(superUser)) {
       newAuthIds.add(new Id(X509AuthenticationUtil.SUPERUSER_AUTH_SCHEME, clientId));
-    } else if (X509AuthenticationConfig.getInstance().isDedicatedServerEnabled()) {
+    } else if (X509AuthenticationConfig.getInstance().isZnodeGroupAclDedicatedServerEnabled()) {
       // If connection filtering feature is turned on, use connection filtering instead of normal authorization
       String serverNamespace = X509AuthenticationConfig.getInstance().getZnodeGroupAclServerDedicatedDomain();
       if (domains.contains(serverNamespace)) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
@@ -136,12 +136,8 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
 
   @Override
   public boolean isValid(String id) {
-    try {
-      new X500Principal(id);
-      return true;
-    } catch (IllegalArgumentException e) {
-      return false;
-    }
+    // Id can be of multiple format since it can be either a domain or a client URI
+    return true;
   }
 
   /**
@@ -216,8 +212,7 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
     // Check if user belongs to super user group
     if (clientId.equals(superUser)) {
       newAuthIds.add(new Id(X509AuthenticationUtil.SUPERUSER_AUTH_SCHEME, clientId));
-    } else if (X509AuthenticationConfig.getInstance().getZnodeGroupAclServerDedicatedDomain() != null
-        && !X509AuthenticationConfig.getInstance().getZnodeGroupAclServerDedicatedDomain().isEmpty()) {
+    } else if (X509AuthenticationConfig.getInstance().isDedicatedServerEnabled()) {
       // If connection filtering feature is turned on, use connection filtering instead of normal authorization
       String serverNamespace = X509AuthenticationConfig.getInstance().getZnodeGroupAclServerDedicatedDomain();
       if (domains.contains(serverNamespace)) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/TestFixupACL.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/TestFixupACL.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.server.auth.znode.groupacl;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -29,9 +30,10 @@ import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Id;
 import org.apache.zookeeper.server.PrepRequestProcessor;
 import org.apache.zookeeper.server.auth.X509AuthenticationConfig;
-import org.junit.AfterClass;
+import org.apache.zookeeper.server.auth.X509AuthenticationUtil;
+import org.junit.After;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -39,30 +41,44 @@ import org.junit.Test;
  * under the znode group acl settings
  */
 public class TestFixupACL {
+  private final String testPath = "/zookeeper/testPath";
+  private final String dedicatedDomain = "dedicatedDomain";
+  private final String crossDomain = "crossDomain";
+  private final List<Id> singleDomainAuthInfo =
+      Collections.singletonList(new Id(X509AuthenticationUtil.X509_SCHEME, "domain"));
   private final List<Id> superUserAuthInfo =
       Collections.singletonList(new Id("super", "superUserId"));
   private final List<Id> crossDomainComponentAuthInfo =
-      Collections.singletonList(new Id("super", "crossDomain"));
-  private final List<ACL> aclList =
-      Collections.singletonList(new ACL(ZooDefs.Perms.ALL, new Id("x509", "toBeAdded")));
-  private final String testPath = "/zookeeper/testPath";
-  private static final Map<String, String> SYSTEM_PROPERTIES = new HashMap<>();
+      Collections.singletonList(new Id("super", crossDomain));
+  private final List<Id> dedicatedDomainAuthInfo =
+      Collections.singletonList(new Id(X509AuthenticationUtil.X509_SCHEME, dedicatedDomain));
+  private List<ACL> aclList = new ArrayList<>();
 
-  static {
+  {
+    aclList
+        .add(new ACL(ZooDefs.Perms.ALL, new Id(X509AuthenticationUtil.X509_SCHEME, "toBeAdded")));
+    aclList.add(new ACL(ZooDefs.Perms.ALL, ZooDefs.Ids.ANYONE_ID_UNSAFE));
+  }
+
+  private final Map<String, String> SYSTEM_PROPERTIES = new HashMap<>();
+
+  {
+    SYSTEM_PROPERTIES
+        .put("zookeeper.authProvider.x509", X509ZNodeGroupAclProvider.class.getCanonicalName());
     SYSTEM_PROPERTIES.put(X509AuthenticationConfig.SET_X509_CLIENT_ID_AS_ACL, "true");
     SYSTEM_PROPERTIES
         .put(X509AuthenticationConfig.ZOOKEEPER_ZNODEGROUPACL_SUPERUSER_ID, "superUserId");
-    SYSTEM_PROPERTIES.put(X509AuthenticationConfig.CROSS_DOMAIN_ACCESS_DOMAIN_NAME, "crossDomain");
   }
 
-  @BeforeClass
-  public static void beforeClass() {
+  @Before
+  public void before() {
     SYSTEM_PROPERTIES.forEach(System::setProperty);
   }
 
-  @AfterClass
-  public static void afterClass() {
+  @After
+  public void after() {
     SYSTEM_PROPERTIES.keySet().forEach(System::clearProperty);
+    X509AuthenticationConfig.reset();
   }
 
   @Test
@@ -70,18 +86,42 @@ public class TestFixupACL {
     List<ACL> returnedList =
         PrepRequestProcessor.fixupACL(testPath, crossDomainComponentAuthInfo, aclList);
     Assert.assertEquals(1, returnedList.size());
-    Id returnedId = returnedList.get(0).getId();
-    Assert.assertEquals("x509", returnedId.getScheme());
-    Assert.assertEquals("crossDomain", returnedId.getId());
+    Assert.assertTrue(returnedList.contains(
+        new ACL(ZooDefs.Perms.ALL, new Id(X509AuthenticationUtil.X509_SCHEME, crossDomain))));
   }
 
   @Test
   public void testSuperUserId() throws KeeperException.InvalidACLException {
-    List<ACL> returnedList =
-        PrepRequestProcessor.fixupACL(testPath, superUserAuthInfo, aclList);
+    List<ACL> returnedList = PrepRequestProcessor.fixupACL(testPath, superUserAuthInfo, aclList);
+    Assert.assertEquals(2, returnedList.size());
+    Assert.assertTrue(returnedList.containsAll(aclList));
+  }
+
+  @Test
+  public void testSingleDomainUser() throws KeeperException.InvalidACLException {
+    List<ACL> returnedList = PrepRequestProcessor.fixupACL(testPath, singleDomainAuthInfo, aclList);
     Assert.assertEquals(1, returnedList.size());
-    Id returnedId = returnedList.get(0).getId();
-    Assert.assertEquals("x509", returnedId.getScheme());
-    Assert.assertEquals("toBeAdded", returnedId.getId());
+    Assert
+        .assertTrue(returnedList.contains(new ACL(ZooDefs.Perms.ALL, singleDomainAuthInfo.get(0))));
+  }
+
+  @Test
+  public void testCnxnFiltering() throws KeeperException.InvalidACLException {
+    System.setProperty(X509AuthenticationConfig.DEDICATED_DOMAIN, dedicatedDomain);
+    List<ACL> returnedList =
+        PrepRequestProcessor.fixupACL(testPath, dedicatedDomainAuthInfo, aclList);
+    Assert.assertEquals(2, returnedList.size());
+    Assert.assertTrue(returnedList.containsAll(aclList));
+    System.clearProperty(X509AuthenticationConfig.DEDICATED_DOMAIN);
+  }
+
+  @Test
+  public void testOpenReadPaths() throws KeeperException.InvalidACLException {
+    System.setProperty(X509AuthenticationConfig.OPEN_READ_ACCESS_PATH_PREFIX, testPath);
+    List<ACL> returnedList = PrepRequestProcessor.fixupACL(testPath, singleDomainAuthInfo, aclList);
+    Assert.assertEquals(2, returnedList.size());
+    Assert.assertTrue(
+        returnedList.contains(new ACL(ZooDefs.Perms.READ, ZooDefs.Ids.ANYONE_ID_UNSAFE)));
+    System.clearProperty(X509AuthenticationConfig.OPEN_READ_ACCESS_PATH_PREFIX);
   }
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/TestFixupACL.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/TestFixupACL.java
@@ -93,6 +93,8 @@ public class TestFixupACL {
 
   @Test
   public void testCrossDomainComponents() throws KeeperException.InvalidACLException {
+    // User provided ACL list will not be honored for cross domain components.
+    // (x509 :  domain name) will be set to the znodes
     List<ACL> returnedList =
         PrepRequestProcessor.fixupACL(testPath, crossDomainComponentAuthInfo, aclList);
     Assert.assertEquals(1, returnedList.size());
@@ -102,6 +104,8 @@ public class TestFixupACL {
 
   @Test
   public void testSuperUserId() throws KeeperException.InvalidACLException {
+    // User provided ACL list will be honored for super users.
+    // No additional ACLs to be set to the znodes besides the user provided ACL list
     List<ACL> returnedList = PrepRequestProcessor.fixupACL(testPath, superUserAuthInfo, aclList);
     Assert.assertEquals(2, returnedList.size());
     Assert.assertTrue(returnedList.containsAll(aclList));
@@ -109,6 +113,8 @@ public class TestFixupACL {
 
   @Test
   public void testSingleDomainUser() throws KeeperException.InvalidACLException {
+    // User provided ACL list will not be honored for single domain users.
+    // (x509 :  domain name) will be set to the znodes
     List<ACL> returnedList = PrepRequestProcessor.fixupACL(testPath, singleDomainAuthInfo, aclList);
     Assert.assertEquals(1, returnedList.size());
     Assert
@@ -116,7 +122,8 @@ public class TestFixupACL {
   }
 
   @Test
-  public void testCnxnFiltering() throws KeeperException.InvalidACLException {
+  public void testDedicatedServer() throws KeeperException.InvalidACLException {
+    // Should route to original fixupACL logic
     System.setProperty(X509AuthenticationConfig.DEDICATED_DOMAIN, dedicatedDomain);
     List<ACL> returnedList =
         PrepRequestProcessor.fixupACL(testPath, dedicatedDomainAuthInfo, aclList);
@@ -127,6 +134,7 @@ public class TestFixupACL {
 
   @Test
   public void testOpenReadPaths() throws KeeperException.InvalidACLException {
+    // Should add (world: anyone, r) to returned ACL list
     System.setProperty(X509AuthenticationConfig.OPEN_READ_ACCESS_PATH_PREFIX, testPath);
     List<ACL> returnedList = PrepRequestProcessor.fixupACL(testPath, singleDomainAuthInfo, aclList);
     Assert.assertEquals(2, returnedList.size());
@@ -137,6 +145,8 @@ public class TestFixupACL {
 
   @Test
   public void testMultiId() throws KeeperException.InvalidACLException {
+    // User provided ACL list will not be honored for single domain users.
+    // One ACL of (x509 :  domain name) for each of the Id in authInfo will be set to the znodes
     List<ACL> returnedList = PrepRequestProcessor.fixupACL(testPath, multiIdAuthInfo, aclList);
     Assert.assertEquals(2, returnedList.size());
     multiIdAuthInfo
@@ -145,6 +155,7 @@ public class TestFixupACL {
 
   @Test
   public void testNonX509ZnodeGroupAclUser() throws KeeperException.InvalidACLException {
+    // Should route to original fixupACL logic
     List<ACL> returnedList = PrepRequestProcessor.fixupACL(testPath, nonX509AuthInfo, aclList);
     Assert.assertEquals(2, returnedList.size());
     Assert.assertTrue(returnedList.containsAll(aclList));


### PR DESCRIPTION
When isX509ClientIdAsAclEnabled is set to true and using X509ZNodeGroupAclProvider as the auth provider, when client send a request, it goes through fixupACL and the results are:
1. If server is dedicated server -> native zk fixupACL logic
2. Client is plaintext port user (no "x509" scheme in authInfo) -> native zk fixupACL logic
3. Client is authenticated by X509ZNodeGroupAclProvider but is not authorized to a domain -> set (x509, clientURI) as znode acl
4. Client is authorized by X509ZNodeGroupAclProvider to a domain  -> set (x509, domain) as znode acl
5. Client is authorized by X509ZNodeGroupAclProvider as a cross domain component -> set (x509, domain) as znode acl
6. Client is authorized by X509ZNodeGroupAclProvider as a super user -> set acl list as znode acl