### PR TITLE
Allow multiple client ids to be super user

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
+
 import org.apache.jute.BinaryOutputArchive;
 import org.apache.jute.Record;
 import org.apache.zookeeper.CreateMode;
@@ -1023,9 +1024,9 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
             for (Id id : authInfo) {
                 boolean isX509 = id.getScheme().equals(X509AuthenticationUtil.X509_SCHEME);
                 boolean isX509CrossDomainComponent =
-                    id.getScheme().equals(X509AuthenticationUtil.SUPERUSER_AUTH_SCHEME) && !id
-                        .getId().equals(
-                        X509AuthenticationConfig.getInstance().getZnodeGroupAclSuperUserId());
+                    id.getScheme().equals(X509AuthenticationUtil.SUPERUSER_AUTH_SCHEME)
+                        && !X509AuthenticationConfig.getInstance().getZnodeGroupAclSuperUserId()
+                        .contains(id.getId());
                 if (isX509 || isX509CrossDomainComponent) {
                     rv.add(new ACL(ZooDefs.Perms.ALL,
                         new Id(X509AuthenticationUtil.X509_SCHEME, id.getId())));

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -1025,7 +1025,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
                 boolean isX509 = id.getScheme().equals(X509AuthenticationUtil.X509_SCHEME);
                 boolean isX509CrossDomainComponent =
                     id.getScheme().equals(X509AuthenticationUtil.SUPERUSER_AUTH_SCHEME)
-                        && !X509AuthenticationConfig.getInstance().getZnodeGroupAclSuperUserId()
+                        && !X509AuthenticationConfig.getInstance().getZnodeGroupAclSuperUserIds()
                         .contains(id.getId());
                 if (isX509 || isX509CrossDomainComponent) {
                     rv.add(new ACL(ZooDefs.Perms.ALL,

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationConfig.java
@@ -20,7 +20,6 @@ package org.apache.zookeeper.server.auth;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -134,7 +133,7 @@ public class X509AuthenticationConfig {
   private static final String ZNODE_GROUP_ACL_CLIENTURI_DOMAIN_MAPPING_ROOT_PATH = "/zookeeper/uri-domain-map";
 
   private String x509ClientIdAsAclEnabled;
-  private String znodeGroupAclSuperUserId;
+  private String znodeGroupAclSuperUserIdStr;
   private String znodeGroupAclCrossDomainAccessDomainNameStr;
   private String znodeGroupAclOpenReadAccessPathPrefixStr;
   private String znodeGroupAclServerDedicatedDomain;
@@ -200,8 +199,8 @@ public class X509AuthenticationConfig {
     x509ClientIdAsAclEnabled = enabled;
   }
 
-  public void setZnodeGroupAclSuperUserId(String znodeGroupAclSuperUserId) {
-    this.znodeGroupAclSuperUserId = znodeGroupAclSuperUserId;
+  public void setZnodeGroupAclSuperUserIdStr(String znodeGroupAclSuperUserIdStr) {
+    this.znodeGroupAclSuperUserIdStr = znodeGroupAclSuperUserIdStr;
   }
 
   public void setZnodeGroupAclCrossDomainAccessDomainNameStr(
@@ -264,7 +263,7 @@ public class X509AuthenticationConfig {
         .parseBoolean(System.getProperty(SET_X509_CLIENT_ID_AS_ACL));
   }
 
-  public Set<String> getZnodeGroupAclSuperUserId() {
+  public Set<String> getZnodeGroupAclSuperUserIds() {
     if (znodeGroupAclSuperUserIds == null) {
       synchronized (znodeGroupAclSuperUserIdsLock) {
         if (znodeGroupAclSuperUserIds == null) {
@@ -309,13 +308,13 @@ public class X509AuthenticationConfig {
   }
 
   private Set<String> loadSuperUserIds() {
-    if (znodeGroupAclSuperUserId == null) {
-      setZnodeGroupAclSuperUserId(System.getProperty(ZOOKEEPER_ZNODEGROUPACL_SUPERUSER_ID));
+    if (znodeGroupAclSuperUserIdStr == null) {
+      setZnodeGroupAclSuperUserIdStr(System.getProperty(ZOOKEEPER_ZNODEGROUPACL_SUPERUSER_ID));
     }
-    if (znodeGroupAclSuperUserId == null || znodeGroupAclSuperUserId.isEmpty()) {
+    if (znodeGroupAclSuperUserIdStr == null || znodeGroupAclSuperUserIdStr.isEmpty()) {
       return Collections.emptySet();
     }
-    return Arrays.stream(znodeGroupAclSuperUserId.split(",")).filter(str -> str.length() > 0)
+    return Arrays.stream(znodeGroupAclSuperUserIdStr.split(",")).filter(str -> str.length() > 0)
         .collect(Collectors.toSet());
   }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
@@ -209,7 +209,7 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
    */
   private void assignAuthInfo(ServerCnxn cnxn, String clientId, Set<String> domains) {
     Set<String> superUserDomainNames = X509AuthenticationConfig.getInstance().getZnodeGroupAclCrossDomainAccessDomains();
-    Set<String> superUsers = X509AuthenticationConfig.getInstance().getZnodeGroupAclSuperUserId();
+    Set<String> superUsers = X509AuthenticationConfig.getInstance().getZnodeGroupAclSuperUserIds();
 
     Set<Id> newAuthIds = new HashSet<>();
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.List;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
-import javax.security.auth.x500.X500Principal;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.common.ZKConfig;
 import org.apache.zookeeper.data.Id;
@@ -210,7 +209,7 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
    */
   private void assignAuthInfo(ServerCnxn cnxn, String clientId, Set<String> domains) {
     Set<String> superUserDomainNames = X509AuthenticationConfig.getInstance().getZnodeGroupAclCrossDomainAccessDomains();
-    String superUser = X509AuthenticationConfig.getInstance().getZnodeGroupAclSuperUserId();
+    Set<String> superUsers = X509AuthenticationConfig.getInstance().getZnodeGroupAclSuperUserId();
 
     Set<Id> newAuthIds = new HashSet<>();
 
@@ -218,8 +217,8 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
     List<String> commonSuperUserDomains =
         superUserDomainNames.stream().filter(domains::contains).collect(Collectors.toList());
 
-    // Check if user belongs to super user group
-    if (clientId.equals(superUser)) {
+    // Check if user belongs to super user id group
+    if (superUsers.contains(clientId)) {
       newAuthIds.add(new Id(X509AuthenticationUtil.SUPERUSER_AUTH_SCHEME, clientId));
     } else if (!commonSuperUserDomains.isEmpty()) {
       // For cross domain components, add (super:domainName) in authInfo

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -394,7 +394,7 @@ public class QuorumPeerConfig {
             } else if (key.equals(X509AuthenticationConfig.DEDICATED_DOMAIN)) {
                 X509AuthenticationConfig.getInstance().setZnodeGroupAclServerDedicatedDomain(value);
             } else if (key.equals(X509AuthenticationConfig.ZOOKEEPER_ZNODEGROUPACL_SUPERUSER_ID)) {
-                X509AuthenticationConfig.getInstance().setZnodeGroupAclSuperUserId(value);
+                X509AuthenticationConfig.getInstance().setZnodeGroupAclSuperUserIdStr(value);
             } else if (key.equals(X509AuthenticationConfig.OPEN_READ_ACCESS_PATH_PREFIX)) {
                 X509AuthenticationConfig.getInstance().setZnodeGroupAclOpenReadAccessPathPrefixStr(value);
             } else if (key.equals("standaloneEnabled")) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
@@ -52,6 +52,7 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
   private static final String HOSTPORT = "127.0.0.1:" + PortAssignment.unique();
   private static X509AuthTest.TestCertificate domainXCert;
   private static X509AuthTest.TestCertificate superCert;
+  private static X509AuthTest.TestCertificate superCert2;
   private static X509AuthTest.TestCertificate unknownCert;
   private static X509AuthTest.TestCertificate crossDomainCert;
   private static final String CLIENT_CERT_ID_SAN_MATCH_TYPE = "6";
@@ -70,7 +71,7 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
       CLIENT_URI_DOMAIN_MAPPING_ROOT_PATH + "/DomainY/DomainYUser"};
   private static final Map<String, String> SYSTEM_PROPERTIES = new HashMap<>();
     static {
-      SYSTEM_PROPERTIES.put(X509AuthenticationConfig.ZOOKEEPER_ZNODEGROUPACL_SUPERUSER_ID, "SuperUser");
+      SYSTEM_PROPERTIES.put(X509AuthenticationConfig.ZOOKEEPER_ZNODEGROUPACL_SUPERUSER_ID, "SuperUser,SuperUser2");
       SYSTEM_PROPERTIES.put("zookeeper.ssl.keyManager", "org.apache.zookeeper.test.X509AuthTest.TestKeyManager");
       SYSTEM_PROPERTIES.put("zookeeper.ssl.trustManager", "org.apache.zookeeper.test.X509AuthTest.TestTrustManager");
       SYSTEM_PROPERTIES.put(X509AuthenticationConfig.SSL_X509_CLIENT_CERT_ID_TYPE, X509AuthenticationConfig.SUBJECT_ALTERNATIVE_NAME_SHORT);
@@ -101,6 +102,7 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
     // Create test client certificates
     domainXCert = new X509AuthTest.TestCertificate("CLIENT", "DomainXUser");
     superCert = new X509AuthTest.TestCertificate("SUPER", "SuperUser");
+    superCert2 = new X509AuthTest.TestCertificate("SUPER", "SuperUser2");
     unknownCert = new X509AuthTest.TestCertificate("UNKNOWN", "UnknownUser");
     crossDomainCert = new X509AuthTest.TestCertificate("CLIENT", "CrossDomainUser");
 
@@ -172,7 +174,8 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
     Assert.assertEquals("super", authInfo.get(0).getScheme());
     Assert.assertEquals("CrossDomain", authInfo.get(0).getId());
 
-    // Directly set in config as super user
+    // Directly set multiple service principals in config as super user
+    // 1st super user
     provider = createProvider(superCert);
     cnxn = new MockServerCnxn();
     cnxn.clientChain = new X509Certificate[]{superCert};
@@ -182,6 +185,17 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
     Assert.assertEquals(1, authInfo.size());
     Assert.assertEquals("super", authInfo.get(0).getScheme());
     Assert.assertEquals("SuperUser", authInfo.get(0).getId());
+
+    // 2nd super user
+    provider = createProvider(superCert2);
+    cnxn = new MockServerCnxn();
+    cnxn.clientChain = new X509Certificate[]{superCert2};
+    Assert.assertEquals(KeeperException.Code.OK, provider
+        .handleAuthentication(new ServerAuthenticationProvider.ServerObjs(zks, cnxn), new byte[0]));
+    authInfo = cnxn.getAuthInfo();
+    Assert.assertEquals(1, authInfo.size());
+    Assert.assertEquals("super", authInfo.get(0).getScheme());
+    Assert.assertEquals("SuperUser2", authInfo.get(0).getId());
   }
 
   @Test


### PR DESCRIPTION
This change allows ZooKeeper server to read  super user id string from system property, and parse it using delimiter "," to multiple client ids. Originally only one client id can be super user, this commit opens up the super user privilege to multiple clients.
This commit includes non-backward-compatible changes in `X509AuthenticationConfig` class:
1. _setZnodeGroupAclSuperUserId_ is renamed to _setZnodeGroupAclSuperUserIdStr_
2. _getZnodeGroupAclSuperUserId_ is renamed to _getZnodeGroupAclSuperUserIds_, and return type is changed from String to Set<String>

Test modified: X509ZNodeGroupAclProviderTest.testSuperUser
Test passed: all tests under `org.apache.zookeeper.server.auth.znode.groupacl`