### PR TITLE
Fixing spotbugs errors in ZNodeGroupACL files.

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationConfig.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.server.auth;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
@@ -38,6 +39,11 @@ public class X509AuthenticationConfig {
   private X509AuthenticationConfig() {
   }
 
+  /**
+   * X509AuthenticationConfig are loaded lazily and hence spotbugs DC_DOUBLECHECK warning is supressed.
+   * @return
+   */
+  @SuppressFBWarnings("DC_DOUBLECHECK")
   public static X509AuthenticationConfig getInstance() {
     if (instance == null) {
       synchronized (X509AuthenticationConfig.class) {
@@ -267,6 +273,11 @@ public class X509AuthenticationConfig {
     return znodeGroupAclSuperUserId;
   }
 
+  /**
+   * crossDomainAccessDomains are loaded lazily and hence spotbugs DC_DOUBLECHECK warning is supressed.
+   * @return
+   */
+  @SuppressFBWarnings("DC_DOUBLECHECK")
   public Set<String> getZnodeGroupAclCrossDomainAccessDomains() {
     if (crossDomainAccessDomains == null) {
       synchronized (crossDomainAccessDomainsLock) {
@@ -278,6 +289,11 @@ public class X509AuthenticationConfig {
     return crossDomainAccessDomains;
   }
 
+  /**
+   * openReadAccessPathPrefixes are loaded lazily and hence spotbugs DC_DOUBLECHECK warning is supressed.
+   * @return
+   */
+  @SuppressFBWarnings("DC_DOUBLECHECK")
   public Set<String> getZnodeGroupAclOpenReadAccessPathPrefixes() {
     if (openReadAccessPathPrefixes == null) {
       synchronized (openReadAccessPathPrefixesLock) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/X509ZNodeGroupAclProvider.java
@@ -19,6 +19,7 @@
 package org.apache.zookeeper.server.auth.znode.groupacl;
 
 import java.util.Collections;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.stream.Collectors;
 import java.util.HashSet;
 import java.util.Set;
@@ -148,9 +149,12 @@ public class X509ZNodeGroupAclProvider extends ServerAuthenticationProvider {
   }
 
   /**
-   * Initialize a new ClientUriDomainMappingHelper instance if it hasn't been instantiated for the ACL provider.
+   * Initialize a new ClientUriDomainMappingHelper instance lazily if it hasn't been instantiated for the ACL provider.
+   * Since it's lazy initialization suppressing spotbugs DC_DOUBLECHECK warning.
+   * Supressing IS2_INCONSISTENT_SYNC warning for uriDomainMappingHelper since it's guarded correctly by synchronized block.
    * @param zks
    */
+  @SuppressFBWarnings({"DC_DOUBLECHECK", "IS2_INCONSISTENT_SYNC"})
   private ClientUriDomainMappingHelper getUriDomainMappingHelper(ZooKeeperServer zks) {
     if (uriDomainMappingHelper == null) {
       synchronized (this) {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper.server.auth.znode.groupacl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -90,6 +91,7 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
    * @return True if the new updater is setup to the helper instance. False if the specified updater is not set since
    * another updater has already been configured.
    */
+  @SuppressFBWarnings("DC_DOUBLECHECK")
   boolean setDomainAuthUpdater(ConnectionAuthInfoUpdater updater) {
     if (this.updater == null) {
       synchronized (this) {


### PR DESCRIPTION
mvn spotbugs has reported few bugs and this PR fixes it from ZK ACL project files.