### PR TITLE
Dedicated server condition fix and log improvements

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationConfig.java
@@ -350,7 +350,7 @@ public class X509AuthenticationConfig {
    * @return true if a domain is set as the server's dedicated domain; false if not set
    */
   public boolean isZnodeGroupAclDedicatedServerEnabled() {
-    return isX509ClientIdAsAclEnabled() && getZnodeGroupAclServerDedicatedDomain() != null
+    return isX509ZnodeGroupAclEnabled() && getZnodeGroupAclServerDedicatedDomain() != null
         && !getZnodeGroupAclServerDedicatedDomain().isEmpty();
   }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
@@ -253,15 +253,16 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
       // Remove all previously assigned ZNodeGroupAcls that are no longer valid.
       if (isZnodeGroupAclScheme(id.getScheme()) && !newAuthIds.contains(id)) {
         cnxn.removeAuthInfo(id);
-        LOG.info(logStrPrefix + "Authenticated Id '{}' has been removed from session 0x{}.", id,
-            Long.toHexString(cnxn.getSessionId()));
+        LOG.info(logStrPrefix + "Authenticated Id 'scheme: {}, id: {}' has been removed from session 0x{}.",
+            id.getScheme(), id.getId(), Long.toHexString(cnxn.getSessionId()));
       }
     });
 
     newAuthIds.stream().forEach(id -> {
       if (!currentCnxnAuthIds.contains(id)) {
         cnxn.addAuthInfo(id);
-        LOG.info(logStrPrefix + "Authenticated Id '{}' has been added to session 0x{}.", id, cnxn.getSessionId());
+        LOG.info(logStrPrefix + "Authenticated Id 'scheme: {}, id: {}' has been added to session 0x{}.", id.getScheme(),
+            id.getId(), Long.toHexString(cnxn.getSessionId()));
       }
     });
   }


### PR DESCRIPTION
Bug fix: `isZnodeGroupAclDedicatedServerEnabled()` condition is incorrect and failing tests. Now all tests pass. 

Log improvements: remove newline in the log by not using `Id.toString()`. 