### PR TITLE
Add an optional feature to add both clientId and domain name to authInfo

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationConfig.java
@@ -125,6 +125,12 @@ public class X509AuthenticationConfig {
    * and enable connection filtering feature for this domain.
    */
   public static final String DEDICATED_DOMAIN = ZNODE_GROUP_ACL_CONFIG_PREFIX + "dedicatedDomain";
+  /**
+   * This config property applies to non-dedicated server. If this property is set to true,
+   * clientId extracted from the certificate will be stored in authInfo, along with the matched
+   * domain name.
+   */
+  public static final String STORE_AUTHED_CLIENT_ID = ZNODE_GROUP_ACL_CONFIG_PREFIX + "storeAuthedClientId";
 
   // The root path for client URI - domain mapping that stored in zk data tree. Refer to
   // {@link org.apache.zookeeper.server.auth.znode.groupacl.ZkClientUriDomainMappingHelper} for
@@ -137,6 +143,7 @@ public class X509AuthenticationConfig {
   private String znodeGroupAclCrossDomainAccessDomainNameStr;
   private String znodeGroupAclOpenReadAccessPathPrefixStr;
   private String znodeGroupAclServerDedicatedDomain;
+  private String storeAuthedClientIdEnabled;
 
   // Although using "volatile" keyword with double checked locking could prevent the undesired
   //creation of multiple objects; not using here for the consideration of read performance
@@ -256,6 +263,10 @@ public class X509AuthenticationConfig {
         : clientCertIdSanExtractMatcherGroupIndex;
   }
 
+  public void setStoreAuthedClientIdEnabled(String enabled) {
+    storeAuthedClientIdEnabled = enabled;
+  }
+
   // Getters for X509 Znode Group Acl properties
 
   public boolean isX509ClientIdAsAclEnabled() {
@@ -305,6 +316,11 @@ public class X509AuthenticationConfig {
 
   public String getZnodeGroupAclClientUriDomainMappingRootPath() {
     return ZNODE_GROUP_ACL_CLIENTURI_DOMAIN_MAPPING_ROOT_PATH;
+  }
+
+  public boolean isStoreAuthedClientIdEnabled() {
+    return Boolean.parseBoolean(storeAuthedClientIdEnabled) || Boolean
+        .parseBoolean(System.getProperty(STORE_AUTHED_CLIENT_ID));
   }
 
   private Set<String> loadSuperUserIds() {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
@@ -226,9 +226,6 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
       // "super" scheme gives access to all znodes without checking znode ACL vs authorized domain name
       commonSuperUserDomains.stream().forEach(d ->
           newAuthIds.add(new Id(X509AuthenticationUtil.SUPERUSER_AUTH_SCHEME, d)));
-      if (X509AuthenticationConfig.getInstance().isStoreAuthedClientIdEnabled()) {
-        newAuthIds.add(new Id(getScheme(), clientId));
-      }
     } else if (X509AuthenticationConfig.getInstance().isZnodeGroupAclDedicatedServerEnabled()) {
       // If connection filtering feature is turned on, use connection filtering instead of normal authorization
       String serverNamespace = X509AuthenticationConfig.getInstance().getZnodeGroupAclServerDedicatedDomain();
@@ -245,6 +242,9 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
     } else {
       // For other cases, add (x509:domainName) in authInfo
       domains.stream().forEach(d -> newAuthIds.add(new Id(getScheme(), d)));
+      // If no domain is matched for the clientId, then clientId will be added to authInfo;
+      // if StoreAuthedClientId feature is enabled, clientId will be added to authInfo in addition
+      // to matched domain names.
       if (domains.isEmpty() || X509AuthenticationConfig.getInstance().isStoreAuthedClientIdEnabled()) {
         newAuthIds.add(new Id(getScheme(), clientId));
       }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
@@ -61,6 +61,8 @@ import org.slf4j.LoggerFactory;
  *    "open read access": this feature concerns read access only. Add (world, anyone r) to all
  *          newly-written znodes whose path prefixes are given in the znode group acl config
  *          (comma-delimited, multiple such prefixes are possible).
+ *    "store authed clientId": If enabled, the server will store the clientId in authInfo, in addition
+ *          to the matched domain. This feature is only available in non-dedicated server cases.
  *    "connection filtering": If the server is a dedicated server that only serves one domain,
  *          the name of the domain is made the "dedicatedDomain" of the server. The server will decline
  *          the connection requests from client who belongs to a domain that does not match with the
@@ -162,8 +164,7 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
             try {
               String clientId = X509AuthenticationUtil.getClientId(cnxn, trustManager);
               assignAuthInfo(cnxn, clientId,
-                  // If no domain name is found, use client Id as default domain name
-                  clientUriToDomainNames.getOrDefault(clientId, Collections.singleton(clientId)));
+                  clientUriToDomainNames.getOrDefault(clientId, Collections.emptySet()));
             } catch (UnsupportedOperationException unsupportedEx) {
               LOG.info("Cannot update AuthInfo for session 0x{} since the operation is not supported.",
                   Long.toHexString(cnxn.getSessionId()));
@@ -225,6 +226,9 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
       // "super" scheme gives access to all znodes without checking znode ACL vs authorized domain name
       commonSuperUserDomains.stream().forEach(d ->
           newAuthIds.add(new Id(X509AuthenticationUtil.SUPERUSER_AUTH_SCHEME, d)));
+      if (X509AuthenticationConfig.getInstance().isStoreAuthedClientIdEnabled()) {
+        newAuthIds.add(new Id(getScheme(), clientId));
+      }
     } else if (X509AuthenticationConfig.getInstance().isZnodeGroupAclDedicatedServerEnabled()) {
       // If connection filtering feature is turned on, use connection filtering instead of normal authorization
       String serverNamespace = X509AuthenticationConfig.getInstance().getZnodeGroupAclServerDedicatedDomain();
@@ -241,6 +245,9 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
     } else {
       // For other cases, add (x509:domainName) in authInfo
       domains.stream().forEach(d -> newAuthIds.add(new Id(getScheme(), d)));
+      if (domains.isEmpty() || X509AuthenticationConfig.getInstance().isStoreAuthedClientIdEnabled()) {
+        newAuthIds.add(new Id(getScheme(), clientId));
+      }
     }
 
     // Update the existing connection AuthInfo accordingly.

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
@@ -308,18 +308,16 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
     Assert.assertEquals(SCHEME, authInfo.get(1).getScheme());
     Assert.assertEquals("DomainXUser", authInfo.get(1).getId());
 
-    // Cross domain component
+    // Cross domain component - should be same no matter this feature is on or not
     provider = createProvider(crossDomainCert);
     cnxn = new MockServerCnxn();
     cnxn.clientChain = new X509Certificate[]{crossDomainCert};
     Assert.assertEquals(KeeperException.Code.OK, provider
         .handleAuthentication(new ServerAuthenticationProvider.ServerObjs(zks, cnxn), new byte[0]));
     authInfo = cnxn.getAuthInfo();
-    Assert.assertEquals(2, authInfo.size());
+    Assert.assertEquals(1, authInfo.size());
     Assert.assertEquals("super", authInfo.get(0).getScheme());
     Assert.assertEquals("CrossDomain", authInfo.get(0).getId());
-    Assert.assertEquals("x509", authInfo.get(1).getScheme());
-    Assert.assertEquals("CrossDomainUser", authInfo.get(1).getId());
 
     // Super user - should be same no matter this feature is on or not
     provider = createProvider(superCert);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProviderTest.java
@@ -291,6 +291,50 @@ public class X509ZNodeGroupAclProviderTest extends ZKTestCase {
     Assert.assertEquals("CrossDomain", authInfo.get(0).getId());
   }
 
+  @Test
+  public void testStoreAuthedClientId() {
+    System.setProperty(X509AuthenticationConfig.STORE_AUTHED_CLIENT_ID, "true");
+
+    // Single domain user
+    X509ZNodeGroupAclProvider provider = createProvider(domainXCert);
+    MockServerCnxn cnxn = new MockServerCnxn();
+    cnxn.clientChain = new X509Certificate[]{domainXCert};
+    Assert.assertEquals(KeeperException.Code.OK, provider
+        .handleAuthentication(new ServerAuthenticationProvider.ServerObjs(zks, cnxn), new byte[0]));
+    List<Id> authInfo = cnxn.getAuthInfo();
+    Assert.assertEquals(2, authInfo.size());
+    Assert.assertEquals(SCHEME, authInfo.get(0).getScheme());
+    Assert.assertEquals("DomainX", authInfo.get(0).getId());
+    Assert.assertEquals(SCHEME, authInfo.get(1).getScheme());
+    Assert.assertEquals("DomainXUser", authInfo.get(1).getId());
+
+    // Cross domain component
+    provider = createProvider(crossDomainCert);
+    cnxn = new MockServerCnxn();
+    cnxn.clientChain = new X509Certificate[]{crossDomainCert};
+    Assert.assertEquals(KeeperException.Code.OK, provider
+        .handleAuthentication(new ServerAuthenticationProvider.ServerObjs(zks, cnxn), new byte[0]));
+    authInfo = cnxn.getAuthInfo();
+    Assert.assertEquals(2, authInfo.size());
+    Assert.assertEquals("super", authInfo.get(0).getScheme());
+    Assert.assertEquals("CrossDomain", authInfo.get(0).getId());
+    Assert.assertEquals("x509", authInfo.get(1).getScheme());
+    Assert.assertEquals("CrossDomainUser", authInfo.get(1).getId());
+
+    // Super user - should be same no matter this feature is on or not
+    provider = createProvider(superCert);
+    cnxn = new MockServerCnxn();
+    cnxn.clientChain = new X509Certificate[]{superCert};
+    Assert.assertEquals(KeeperException.Code.OK, provider
+        .handleAuthentication(new ServerAuthenticationProvider.ServerObjs(zks, cnxn), new byte[0]));
+    authInfo = cnxn.getAuthInfo();
+    Assert.assertEquals(1, authInfo.size());
+    Assert.assertEquals("super", authInfo.get(0).getScheme());
+    Assert.assertEquals("SuperUser", authInfo.get(0).getId());
+
+    System.clearProperty(X509AuthenticationConfig.STORE_AUTHED_CLIENT_ID);
+  }
+
   private X509ZNodeGroupAclProvider createProvider(X509Certificate trustedCert) {
     return new X509ZNodeGroupAclProvider(new X509AuthTest.TestTrustManager(trustedCert),
         new X509AuthTest.TestKeyManager());


### PR DESCRIPTION
This commit adds an optional feature to be configured by key "zookeeper.X509ZNodeGroupAclProvider.storeAuthedClientId". If enabled, the server will store the clientId in authInfo, in addition to the matched domain name(s). This feature is only available in non-dedicated server cases.

Added test: X509ZNodeGroupAclProviderTest.testStoreAuthedClientId