### PR TITLE
Fixing cross domain component for dedicated server connection.

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.stream.Collectors;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.List;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 import javax.security.auth.x500.X500Principal;
@@ -219,8 +220,8 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
     Set<Id> newAuthIds = new HashSet<>();
 
     // Find interesecting super user domains/cross domains from provided domains list
-    Set<String> commonSuperUserDomains =
-        superUserDomainNames.stream().filter(domains::contains).collect(Collectors.toSet());
+    List<String> commonSuperUserDomains =
+        superUserDomainNames.stream().filter(domains::contains).collect(Collectors.toList());
 
     // Check if user belongs to super user group
     if (clientId.equals(superUser)) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
@@ -60,7 +60,7 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
   private TestNIOServerCnxnFactory serverCnxnFactory;
   private ZooKeeper admin;
   private static final String AUTH_PROVIDER_PROPERTY_NAME = "zookeeper.authProvider.x509";
-  private static final String CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH = "/_CLIENT_URI_DOMAIN_MAPPING";
+  private static final String CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH = "/zookeeper/uri-domain-map";
   private static final String[] MAPPING_PATHS = {CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH,
       CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/CrossDomain",
       CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/CrossDomain/CrossDomainUser",
@@ -264,6 +264,17 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
     Assert.assertEquals("super", authInfo.get(0).getScheme());
     Assert.assertEquals("SuperUser", authInfo.get(0).getId());
     System.clearProperty(X509AuthenticationConfig.DEDICATED_DOMAIN);
+
+    // Cross domain components
+    provider = createProvider(crossDomainCert);
+    cnxn = new MockServerCnxn();
+    cnxn.clientChain = new X509Certificate[]{crossDomainCert};
+    Assert.assertEquals(KeeperException.Code.OK, provider
+        .handleAuthentication(new ServerAuthenticationProvider.ServerObjs(zks, cnxn), new byte[0]));
+    authInfo = cnxn.getAuthInfo();
+    Assert.assertEquals(1, authInfo.size());
+    Assert.assertEquals("super", authInfo.get(0).getScheme());
+    Assert.assertEquals("CrossDomain", authInfo.get(0).getId());
   }
 
   private X509ZNodeGroupAclProvider createProvider(X509Certificate trustedCert) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelperTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelperTest.java
@@ -49,7 +49,7 @@ public class ZkClientUriDomainMappingHelperTest extends ZKTestCase {
   private static final Logger LOG =
       LoggerFactory.getLogger(ZkClientUriDomainMappingHelperTest.class);
   private static final String HOSTPORT = "127.0.0.1:" + PortAssignment.unique();
-  private static final String CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH = "/_CLIENT_URI_DOMAIN_MAPPING";
+  private static final String CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH = "/zookeeper/uri-domain-map";
   private static final int CONNECTION_TIMEOUT = 300000;
   private static final String[] MAPPING_PATHS = {
       CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH,
@@ -106,16 +106,6 @@ public class ZkClientUriDomainMappingHelperTest extends ZKTestCase {
     }
     Assert.assertTrue("waiting for ZK server to shutdown",
         ClientBase.waitForServerDown(HOSTPORT, CONNECTION_TIMEOUT));
-  }
-
-  /**
-   * Mapping root path hasn't been created - should create the node automatically
-   */
-  @Test
-  public void testA_ZkClientUriDomainMappingHelper() {
-    new ZkClientUriDomainMappingHelper(zookeeperServer);
-    Assert.assertNotNull(
-        zookeeperServer.getZKDatabase().getNode(CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH));
   }
 
   /**


### PR DESCRIPTION
Issue : 
Current implementation do no honor cross domain component list if connection filtering is turned on.

Fix :
1. All the superUser as well as superDomain (cross domain list acts as super domains) should be handled before connection filtering.
2. When connection filtering is turned off :
     a. For super user case authID should be (super:clientID) which would set ACLs as [WORLD_ALL]
     b. For super domain case authID should be (super:superDomainName) which would set ACLs as (x509, domain)
3. When connection filtering it turned on :
    a. For super user case authID should be (super:clientID) which would set ACLs as [WORLD_ALL]
    b. For super domain case authID should be (super:superDomainName) which would set ACLs as [WORLD_ALL]

Also fixed few UTs.

Testing :
Added new UT.