### PR TITLE
Adding authinfo in connection info metrics

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxnFactory.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxnFactory.java
@@ -169,7 +169,6 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
         @Override
         protected SslHandler newSslHandler(ChannelHandlerContext context, SslContext sslContext) {
             NettyServerCnxn cnxn = Objects.requireNonNull(context.channel().attr(CONNECTION_ATTRIBUTE).get());
-            ServerMetrics.getMetrics().UNIFIED_PORT_SSL_REQUESTS.add(1);
             LOG.debug("creating ssl handler for session {}", cnxn.getSessionId());
             SslHandler handler = super.newSslHandler(context, sslContext);
             Future<Channel> handshakeFuture = handler.handshakeFuture();
@@ -180,7 +179,6 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
         @Override
         protected ChannelHandler newNonSslHandler(ChannelHandlerContext context) {
             NettyServerCnxn cnxn = Objects.requireNonNull(context.channel().attr(CONNECTION_ATTRIBUTE).get());
-            ServerMetrics.getMetrics().UNIFIED_PORT_NONSSL_REQUESTS.add(1);
             LOG.debug("creating plaintext handler for session {}", cnxn.getSessionId());
             // Mark handshake finished if it's a insecure cnxn
             updateHandshakeCountIfStarted(cnxn);
@@ -444,7 +442,6 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
                         return;
                     }
 
-                    ServerMetrics.getMetrics().X509_AUTH_REQUESTS.add(1);
                     KeeperException.Code code = KeeperException.Code.AUTHFAILED;
                     if (authProvider != null) {
                         code = authProvider.handleAuthentication(cnxn, null);

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerCnxn.java
@@ -562,6 +562,7 @@ public abstract class ServerCnxn implements Stats, Watcher {
         info.put("outstanding_requests", getOutstandingRequests());
         info.put("packets_received", getPacketsReceived());
         info.put("packets_sent", getPacketsSent());
+        info.put("auth_info", getAuthInfo());
         if (!brief) {
             info.put("session_id", getSessionId());
             info.put("last_operation", getLastOperation());

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerMetrics.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerMetrics.java
@@ -229,11 +229,6 @@ public final class ServerMetrics {
         REQUEST_THROTTLE_WAIT_COUNT = metricsContext.getCounter("request_throttle_wait_count");
         LARGE_REQUESTS_REJECTED = metricsContext.getCounter("large_requests_rejected");
 
-        UNIFIED_PORT_NONSSL_REQUESTS = metricsContext.getCounter("unified_port_nonssl_requests");
-        UNIFIED_PORT_SSL_REQUESTS = metricsContext.getCounter("unified_port_ssl_requests");
-        X509_AUTH_REQUESTS = metricsContext.getCounter("x509_auth_requests");
-        X509_ZNODEGROUPACL_AUTH_PROVDER_REQUESTS = metricsContext.getCounter("x509_ZNodeGroupACL_auth_requests");
-
         NETTY_QUEUED_BUFFER = metricsContext.getSummary("netty_queued_buffer_capacity", DetailLevel.BASIC);
 
         DIGEST_MISMATCHES_COUNT = metricsContext.getCounter("digest_mismatches_count");
@@ -448,14 +443,6 @@ public final class ServerMetrics {
     public final Counter STALE_REPLIES;
     public final Counter REQUEST_THROTTLE_WAIT_COUNT;
     public final Counter LARGE_REQUESTS_REJECTED;
-
-    /*
-     * Client Auth requests for x509 based AuthenticationProviders through portUnification.
-     */
-    public final Counter UNIFIED_PORT_NONSSL_REQUESTS;
-    public final Counter UNIFIED_PORT_SSL_REQUESTS;
-    public final Counter X509_AUTH_REQUESTS;
-    public final Counter X509_ZNODEGROUPACL_AUTH_PROVDER_REQUESTS;
 
     public final Summary NETTY_QUEUED_BUFFER;
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
@@ -18,7 +18,6 @@
 
 package org.apache.zookeeper.server.auth.znode.groupacl;
 
-import org.apache.zookeeper.server.ServerMetrics;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -91,7 +90,6 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
 
   @Override
   public KeeperException.Code handleAuthentication(ServerObjs serverObjs, byte[] authData) {
-    ServerMetrics.getMetrics().X509_ZNODEGROUPACL_AUTH_PROVDER_REQUESTS.add(1);
     // 1. Authenticate connection
     ServerCnxn cnxn = serverObjs.getCnxn();
     try {


### PR DESCRIPTION
Issue :
Current metrics added in zk server to track connections on unified port doesn't reflect live connections status. Adding info in live connections list which would help to identify if connection to plaintext/unified port is authenticated or not.

Fix : 
Since this info lies in channel context it would be available in connection object. Hence adding auth info in connection info list which can tell if given connection is authenticated or not and if authenticated then using which scheme and which id.


Testing : 
Verified on local host
Non-ssl connections on unified port : 
![Screen Shot 2022-06-22 at 2 23 48 PM](https://user-images.githubusercontent.com/23309709/175142464-b1d1982e-17fe-4226-a340-291e7835fdbf.png)
ssl connections on unified port :
![Screen Shot 2022-06-22 at 2 23 22 PM](https://user-images.githubusercontent.com/23309709/175142560-3e959a3e-e45d-4f53-80a4-90db1d1a8288.png)

