### PR TITLE
Change the way ZkClientUriDomainMappingHelper add watch

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
@@ -25,7 +25,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.ZooDefs;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelper.java
@@ -26,8 +26,8 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
-import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.server.DumbWatcher;
 import org.apache.zookeeper.server.ServerCnxn;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.ZooKeeperServer;
@@ -57,7 +57,7 @@ import org.slf4j.LoggerFactory;
  * Note: It is not expected that there would be too many distinct client URIs so as to overwhelm
  * heap usage.
  */
-public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainMappingHelper {
+public class ZkClientUriDomainMappingHelper implements ClientUriDomainMappingHelper {
 
   private static final Logger LOG = LoggerFactory.getLogger(ZkClientUriDomainMappingHelper.class);
 
@@ -106,7 +106,7 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
    * Install a persistent recursive watch on the root path.
    */
   private void addWatches() {
-    zks.getZKDatabase().addWatch(rootPath, this, ZooDefs.AddWatchModes.persistentRecursive);
+    zks.getZKDatabase().addWatch(rootPath, new MappingRootWatcher(), ZooDefs.AddWatchModes.persistentRecursive);
   }
 
   /**
@@ -140,33 +140,6 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
   }
 
   @Override
-  public void process(WatchedEvent event) {
-    LOG.info("Processing watched event: {}", event.toString());
-    parseZNodeMapping();
-    // Update AuthInfo for all the known connections.
-    // Note : It is not ideal to iterate over all plaintext connections which are connected over non-TLS but right now
-    // there is no way to find out if connection on unified port is using SSLHandler or nonSSLHandler. Anyways, we
-    // should not ideally have any nonSSLHandler connections on unified port after complete rollout.
-
-    // TODO Change to read SecureServerCnxnFactory only. The current logic is to support unit test who is not creating
-    // a secured server cnxn factory. It won't cause any problem but is not technically correct.
-
-    // Since port unification is supported, TLS requests could be made on unified as well as secure port. Hence iterate
-    // over all connections to update auth info.
-    ServerCnxnFactory factory = zks.getServerCnxnFactory();
-    LOG.info("Updating auth info for connections");
-    // TODO Evaluate performance impact and potentially use thread pool to parallelize the AuthInfo update.
-    if (factory != null) {
-      factory.getConnections().forEach(cnxn -> updateDomainBasedAuthInfo(cnxn));
-    }
-    ServerCnxnFactory secureFactory = zks.getSecureServerCnxnFactory();
-    LOG.info("Updating auth info for TLS connections");
-    if (secureFactory != null) {
-      secureFactory.getConnections().forEach(cnxn -> updateDomainBasedAuthInfo(cnxn));
-    }
-  }
-
-  @Override
   public Set<String> getDomains(String clientUri) {
     return clientUriToDomainNames.getOrDefault(clientUri, Collections.emptySet());
   }
@@ -178,6 +151,39 @@ public class ZkClientUriDomainMappingHelper implements Watcher, ClientUriDomainM
       // To prevent inconsistent update, concurrency control is necessary.
       synchronized (updater) {
         updater.updateAuthInfo(cnxn, clientUriToDomainNames);
+      }
+    }
+  }
+
+  /**
+   * The watcher used to listen on client uri - domain mapping root path for mapping update
+   * Extends DumbWatcher instead of ServerCnxn here some methods in ServerCnxn are not accessible from here
+   */
+  public class MappingRootWatcher extends DumbWatcher {
+    @Override
+    public void process(WatchedEvent event) {
+      LOG.info("Processing watched event: {}", event.toString());
+      parseZNodeMapping();
+      // Update AuthInfo for all the known connections.
+      // Note : It is not ideal to iterate over all plaintext connections which are connected over non-TLS but right now
+      // there is no way to find out if connection on unified port is using SSLHandler or nonSSLHandler. Anyways, we
+      // should not ideally have any nonSSLHandler connections on unified port after complete rollout.
+
+      // TODO Change to read SecureServerCnxnFactory only. The current logic is to support unit test who is not creating
+      // a secured server cnxn factory. It won't cause any problem but is not technically correct.
+
+      // Since port unification is supported, TLS requests could be made on unified as well as secure port. Hence iterate
+      // over all connections to update auth info.
+      ServerCnxnFactory factory = zks.getServerCnxnFactory();
+      LOG.info("Updating auth info for connections");
+      // TODO Evaluate performance impact and potentially use thread pool to parallelize the AuthInfo update.
+      if (factory != null) {
+        factory.getConnections().forEach(cnxn -> updateDomainBasedAuthInfo(cnxn));
+      }
+      ServerCnxnFactory secureFactory = zks.getSecureServerCnxnFactory();
+      LOG.info("Updating auth info for TLS connections");
+      if (secureFactory != null) {
+        secureFactory.getConnections().forEach(cnxn -> updateDomainBasedAuthInfo(cnxn));
       }
     }
   }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelperTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/auth/znode/groupacl/ZkClientUriDomainMappingHelperTest.java
@@ -163,7 +163,8 @@ public class ZkClientUriDomainMappingHelperTest extends ZKTestCase {
    * the functionality of getting watches
    */
   public void testB_GetWatches() {
+    ClientUriDomainMappingHelper helper = new ZkClientUriDomainMappingHelper(zookeeperServer);
     WatchesReport report = zookeeperServer.getZKDatabase().getDataTree().getWatches();
-    Assert.assertNotNull(report);
+    Assert.assertEquals(1, report.getPaths(0).size());
   }
 }


### PR DESCRIPTION
<!-- 
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at
http://www.apache.org/licenses/LICENSE-2.0
Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
--> 
    
### Description
ZkClientUriDomainMappingHelper instance is registered as a watcher during the instantiation process, so it will get the notification every time there's a change in the client URI domain mapping, and it can update each session that are connected to this zookeeper server for the updated access control metatdata.
However, in ZooKeeper server code, there is an implicit assumption that the objects registered as a watcher are ServerCnxn objects, while ZkClientUriDomainMappingHelper is not an instance of ServerCnxn. This incorrect cast of ZkClientUriDomainMappingHelper to ServerCnxn can lead to code failure.
This commit leveraged a dummy server cnxn class `DumbWatcher` which actually functions as a watcher, to prevent this error.

### Tests
 The following tests are written for this issue:
ZkClientUriDomainMappingHelperTest.testB_GetWatches

The following is the result of the "mvn test" command on the appropriate module:
[INFO] Results:
[INFO] 
[WARNING] Tests run: 3158, Failures: 0, Errors: 0, Skipped: 3
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  18:39 min
[INFO] Finished at: 2022-12-13T13:41:21-08:00
[INFO] ------------------------------------------------------------------------


### Changes that Break Backward Compatibility (Optional)
My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:
(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)
In case of new functionality, my PR adds documentation in the following wiki page:
(Link the GitHub wiki you added)
