### PR TITLE
Add allowedClientIdAsAclDomains property

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -1021,7 +1021,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
         // Examples that will not be handled by the "following logic" are:
         //      x509 super user, plaintext port clients, any user when dedicated server is enabled
         //      -> will go through original zk fixupACL logic
-        Set<String> enabledX509ClientIdAsCL = authInfo.stream()
+        Set<String> enabledX509ClientIdAsACL = authInfo.stream()
             .filter(id -> X509AuthenticationUtil.X509_SCHEME.equals(id.getScheme()))
             .map(Id::getId)
             .collect(Collectors.toCollection(HashSet::new));
@@ -1029,16 +1029,16 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
           // If clientIdAsAclEnabled is true, all the X509 auth entries should be added to the ACL. If it's not enabled,
           // only preserve the ones that are present in allowedClientIdAsAclDomains. If the intersection is empty,
           // overwriting the ACL will be disabled.
-          enabledX509ClientIdAsCL
+          enabledX509ClientIdAsACL
               .removeIf(id -> !X509AuthenticationConfig.getInstance().getAllowedClientIdAsAclDomains().contains(id));
         }
 
-      if ((!enabledX509ClientIdAsCL.isEmpty() || X509AuthenticationConfig.getInstance().isX509ClientIdAsAclEnabled())
+      if ((!enabledX509ClientIdAsACL.isEmpty() || X509AuthenticationConfig.getInstance().isX509ClientIdAsAclEnabled())
             && X509AuthenticationConfig.getInstance().isX509ZnodeGroupAclEnabled()
             && !X509AuthenticationConfig.getInstance().isZnodeGroupAclDedicatedServerEnabled()) {
             boolean isUserProvidedAclOverriden = false;
             for (Id id : authInfo) {
-                boolean isX509 = enabledX509ClientIdAsCL.contains(id.getId());
+                boolean isX509 = enabledX509ClientIdAsACL.contains(id.getId());
                 boolean isX509CrossDomainComponent =
                     id.getScheme().equals(X509AuthenticationUtil.SUPERUSER_AUTH_SCHEME)
                         && !X509AuthenticationConfig.getInstance().getZnodeGroupAclSuperUserIds()

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -32,6 +33,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.stream.Collectors;
 import org.apache.jute.BinaryOutputArchive;
 import org.apache.jute.Record;
 import org.apache.zookeeper.CreateMode;
@@ -1005,7 +1007,10 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
         List<ACL> rv = new ArrayList<>();
 
         // Overwrite the acl list for users (except super user) when the auth provider is
-        // X509ZnodeGroupAclProvider, and isX509ClientIdAsAclEnabled is true;
+        // X509ZnodeGroupAclProvider, and isX509ClientIdAsAclEnabled is true. Note that
+        // clientIdAsAcl can be partially enabled for specific domains by adding them to
+        // the allowedClientIdAsAclDomains list.
+        //
         // Set x509 ZNode ACL as the client's corresponding domain name. This domain name denotes a
         // ZNode group the client belongs to and can be derived from the client URI-domain mapping
         // (UriDomainMappingHelper).
@@ -1016,12 +1021,24 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
         // Examples that will not be handled by the "following logic" are:
         //      x509 super user, plaintext port clients, any user when dedicated server is enabled
         //      -> will go through original zk fixupACL logic
-        boolean isUserProvidedAclOverriden = false;
-        if (X509AuthenticationConfig.getInstance().isX509ClientIdAsAclEnabled()
+        Set<String> enabledX509ClientIdAsCL = authInfo.stream()
+            .filter(id -> X509AuthenticationUtil.X509_SCHEME.equals(id.getScheme()))
+            .map(Id::getId)
+            .collect(Collectors.toCollection(HashSet::new));
+        if (!X509AuthenticationConfig.getInstance().isX509ClientIdAsAclEnabled()) {
+          // If clientIdAsAclEnabled is true, all the X509 auth entries should be added to the ACL. If it's not enabled,
+          // only preserve the ones that are present in allowedClientIdAsAclDomains. If the intersection is empty,
+          // overwriting the ACL will be disabled.
+          enabledX509ClientIdAsCL
+              .removeIf(id -> !X509AuthenticationConfig.getInstance().getAllowedClientIdAsAclDomains().contains(id));
+        }
+
+      if ((!enabledX509ClientIdAsCL.isEmpty() || X509AuthenticationConfig.getInstance().isX509ClientIdAsAclEnabled())
             && X509AuthenticationConfig.getInstance().isX509ZnodeGroupAclEnabled()
             && !X509AuthenticationConfig.getInstance().isZnodeGroupAclDedicatedServerEnabled()) {
+            boolean isUserProvidedAclOverriden = false;
             for (Id id : authInfo) {
-                boolean isX509 = id.getScheme().equals(X509AuthenticationUtil.X509_SCHEME);
+                boolean isX509 = enabledX509ClientIdAsCL.contains(id.getId());
                 boolean isX509CrossDomainComponent =
                     id.getScheme().equals(X509AuthenticationUtil.SUPERUSER_AUTH_SCHEME)
                         && !X509AuthenticationConfig.getInstance().getZnodeGroupAclSuperUserIds()

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeerConfig.java
@@ -399,6 +399,8 @@ public class QuorumPeerConfig {
                 X509AuthenticationConfig.getInstance().setZnodeGroupAclOpenReadAccessPathPrefixStr(value);
             } else if (key.equals(X509AuthenticationConfig.STORE_AUTHED_CLIENT_ID)) {
                 X509AuthenticationConfig.getInstance().setStoreAuthedClientIdEnabled(value);
+            } else if (key.equals(X509AuthenticationConfig.ALLOWED_CLIENT_ID_AS_ACL_DOMAINS)) {
+                X509AuthenticationConfig.getInstance().setAllowedClientIdAsAclDomainsStr(value);
             } else if (key.equals("standaloneEnabled")) {
                 if (value.toLowerCase().equals("true")) {
                     setStandaloneEnabled(true);


### PR DESCRIPTION
<!-- 
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at
http://www.apache.org/licenses/LICENSE-2.0
Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
--> 
    
### Description
This property allows partially enabling setX509ClientIdAsAcl for certain x509 principals. This granular approach to enabling the property will allow self managing apps to set their own ACLs without giving them superuser access or giving them access to groups/domains they do not have access to.

### Tests
 The following tests are written for this issue:
(List the names of added unit/integration tests)

The following is the result of the "mvn test" command on the appropriate module:
(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)