### PR TITLE
Fixing updating auth info whenever mapping is updated to TLS connection on unified port.

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
@@ -144,6 +144,9 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
     LOG.info("Processing watched event: {}", event.toString());
     parseZNodeMapping();
     // Update AuthInfo for all the known connections.
+    // Note : It is not ideal to iterate over all plaintext connections which are connected over non-TLS but right now
+    // there is no way to find out if connection on unified port is using SSLHandler or nonSSLHandler. And anways we
+    // should not ideally have any nonSSLHandler connection on unified port.
 
     // TODO Change to read SecureServerCnxnFactory only. The current logic is to support unit test who is not creating
     // a secured server cnxn factory. It won't cause any problem but is not technically correct.

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
@@ -145,8 +145,8 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
     parseZNodeMapping();
     // Update AuthInfo for all the known connections.
     // Note : It is not ideal to iterate over all plaintext connections which are connected over non-TLS but right now
-    // there is no way to find out if connection on unified port is using SSLHandler or nonSSLHandler. And anways we
-    // should not ideally have any nonSSLHandler connection on unified port.
+    // there is no way to find out if connection on unified port is using SSLHandler or nonSSLHandler. Anyways, we
+    // should not ideally have any nonSSLHandler connections on unified port after complete rollout.
 
     // TODO Change to read SecureServerCnxnFactory only. The current logic is to support unit test who is not creating
     // a secured server cnxn factory. It won't cause any problem but is not technically correct.


### PR DESCRIPTION
Issue :
Currently for any uri-domain mapping update only secure connections auth info is updated. But after supporting port unification auth info should be updated foo all TLS connections on unified port.

Fix : 
Iterating over all - plaintext connections as well as secure connections and updating auth info for it.

Risk :
This also added overhead of iterating over all connections on unified port with non-TLS which could clutter logs. But ideally once whole rollout is completed we should not expect this connections.

Testing : 
Verified that auth info is updated for TLS connection on unified port :
![Screen Shot 2022-06-30 at 4 13 28 PM](https://user-images.githubusercontent.com/23309709/176793536-f8fef6b6-1acc-4398-8d6c-f0e9bf6d1fbd.png)


Verified using UTs :
![Screen Shot 2022-06-30 at 4 09 10 PM](https://user-images.githubusercontent.com/23309709/176793183-bdfe7a06-8d8d-4c15-aa82-e5250e1ad8a7.png)

Verified that auth info fails without issue for non-TLS connection on unified port :
![Screen Shot 2022-06-30 at 4 12 39 PM](https://user-images.githubusercontent.com/23309709/176793503-3f5d939f-fc13-4345-a8b9-ef2f65742706.png)

