### PR TITLE
Add option to log but not enforce connection filtering, reset proposal stats through Admin server API 

### DIFF
--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -2592,11 +2592,6 @@ static int init_ssl_for_socket(zsock_t *fd, zhandle_t *zh, int fail_on_error) {
         OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS | OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
         method = TLS_client_method();
 #endif
-        if (FIPS_mode() == 0) {
-            LOG_INFO(LOGCALLBACK(zh), "FIPS mode is OFF ");
-        } else {
-            LOG_INFO(LOGCALLBACK(zh), "FIPS mode is ON ");
-        }
         fd->ssl_ctx = SSL_CTX_new(method);
         ctx = &fd->ssl_ctx;
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/Commands.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/admin/Commands.java
@@ -614,6 +614,9 @@ public class Commands {
         public CommandResponse run(ZooKeeperServer zkServer, Map<String, String> kwargs) {
             CommandResponse response = initializeResponse();
             zkServer.serverStats().reset();
+            if (zkServer instanceof LeaderZooKeeperServer) {
+                ((LeaderZooKeeperServer) zkServer).getLeader().getProposalStats().reset();
+            }
             return response;
         }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/auth/X509AuthenticationConfig.java
@@ -132,6 +132,12 @@ public class X509AuthenticationConfig {
    */
   public static final String DEDICATED_DOMAIN = ZNODE_GROUP_ACL_CONFIG_PREFIX + "dedicatedDomain";
   /**
+   * This config property applies only to dedicated server. When true (default), domain specific connection filtering is
+   * enabled and enforced. When false, the server simply logs a warning message but doesn't actually filter/disconnect
+   * the connection if it does not belong to dedicated domain.
+   */
+  public static final String ENFORCE_DEDICATED_DOMAIN = ZNODE_GROUP_ACL_CONFIG_PREFIX + "enforceDedicatedDomain";
+  /**
    * This config property applies to non-dedicated server. If this property is set to true,
    * clientId extracted from the certificate will be stored in authInfo, along with the matched
    * domain name.
@@ -154,6 +160,7 @@ public class X509AuthenticationConfig {
   private String znodeGroupAclCrossDomainAccessDomainNameStr;
   private String znodeGroupAclOpenReadAccessPathPrefixStr;
   private String znodeGroupAclServerDedicatedDomain;
+  private String znodeGroupAclServerShouldEnforceDedicatedDomain;
   private String storeAuthedClientIdEnabled;
   private String allowedClientIdAsAclDomainsStr;
 
@@ -171,10 +178,12 @@ public class X509AuthenticationConfig {
   // Setters for X509 properties
 
   public void setClientCertIdType(String clientCertIdType) {
+    LOG.debug("{} = {}", SSL_X509_CLIENT_CERT_ID_TYPE, clientCertIdType);
     this.clientCertIdType = clientCertIdType;
   }
 
   public void setClientCertIdSanMatchType(String clientCertIdSanMatchType) {
+    LOG.debug("{} = {}", SSL_X509_CLIENT_CERT_ID_SAN_MATCH_TYPE, clientCertIdSanMatchType);
     if (clientCertIdSanMatchType == null) {
       return;
     }
@@ -190,15 +199,18 @@ public class X509AuthenticationConfig {
   }
 
   public void setClientCertIdSanMatchRegex(String clientCertIdSanMatchRegex) {
+    LOG.debug("{} = {}", SSL_X509_CLIENT_CERT_ID_SAN_MATCH_REGEX, clientCertIdSanMatchRegex);
     this.clientCertIdSanMatchRegex = clientCertIdSanMatchRegex;
   }
 
   public void setClientCertIdSanExtractRegex(String clientCertIdSanExtractRegex) {
+    LOG.debug("{} = {}", SSL_X509_CLIENT_CERT_ID_SAN_EXTRACT_REGEX, clientCertIdSanExtractRegex);
     this.clientCertIdSanExtractRegex = clientCertIdSanExtractRegex;
   }
 
   public void setClientCertIdSanExtractMatcherGroupIndex(
       String clientCertIdSanExtractMatcherGroupIndex) {
+    LOG.debug("{} = {}", SSL_X509_CLIENT_CERT_ID_SAN_EXTRACT_MATCHER_GROUP_INDEX, clientCertIdSanExtractMatcherGroupIndex);
     if (clientCertIdSanExtractMatcherGroupIndex == null) {
       return;
     }
@@ -217,20 +229,24 @@ public class X509AuthenticationConfig {
   // Setters for X509 Znode Group Acl properties
 
   public void setX509ClientIdAsAclEnabled(String enabled) {
+    LOG.debug("{} = {}", SET_X509_CLIENT_ID_AS_ACL, enabled);
     x509ClientIdAsAclEnabled = enabled;
   }
 
   public void setZnodeGroupAclSuperUserIdStr(String znodeGroupAclSuperUserIdStr) {
+    LOG.debug("{} = {}", ZOOKEEPER_ZNODEGROUPACL_SUPERUSER_ID, znodeGroupAclSuperUserIdStr);
     this.znodeGroupAclSuperUserIdStr = znodeGroupAclSuperUserIdStr;
   }
 
   public void setZnodeGroupAclCrossDomainAccessDomainNameStr(
       String znodeGroupAclCrossDomainAccessDomainNameStr) {
+    LOG.debug("{} = {}", CROSS_DOMAIN_ACCESS_DOMAIN_NAME, znodeGroupAclCrossDomainAccessDomainNameStr);
     this.znodeGroupAclCrossDomainAccessDomainNameStr = znodeGroupAclCrossDomainAccessDomainNameStr;
   }
 
   public void setZnodeGroupAclOpenReadAccessPathPrefixStr(
       String znodeGroupAclOpenReadAccessPathPrefixStr) {
+    LOG.debug("{} = {}", OPEN_READ_ACCESS_PATH_PREFIX, znodeGroupAclOpenReadAccessPathPrefixStr);
     this.znodeGroupAclOpenReadAccessPathPrefixStr = znodeGroupAclOpenReadAccessPathPrefixStr;
   }
 
@@ -239,10 +255,17 @@ public class X509AuthenticationConfig {
   }
 
   public void setZnodeGroupAclServerDedicatedDomain(String znodeGroupAclServerDedicatedDomain) {
+    LOG.info("{} = {}", DEDICATED_DOMAIN, znodeGroupAclServerDedicatedDomain);
     this.znodeGroupAclServerDedicatedDomain = znodeGroupAclServerDedicatedDomain;
   }
 
+  public void setZnodeGroupAclServerShouldEnforceDedicatedDomain(String znodeGroupAclServerShouldEnforceDedicatedDomain) {
+    LOG.info("{} = {}", ENFORCE_DEDICATED_DOMAIN, znodeGroupAclServerShouldEnforceDedicatedDomain);
+    this.znodeGroupAclServerShouldEnforceDedicatedDomain = znodeGroupAclServerShouldEnforceDedicatedDomain;
+  }
+
   public void setStoreAuthedClientIdEnabled(String enabled) {
+    LOG.debug("{} = {}", STORE_AUTHED_CLIENT_ID, enabled);
     storeAuthedClientIdEnabled = enabled;
   }
 
@@ -352,6 +375,13 @@ public class X509AuthenticationConfig {
       setZnodeGroupAclServerDedicatedDomain(System.getProperty(DEDICATED_DOMAIN));
     }
     return znodeGroupAclServerDedicatedDomain;
+  }
+
+  public boolean isEnforceDedicatedDomainEnabled() {
+    if (znodeGroupAclServerShouldEnforceDedicatedDomain == null) {
+      setZnodeGroupAclServerShouldEnforceDedicatedDomain(System.getProperty(ENFORCE_DEDICATED_DOMAIN, "true"));
+    }
+    return Boolean.parseBoolean(znodeGroupAclServerShouldEnforceDedicatedDomain);
   }
 
   public String getZnodeGroupAclClientUriDomainMappingRootPath() {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -378,6 +378,15 @@ public class QuorumPeerConfig {
             } else if (key.equals(BackupSystemProperty.BACKUP_TIMETABLE_BACKUP_INTERVAL_MS)) {
                 backupConfigBuilder.setTimetableBackupIntervalInMs(Long.parseLong(value));
             } else if (key.equals(X509AuthenticationConfig.SET_X509_CLIENT_ID_AS_ACL)) {
+            // TODO: the above key.equals(X509AuthenticationConfig.SET_X509_CLIENT_ID_AS_ACL) is checking if the key
+            //   is equal to "zookeeper.X509ZNodeGroupAclProvider.setX509ClientIdAsAcl" (see
+            //   ZNODE_GROUP_ACL_CONFIG_PREFIX) which is the wrong format for zoo.cfg (zoo.cfg properties do not have
+            //   "zookeeper." prefix typically). So, if "X509ZNodeGroupAclProvider.setX509ClientIdAsAcl" is set in
+            //   in zoo.cfg, it does not get caught by the above "if". Instead, it falls through to the default "else"
+            //   where it gets set as a system property with a "zookeeper." prefix. So NONE of the
+            //   X509AuthenticationConfig "if" matches here are working as expected. Since the setters never get invoked
+            //   here, we rely on the getters in X509ZNodeGroupAclProvider to read the the associated system property
+            //   and invoke the setters there.
                 X509AuthenticationConfig.getInstance().setX509ClientIdAsAclEnabled(value);
             } else if (key.equals(X509AuthenticationConfig.SSL_X509_CLIENT_CERT_ID_TYPE)) {
                 X509AuthenticationConfig.getInstance().setClientCertIdType(value);
@@ -401,7 +410,9 @@ public class QuorumPeerConfig {
                 X509AuthenticationConfig.getInstance().setStoreAuthedClientIdEnabled(value);
             } else if (key.equals(X509AuthenticationConfig.ALLOWED_CLIENT_ID_AS_ACL_DOMAINS)) {
                 X509AuthenticationConfig.getInstance().setAllowedClientIdAsAclDomainsStr(value);
-            } else if (key.equals("standaloneEnabled")) {
+            } else if (key.equals(X509AuthenticationConfig.ENFORCE_DEDICATED_DOMAIN)) {
+                X509AuthenticationConfig.getInstance().setZnodeGroupAclServerShouldEnforceDedicatedDomain(value);
+            }  else if (key.equals("standaloneEnabled")) {
                 if (value.toLowerCase().equals("true")) {
                     setStandaloneEnabled(true);
                 } else if (value.toLowerCase().equals("false")) {


### PR DESCRIPTION
### Description
1. Add option to log but not enforce connection filtering.
    - When ZK server is in dedicated mode and  `X509ZNodeGroupAclProvider.enforceDedicatedDomain` is **false** and a client with ID not part of the corresponding dedicated domain tries to connect, ZK server logs a warning but allows the connection to be established. When `X509ZNodeGroupAclProvider.enforceDedicatedDomain` is **true**, ZK server disconnects the connection (current and default behavior).
2. Reset proposal stats through Admin server API (in line with [stat reset 4lw command](https://github.com/apache/zookeeper/blob/master/zookeeper-server/src/main/java/org/apache/zookeeper/server/command/StatResetCommand.java#L39))
3. [**Update: These changes were removed from this PR and will be incorporated in a different PR** ] Removes misconfigured attempts to parse `zookeeper.X509ZNodeGroupAclProvider` related properties from zoo.cfg.
    - Let's take an example `zoo.cfg` line, `X509ZNodeGroupAclProvider.setX509ClientIdAsAcl=true`
    - This will not be captured by
       ```
       if (key.equals(X509AuthenticationConfig.SET_X509_CLIENT_ID_AS_ACL)) {
                X509AuthenticationConfig.getInstance().setX509ClientIdAsAclEnabled(value);
       } 
       ```
    - This is because `X509AuthenticationConfig.SET_X509_CLIENT_ID_AS_ACL` is equal to `zookeeper.X509ZNodeGroupAclProvider.setX509ClientIdAsAcl`, but `key` is `X509ZNodeGroupAclProvider.setX509ClientIdAsAcl` (without `zookeeper.`).
    - The zoo.cfg parsing of `X509ZNodeGroupAclProvider` and usage of associated setters (like in the above `if` block) was never being used so far.
    - Instead, we were relying on the default `else` block below to set `X509ZNodeGroupAclProvider.setX509ClientIdAsAcl` from zoo.cfg as `zookeeper.X509ZNodeGroupAclProvider.setX509ClientIdAsAcl` System property, which is then read by associated getters.
      ```
       else {
           System.setProperty("zookeeper." + key, value);
       }
      ```
    
### Tests
```
mvn test -e -Dtest=X509ZNodeGroupAclProviderTest#testConnectionFiltering -DfailIfNoTests=false
```

Dedicated domain = `DomainX`

1. Authorized domain is allowed to connect
```
2023-05-12 16:40:16,314 [myid:] - INFO  [main:ZkClientUriDomainMappingHelper@76] - Client URI domain mapping root path: /zookeeper/uri-domain-map
2023-05-12 16:40:16,317 [myid:] - INFO  [main:ZkClientUriDomainMappingHelper@135] - Registering client URI domain mapping: DomainYUser --> DomainY
2023-05-12 16:40:16,317 [myid:] - INFO  [main:ZkClientUriDomainMappingHelper@135] - Registering client URI domain mapping: CrossDomainUser --> CrossDomain
2023-05-12 16:40:16,318 [myid:] - INFO  [main:ZkClientUriDomainMappingHelper@135] - Registering client URI domain mapping: DomainXUser --> DomainX
2023-05-12 16:40:16,318 [myid:] - INFO  [main:X509ZNodeGroupAclProvider@194] - New UriDomainMappingHelper has been instantiated.
2023-05-12 16:40:16,322 [myid:] - WARN  [main:X509AuthenticationUtil@74] - Key store location not specified for SSL
2023-05-12 16:40:16,322 [myid:] - WARN  [main:X509AuthenticationUtil@106] - Truststore location not specified for SSL
2023-05-12 16:40:16,322 [myid:] - INFO  [main:X509AuthenticationConfig@245] - zookeeper.X509ZNodeGroupAclProvider.dedicatedDomain = DomainX
2023-05-12 16:40:16,322 [myid:] - INFO  [main:X509ZNodeGroupAclProvider@237] - Id 'DomainXUser' belongs to domain that matches server namespace 'DomainX', authorized for access.
2023-05-12 16:40:16,323 [myid:] - INFO  [main:X509ZNodeGroupAclProvider@277] - Authenticated Id 'scheme: x509, id: DomainXUser' has been added to session 0x0 from host .
```

2. Unauthorized domain is not allowed to connect (connection filtering is enforced)
```
2023-05-12 16:40:16,323 [myid:] - INFO  [main:ZkClientUriDomainMappingHelper@76] - Client URI domain mapping root path: /zookeeper/uri-domain-map
2023-05-12 16:40:16,324 [myid:] - INFO  [main:ZkClientUriDomainMappingHelper@135] - Registering client URI domain mapping: DomainYUser --> DomainY
2023-05-12 16:40:16,324 [myid:] - INFO  [main:ZkClientUriDomainMappingHelper@135] - Registering client URI domain mapping: CrossDomainUser --> CrossDomain
2023-05-12 16:40:16,324 [myid:] - INFO  [main:ZkClientUriDomainMappingHelper@135] - Registering client URI domain mapping: DomainXUser --> DomainX
2023-05-12 16:40:16,324 [myid:] - INFO  [main:X509ZNodeGroupAclProvider@194] - New UriDomainMappingHelper has been instantiated.
2023-05-12 16:40:16,324 [myid:] - INFO  [main:X509AuthenticationConfig@245] - zookeeper.X509ZNodeGroupAclProvider.dedicatedDomain = DomainY
2023-05-12 16:40:16,324 [myid:] - INFO  [main:X509AuthenticationConfig@250] - zookeeper.X509ZNodeGroupAclProvider.enforceDedicatedDomain = true
2023-05-12 16:40:16,325 [myid:] - ERROR [main:X509ZNodeGroupAclProvider@243] - Id 'DomainXUser' does not belong to domain that matches server namespace 'DomainY', disconnecting the connection.
```

3. Unauthorized domain is allowed to connect with a warning log (connection filterning not enforced)
```
2023-05-12 16:40:16,325 [myid:] - INFO  [main:ZkClientUriDomainMappingHelper@76] - Client URI domain mapping root path: /zookeeper/uri-domain-map
2023-05-12 16:40:16,325 [myid:] - INFO  [main:ZkClientUriDomainMappingHelper@135] - Registering client URI domain mapping: DomainYUser --> DomainY
2023-05-12 16:40:16,325 [myid:] - INFO  [main:ZkClientUriDomainMappingHelper@135] - Registering client URI domain mapping: CrossDomainUser --> CrossDomain
2023-05-12 16:40:16,325 [myid:] - INFO  [main:ZkClientUriDomainMappingHelper@135] - Registering client URI domain mapping: DomainXUser --> DomainX
2023-05-12 16:40:16,325 [myid:] - INFO  [main:X509ZNodeGroupAclProvider@194] - New UriDomainMappingHelper has been instantiated.
2023-05-12 16:40:16,326 [myid:] - INFO  [main:X509AuthenticationConfig@245] - zookeeper.X509ZNodeGroupAclProvider.dedicatedDomain = DomainY
2023-05-12 16:40:16,326 [myid:] - INFO  [main:X509AuthenticationConfig@250] - zookeeper.X509ZNodeGroupAclProvider.enforceDedicatedDomain = false
2023-05-12 16:40:16,326 [myid:] - WARN  [main:X509ZNodeGroupAclProvider@247] - Id 'DomainXUser' does not belong to domain that matches server namespace 'DomainY'. Allowing connection for now, but client connection will be blocked/disconnected in future when dedicated domain connection filtering is enforced.
```