### PR TITLE
Add entry point for setting StoreAuthedClientId config property

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationConfig.java
@@ -230,6 +230,10 @@ public class X509AuthenticationConfig {
     this.znodeGroupAclServerDedicatedDomain = znodeGroupAclServerDedicatedDomain;
   }
 
+  public void setStoreAuthedClientIdEnabled(String enabled) {
+    storeAuthedClientIdEnabled = enabled;
+  }
+
   // Getters for X509 properties
 
   public String getClientCertIdType() {
@@ -267,10 +271,6 @@ public class X509AuthenticationConfig {
     }
     return clientCertIdSanExtractMatcherGroupIndex == -1 ? 0
         : clientCertIdSanExtractMatcherGroupIndex;
-  }
-
-  public void setStoreAuthedClientIdEnabled(String enabled) {
-    storeAuthedClientIdEnabled = enabled;
   }
 
   // Getters for X509 Znode Group Acl properties

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -397,6 +397,8 @@ public class QuorumPeerConfig {
                 X509AuthenticationConfig.getInstance().setZnodeGroupAclSuperUserIdStr(value);
             } else if (key.equals(X509AuthenticationConfig.OPEN_READ_ACCESS_PATH_PREFIX)) {
                 X509AuthenticationConfig.getInstance().setZnodeGroupAclOpenReadAccessPathPrefixStr(value);
+            } else if (key.equals(X509AuthenticationConfig.STORE_AUTHED_CLIENT_ID)) {
+                X509AuthenticationConfig.getInstance().setStoreAuthedClientIdEnabled(value);
             } else if (key.equals("standaloneEnabled")) {
                 if (value.toLowerCase().equals("true")) {
                     setStandaloneEnabled(true);


### PR DESCRIPTION
In https://github.com/linkedin/zookeeper/pull/87, one entry point for setting the config value is missing. This commit adds the entry point in QuorumPeerConfig.

All znode group acl tests passed.
Will validate the config loading manually by deploying zk server with StoreAuthedClientId enabled in zk config.