### PR TITLE
ZOOKEEPER-4465: zooinspector logback pattern config add escape for '(' and ')'

### DIFF
--- a/zookeeper-contrib/zookeeper-contrib-zooinspector/src/main/resources/logback.xml
+++ b/zookeeper-contrib/zookeeper-contrib-zooinspector/src/main/resources/logback.xml
@@ -22,7 +22,7 @@
 <configuration>
   <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%5p [%t] (%F:%L) - %m%n</pattern>
+      <pattern>%5p [%t] \(%F:%L\) - %m%n</pattern>
     </encoder>
   </appender>
   <root level="INFO">

--- a/zookeeper-contrib/zookeeper-contrib-zooinspector/src/test/java/org/apache/zookeeper/inspector/LoggerTest.java
+++ b/zookeeper-contrib/zookeeper-contrib-zooinspector/src/test/java/org/apache/zookeeper/inspector/LoggerTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.inspector;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+public class LoggerTest {
+    Logger LOG = LoggerFactory.getLogger(LoggerTest.class);
+    String testMessage = "a test message";
+
+    @Test
+    public void testLogStdOutConfig() {
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        PrintStream realStdOut = System.out;
+        System.setOut(new PrintStream(byteArrayOutputStream));
+        LOG.info(testMessage);
+        System.setOut(realStdOut);
+
+        //log to stdout for debug
+        LOG.info(testMessage);
+        String bufferMessage = new String(byteArrayOutputStream.toByteArray(), StandardCharsets.UTF_8);
+        LOG.info(bufferMessage);
+
+        Assert.assertTrue(bufferMessage.contains(testMessage));
+    }
+}


### PR DESCRIPTION
<!-- 
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at
http://www.apache.org/licenses/LICENSE-2.0
Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
--> 
    
### Description
Cherry picked [#PR1814](https://github.com/apache/zookeeper/pull/1814)

### Tests
 The following tests are written for this issue:
CI and end-to-end tests
Local zookeeper testing done.

### Changes that Break Backward Compatibility (Optional)
NA

### Documentation (Optional)
In case of new functionality, my PR adds documentation in the following wiki page:
(Link the GitHub wiki you added)
