### PR TITLE
Adding zk server metrics to track connections on unified client port.

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxnFactory.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxnFactory.java
@@ -169,6 +169,7 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
         @Override
         protected SslHandler newSslHandler(ChannelHandlerContext context, SslContext sslContext) {
             NettyServerCnxn cnxn = Objects.requireNonNull(context.channel().attr(CONNECTION_ATTRIBUTE).get());
+            ServerMetrics.getMetrics().UNIFIED_PORT_SSL_REQUESTS.add(1);
             LOG.debug("creating ssl handler for session {}", cnxn.getSessionId());
             SslHandler handler = super.newSslHandler(context, sslContext);
             Future<Channel> handshakeFuture = handler.handshakeFuture();
@@ -179,6 +180,7 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
         @Override
         protected ChannelHandler newNonSslHandler(ChannelHandlerContext context) {
             NettyServerCnxn cnxn = Objects.requireNonNull(context.channel().attr(CONNECTION_ATTRIBUTE).get());
+            ServerMetrics.getMetrics().UNIFIED_PORT_NONSSL_REQUESTS.add(1);
             LOG.debug("creating plaintext handler for session {}", cnxn.getSessionId());
             // Mark handshake finished if it's a insecure cnxn
             updateHandshakeCountIfStarted(cnxn);
@@ -442,6 +444,7 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
                         return;
                     }
 
+                    ServerMetrics.getMetrics().X509_AUTH_REQUESTS.add(1);
                     KeeperException.Code code = KeeperException.Code.AUTHFAILED;
                     if (authProvider != null) {
                         code = authProvider.handleAuthentication(cnxn, null);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerMetrics.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerMetrics.java
@@ -229,6 +229,11 @@ public final class ServerMetrics {
         REQUEST_THROTTLE_WAIT_COUNT = metricsContext.getCounter("request_throttle_wait_count");
         LARGE_REQUESTS_REJECTED = metricsContext.getCounter("large_requests_rejected");
 
+        UNIFIED_PORT_NONSSL_REQUESTS = metricsContext.getCounter("unified_port_nonssl_requests");
+        UNIFIED_PORT_SSL_REQUESTS = metricsContext.getCounter("unified_port_ssl_requests");
+        X509_AUTH_REQUESTS = metricsContext.getCounter("x509_auth_requests");
+        X509ZNODEGROUPACL_AUTH_PROVDER_REQUESTS = metricsContext.getCounter("x509ZNodeGroupACL_auth_requests");
+
         NETTY_QUEUED_BUFFER = metricsContext.getSummary("netty_queued_buffer_capacity", DetailLevel.BASIC);
 
         DIGEST_MISMATCHES_COUNT = metricsContext.getCounter("digest_mismatches_count");
@@ -443,6 +448,14 @@ public final class ServerMetrics {
     public final Counter STALE_REPLIES;
     public final Counter REQUEST_THROTTLE_WAIT_COUNT;
     public final Counter LARGE_REQUESTS_REJECTED;
+
+    /*
+     * Client Auth requests for x509 based AuthenticationProviders through portUnification.
+     */
+    public final Counter UNIFIED_PORT_NONSSL_REQUESTS;
+    public final Counter UNIFIED_PORT_SSL_REQUESTS;
+    public final Counter X509_AUTH_REQUESTS;
+    public final Counter X509ZNODEGROUPACL_AUTH_PROVDER_REQUESTS;
 
     public final Summary NETTY_QUEUED_BUFFER;
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerMetrics.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerMetrics.java
@@ -232,7 +232,7 @@ public final class ServerMetrics {
         UNIFIED_PORT_NONSSL_REQUESTS = metricsContext.getCounter("unified_port_nonssl_requests");
         UNIFIED_PORT_SSL_REQUESTS = metricsContext.getCounter("unified_port_ssl_requests");
         X509_AUTH_REQUESTS = metricsContext.getCounter("x509_auth_requests");
-        X509ZNODEGROUPACL_AUTH_PROVDER_REQUESTS = metricsContext.getCounter("x509ZNodeGroupACL_auth_requests");
+        X509_ZNODEGROUPACL_AUTH_PROVDER_REQUESTS = metricsContext.getCounter("x509_ZNodeGroupACL_auth_requests");
 
         NETTY_QUEUED_BUFFER = metricsContext.getSummary("netty_queued_buffer_capacity", DetailLevel.BASIC);
 
@@ -455,7 +455,7 @@ public final class ServerMetrics {
     public final Counter UNIFIED_PORT_NONSSL_REQUESTS;
     public final Counter UNIFIED_PORT_SSL_REQUESTS;
     public final Counter X509_AUTH_REQUESTS;
-    public final Counter X509ZNODEGROUPACL_AUTH_PROVDER_REQUESTS;
+    public final Counter X509_ZNODEGROUPACL_AUTH_PROVDER_REQUESTS;
 
     public final Summary NETTY_QUEUED_BUFFER;
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
@@ -91,7 +91,7 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
 
   @Override
   public KeeperException.Code handleAuthentication(ServerObjs serverObjs, byte[] authData) {
-    ServerMetrics.getMetrics().X509ZNODEGROUPACL_AUTH_PROVDER_REQUESTS.add(1);
+    ServerMetrics.getMetrics().X509_ZNODEGROUPACL_AUTH_PROVDER_REQUESTS.add(1);
     // 1. Authenticate connection
     ServerCnxn cnxn = serverObjs.getCnxn();
     try {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.server.auth.znode.groupacl;
 
+import org.apache.zookeeper.server.ServerMetrics;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -90,6 +91,7 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
 
   @Override
   public KeeperException.Code handleAuthentication(ServerObjs serverObjs, byte[] authData) {
+    ServerMetrics.getMetrics().X509ZNODEGROUPACL_AUTH_PROVDER_REQUESTS.add(1);
     // 1. Authenticate connection
     ServerCnxn cnxn = serverObjs.getCnxn();
     try {


### PR DESCRIPTION
Issue :
If client port unification is turned on then right now there is not server metric to monitor non-SSL requests over unified port.

Fix :
Adding couple of metrics which would give some insights on connection requests from clients.
UNIFIED_PORT_NONSSL_REQUESTS - client request to unified port which won't do SSL handshake.
UNIFIED_PORT_SSL_REQUESTS - client request to unified port which would do SSL handshake.
X509_AUTH_REQUESTS - client requests which does x509 Authentication
X509ZNODEGROUPACL_AUTH_PROVDER_REQUESTS - client requests which does X509ZNodeGroupAclProvider authentication.

Verification:
Verified locally following scenarios:

Connection request to unified port.
Connection request to secured port.
