### PR TITLE
Allow it initialize client-uri-domain mapping helper even when root path does not exist.

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
@@ -85,7 +85,7 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
     }
 
     if (zks.getZKDatabase().getNode(rootPath) == null) {
-        throw new IllegalStateException("ZkClientUriDomainMappingHelper::ClientUriDomainMapping root path is not present!");
+      LOG.info("ZkClientUriDomainMappingHelper::ClientUriDomainMapping Client URI domain mapping root path {} does not exist.", this.rootPath);
     }
 
     addWatches();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
@@ -85,7 +85,7 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
     }
 
     if (zks.getZKDatabase().getNode(rootPath) == null) {
-      LOG.info("ZkClientUriDomainMappingHelper::ClientUriDomainMapping Client URI domain mapping root path {} does not exist.", this.rootPath);
+      LOG.warn("ZkClientUriDomainMappingHelper::ClientUriDomainMapping Client URI domain mapping root path {} does not exist.", this.rootPath);
     }
 
     addWatches();


### PR DESCRIPTION
Issue :
Previously ZkClientUriDomainMappingHelper used to throw exception if uri-domain-map root path does not exist. This has been an issue since uri-domain-map root path could not be created by zookeeper server itself.

Fix :
It's okay to create ZkClientUriDomainMappingHelper even if root path does not exist because watcher can be added on znode paths which are not present at that the time of creation.
