### PR TITLE
Fixing failing unit tests on ZK ACL branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,7 @@
     <jackson.version>2.10.5.1</jackson.version>
     <json.version>1.1.1</json.version>
     <jline.version>2.14.6</jline.version>
-    <snappy.version>1.1.7</snappy.version>
+    <snappy.version>1.1.8.4</snappy.version>
     <kerby.version>2.0.0</kerby.version>
     <bouncycastle.version>1.60</bouncycastle.version>
     <commons-collections.version>3.2.2</commons-collections.version>

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationConfig.java
@@ -280,6 +280,7 @@ public class X509AuthenticationConfig {
         .parseBoolean(System.getProperty(SET_X509_CLIENT_ID_AS_ACL));
   }
 
+  @SuppressFBWarnings("DC_DOUBLECHECK")
   public Set<String> getZnodeGroupAclSuperUserIds() {
     if (znodeGroupAclSuperUserIds == null) {
       synchronized (znodeGroupAclSuperUserIdsLock) {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/CnxManagerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/CnxManagerTest.java
@@ -306,6 +306,7 @@ public class CnxManagerTest extends ZKTestCase {
         final Map<Long, QuorumServer> unresolvablePeers = new HashMap<>();
         final long myid = 1L;
         unresolvablePeers.put(myid, new QuorumServer(myid, "unresolvable-domain.org:2182:2183;2181"));
+        // Note: Make sure NO local zk server is already running on this port.
         final QuorumPeer peer = new QuorumPeer(unresolvablePeers, ClientBase.createTmpDir(), ClientBase.createTmpDir(), 2181, 3, myid, 1000, 2, 2, 2);
         final QuorumCnxManager cnxManager = peer.createCnxnManager();
         final QuorumCnxManager.Listener listener = cnxManager.listener;


### PR DESCRIPTION
Description
This PR would try to fix all failing unit tests on this branch. Here are couple of things fixed :
1. Updated snappy dependency to fix 4 UTs.
2. Now test suite runs ~3100 tests and out of which 3-4 tests fails randomly. But if they run individually then runs successfully. I will be still digging deeper into this.

Tests
 mvn clean install -dskipTests

The following is the result of the "mvn test" command on the appropriate module:
(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

Changes that Break Backward Compatibility (Optional)
My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:
NA

Documentation (Optional)
In case of new functionality, my PR adds documentation in the following wiki page:
NA
