### PR TITLE
Updating CI workflow to run on master and all li-dev branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,9 +25,13 @@ name: CI
 
 on:
   push:
-    branches: [ '*' ]
+    branches:
+      - master
+      - 'li-dev/**'
   pull_request:
-    branches: [ '*' ]
+    branches:
+      - master
+      - 'li-dev/**'
 
 jobs:
   mvn:


### PR DESCRIPTION
Issue :
Currently there is single '*' which matches to all branches only if branch do not '/' but since li-dev branches has '/' in it these workflows are not running on them. 

Fix :
Updating CI workflow to run on master and all li-dev branches. Adding explicit branches like master and regex to match all li-dev feature branches.

Description
(Write a concise description including what, why, how)

Tests
 The following tests are written for this issue:
(List the names of added unit/integration tests)

The following is the result of the "mvn test" command on the appropriate module:
(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

Changes that Break Backward Compatibility (Optional)
My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:
(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

Documentation (Optional)
In case of new functionality, my PR adds documentation in the following wiki page:
(Link the GitHub wiki you added)
