### PR TITLE
Limit the number of ephemeral nodes a session can create

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1070,9 +1070,12 @@ property, when available, is noted below.
     **New in 3.6.0:**
     The size threshold after which a request is considered a large request. If it is -1, then all requests are considered small, effectively turning off large request throttling. The default is -1.
 
-* *ephemeral.count.limit* :
-  (Java system property: **zookeeper.ephemeral.count.limit**)
-  This property sets a limit on the number of ephemeral nodes a session can create. The default value is 7500, set in PrepRequestProcessor.java. The limit will be ignored when the value is set to -1.
+* *ephemeralNodes.total.byte.limit* :
+  (Java system property: **zookeeper.ephemeralNodes.total.byte.limit**)
+  This property set a limit on the amount of ephemeral nodes that can be created in one session. The limit is the number 
+  of bytes it takes to store the serialized path strings for all the session's ephemeral nodes. 
+  This limit should always be under the jute maxbuffer, as exceeding will cause the server to crash whne the connection is closed 
+  and a transaction to delete all the ephemeral nodes for that session are deleted. This limit will be ignored if not explicitly set.
 
 * *outstandingHandshake.limit* 
     (Jave system property only: **zookeeper.netty.server.outstandingHandshake.limit**)

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1074,7 +1074,7 @@ property, when available, is noted below.
   (Java system property: **zookeeper.ephemeralNodes.total.byte.limit**)
   This property set a limit on the amount of ephemeral nodes that can be created in one session. The limit is the number 
   of bytes it takes to store the serialized path strings for all the session's ephemeral nodes. 
-  This limit should always be under the jute maxbuffer, as exceeding will cause the server to crash whne the connection is closed 
+  This limit should always be under the jute maxbuffer, as exceeding will cause the server to crash when the connection is closed 
   and a transaction to delete all the ephemeral nodes for that session are deleted. This limit will be ignored if not explicitly set.
 
 * *outstandingHandshake.limit* 

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1069,7 +1069,6 @@ property, when available, is noted below.
     (Java system property: **zookeeper.largeRequestThreshold**)
     **New in 3.6.0:**
     The size threshold after which a request is considered a large request. If it is -1, then all requests are considered small, effectively turning off large request throttling. The default is -1.
-* 
 
 * *ephemeral.count.limit* :
   (Java system property: **zookeeper.ephemeral.count.limit**)

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1073,7 +1073,6 @@ property, when available, is noted below.
 
 * *ephemeral.count.limit* :
   (Java system property: **zookeeper.ephemeral.count.limit**)
-  **New in !!! TODO VERSION NUMBER HERE !!!**
   This property sets a limit on the number of ephemeral nodes a session can create. The default value is 10000.
 
 * *outstandingHandshake.limit* 

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1072,7 +1072,7 @@ property, when available, is noted below.
 
 * *ephemeral.count.limit* :
   (Java system property: **zookeeper.ephemeral.count.limit**)
-  This property sets a limit on the number of ephemeral nodes a session can create. The default value is 7500, set in PrepRequestProcessor.java.
+  This property sets a limit on the number of ephemeral nodes a session can create. The default value is 7500, set in PrepRequestProcessor.java. The limit will be ignored when the value is set to -1.
 
 * *outstandingHandshake.limit* 
     (Jave system property only: **zookeeper.netty.server.outstandingHandshake.limit**)

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1069,6 +1069,12 @@ property, when available, is noted below.
     (Java system property: **zookeeper.largeRequestThreshold**)
     **New in 3.6.0:**
     The size threshold after which a request is considered a large request. If it is -1, then all requests are considered small, effectively turning off large request throttling. The default is -1.
+* 
+
+* *ephemeral.count.limit* :
+  (Java system property: **zookeeper.ephemeral.count.limit**)
+  **New in !!! TODO VERSION NUMBER HERE !!!**
+  This property sets a limit on the number of ephemeral nodes a session can create. The default value is 10000.
 
 * *outstandingHandshake.limit* 
     (Jave system property only: **zookeeper.netty.server.outstandingHandshake.limit**)

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1072,7 +1072,7 @@ property, when available, is noted below.
 
 * *ephemeral.count.limit* :
   (Java system property: **zookeeper.ephemeral.count.limit**)
-  This property sets a limit on the number of ephemeral nodes a session can create. The default value is 10000.
+  This property sets a limit on the number of ephemeral nodes a session can create. The default value is 7500, set in PrepRequestProcessor.java.
 
 * *outstandingHandshake.limit* 
     (Jave system property only: **zookeeper.netty.server.outstandingHandshake.limit**)

--- a/zookeeper-jute/src/main/java/org/apache/jute/BinaryOutputArchive.java
+++ b/zookeeper-jute/src/main/java/org/apache/jute/BinaryOutputArchive.java
@@ -102,6 +102,29 @@ public class BinaryOutputArchive implements OutputArchive {
         return bb;
     }
 
+    public static int getSerializedStringByteSize(String s) throws ArithmeticException {
+        if (s == null) {
+            return 0;
+        }
+
+        // Always add 4 bytes to size as we call writeInt(bb.remaining(), "len") when writing to DataOutput
+        int length_descriptor_size = 4;
+
+        int size = 0;
+        final int len = s.length();
+        for (int i = 0; i < len; i++) {
+            char c = s.charAt(i);
+            if (c < 0x80) {
+                size = Math.addExact(size, 1);
+            } else if (c < 0x800) {
+                size = Math.addExact(size, 2);
+            } else {
+                size = Math.addExact(size, 3);
+            }
+        }
+        return Math.addExact(size, length_descriptor_size);
+    }
+
     public void writeString(String s, String tag) throws IOException {
         if (s == null) {
             writeInt(-1, "len");

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/KeeperException.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/KeeperException.java
@@ -407,6 +407,8 @@ public abstract class KeeperException extends Exception {
          *  but client is not configured with SASL authentication or configuted with SASL but failed
          *  (i.e. wrong credential used.). */
         SESSIONCLOSEDREQUIRESASLAUTH(-124),
+        /** Request to create ephemeral node was rejected because the limit for the session was exceeded. The default is
+         * 7500, but can be set through the "zookeeper.ephemeral.count.limit" system property. */
         EPHEMERALCOUNTEXCEEDED(-125);
 
         private static final Map<Integer, Code> lookup = new HashMap<Integer, Code>();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/KeeperException.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/KeeperException.java
@@ -148,8 +148,8 @@ public abstract class KeeperException extends Exception {
             return new SessionClosedRequireAuthException();
         case REQUESTTIMEOUT:
             return new RequestTimeoutException();
-        case EPHEMERALCOUNTEXCEEDED:
-            return new EphemeralCountExceededException();
+        case TOTALEPHEMERALLIMITEXCEEDED:
+            return new TotalEphemeralLimitExceeded();
         case OK:
         default:
             throw new IllegalArgumentException("Invalid exception code");
@@ -409,7 +409,7 @@ public abstract class KeeperException extends Exception {
         SESSIONCLOSEDREQUIRESASLAUTH(-124),
         /** Request to create ephemeral node was rejected because the limit for the session was exceeded. The default is
          * 7500, but can be set through the "zookeeper.ephemeral.count.limit" system property. */
-        EPHEMERALCOUNTEXCEEDED(-125);
+        TOTALEPHEMERALLIMITEXCEEDED(-125);
 
         private static final Map<Integer, Code> lookup = new HashMap<Integer, Code>();
 
@@ -500,7 +500,7 @@ public abstract class KeeperException extends Exception {
             return "Reconfig is disabled";
         case SESSIONCLOSEDREQUIRESASLAUTH:
             return "Session closed because client failed to authenticate";
-        case EPHEMERALCOUNTEXCEEDED:
+        case TOTALEPHEMERALLIMITEXCEEDED:
             return "Ephemeral count exceeded for session";
         default:
             return "Unknown error " + code;
@@ -947,9 +947,9 @@ public abstract class KeeperException extends Exception {
 
     }
 
-    public static class EphemeralCountExceededException extends KeeperException {
-        public EphemeralCountExceededException() {
-            super(Code.EPHEMERALCOUNTEXCEEDED);
+    public static class TotalEphemeralLimitExceeded extends KeeperException {
+        public TotalEphemeralLimitExceeded() {
+            super(Code.TOTALEPHEMERALLIMITEXCEEDED);
         }
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/KeeperException.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/KeeperException.java
@@ -407,8 +407,8 @@ public abstract class KeeperException extends Exception {
          *  but client is not configured with SASL authentication or configuted with SASL but failed
          *  (i.e. wrong credential used.). */
         SESSIONCLOSEDREQUIRESASLAUTH(-124),
-        /** Request to create ephemeral node was rejected because the limit for the session was exceeded. The default is
-         * 7500, but can be set through the "zookeeper.ephemeral.count.limit" system property. */
+        /** Request to create ephemeral node was rejected because the total byte limit for the session was exceeded.
+         * This limit is manually set through the "zookeeper.ephemeralNodes.total.byte.limit" system property. */
         TOTALEPHEMERALLIMITEXCEEDED(-125);
 
         private static final Map<Integer, Code> lookup = new HashMap<Integer, Code>();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/KeeperException.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/KeeperException.java
@@ -148,6 +148,8 @@ public abstract class KeeperException extends Exception {
             return new SessionClosedRequireAuthException();
         case REQUESTTIMEOUT:
             return new RequestTimeoutException();
+        case EPHEMERALCOUNTEXCEEDED:
+            return new EphemeralCountExceededException();
         case OK:
         default:
             throw new IllegalArgumentException("Invalid exception code");
@@ -404,7 +406,8 @@ public abstract class KeeperException extends Exception {
         /** The session has been closed by server because server requires client to do SASL authentication,
          *  but client is not configured with SASL authentication or configuted with SASL but failed
          *  (i.e. wrong credential used.). */
-        SESSIONCLOSEDREQUIRESASLAUTH(-124);
+        SESSIONCLOSEDREQUIRESASLAUTH(-124),
+        EPHEMERALCOUNTEXCEEDED(-125);
 
         private static final Map<Integer, Code> lookup = new HashMap<Integer, Code>();
 
@@ -495,6 +498,8 @@ public abstract class KeeperException extends Exception {
             return "Reconfig is disabled";
         case SESSIONCLOSEDREQUIRESASLAUTH:
             return "Session closed because client failed to authenticate";
+        case EPHEMERALCOUNTEXCEEDED:
+            return "Ephemeral count exceeded for session";
         default:
             return "Unknown error " + code;
         }
@@ -938,6 +943,12 @@ public abstract class KeeperException extends Exception {
             super(Code.REQUESTTIMEOUT);
         }
 
+    }
+
+    public static class EphemeralCountExceededException extends KeeperException {
+        public EphemeralCountExceededException() {
+            super(Code.EPHEMERALCOUNTEXCEEDED);
+        }
     }
 
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -573,7 +573,8 @@ public class DataTree {
                         totalEphemeralsByteSize = new AtomicInteger();
                         ephemeralsByteSizeMap.put(ephemeralOwner, totalEphemeralsByteSize);
                     }
-                    totalEphemeralsByteSize.addAndGet(BinaryOutputArchive.getSerializedStringByteSize(path));
+                    int byteSize = totalEphemeralsByteSize.addAndGet(BinaryOutputArchive.getSerializedStringByteSize(path));
+                    System.out.println("----- total byte size is " + byteSize + " after adding path" + path + " and limit is: " + ZooKeeperServer.getEphemeralNodesTotalByteLimit() + " -----");
                 }
             }
             if (outputStat != null) {
@@ -667,7 +668,8 @@ public class DataTree {
                     }
                     //  Only store sum of ephemeral node byte sizes if we're enforcing a limit
                     if (ZooKeeperServer.getEphemeralNodesTotalByteLimit() != 1 && nodeExisted && totalEphemeralsByteSize != null) {
-                        totalEphemeralsByteSize.addAndGet(-(BinaryOutputArchive.getSerializedStringByteSize(path)));
+                        int byteSize = totalEphemeralsByteSize.addAndGet(-(BinaryOutputArchive.getSerializedStringByteSize(path)));
+                        System.out.println("----- total byte size is " + byteSize + " after removing path " + path + " and limit is: " + ZooKeeperServer.getEphemeralNodesTotalByteLimit() + " -----");
                     }
                 }
             }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -573,8 +572,7 @@ public class DataTree {
                         totalEphemeralsByteSize = new AtomicInteger();
                         ephemeralsByteSizeMap.put(ephemeralOwner, totalEphemeralsByteSize);
                     }
-                    int byteSize = totalEphemeralsByteSize.addAndGet(BinaryOutputArchive.getSerializedStringByteSize(path));
-                    System.out.println("----- total byte size is " + byteSize + " after adding path" + path + " and limit is: " + ZooKeeperServer.getEphemeralNodesTotalByteLimit() + " -----");
+                    totalEphemeralsByteSize.addAndGet(BinaryOutputArchive.getSerializedStringByteSize(path));
                 }
             }
             if (outputStat != null) {
@@ -668,8 +666,7 @@ public class DataTree {
                     }
                     //  Only store sum of ephemeral node byte sizes if we're enforcing a limit
                     if (ZooKeeperServer.getEphemeralNodesTotalByteLimit() != 1 && nodeExisted && totalEphemeralsByteSize != null) {
-                        int byteSize = totalEphemeralsByteSize.addAndGet(-(BinaryOutputArchive.getSerializedStringByteSize(path)));
-                        System.out.println("----- total byte size is " + byteSize + " after removing path " + path + " and limit is: " + ZooKeeperServer.getEphemeralNodesTotalByteLimit() + " -----");
+                        totalEphemeralsByteSize.addAndGet(-(BinaryOutputArchive.getSerializedStringByteSize(path)));
                     }
                 }
             }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -568,13 +568,12 @@ public class DataTree {
                     list.add(path);
                 }
                 //  Only store sum of ephemeral node byte sizes if we're enforcing a limit
-                if (ZooKeeperServer.getEphemeralCountLimit() != 1) {
+                if (ZooKeeperServer.getEphemeralNodesTotalByteLimit() != 1) {
                     if (totalEphemeralsByteSize == null) {
                         totalEphemeralsByteSize = new AtomicInteger();
                         ephemeralsByteSizeMap.put(ephemeralOwner, totalEphemeralsByteSize);
                     }
-                    int byteSize = totalEphemeralsByteSize.addAndGet(BinaryOutputArchive.getSerializedStringByteSize(path));
-                    System.out.println("----- total byte size is " + byteSize + " after adding path" + path + " -----");
+                    totalEphemeralsByteSize.addAndGet(BinaryOutputArchive.getSerializedStringByteSize(path));
                 }
             }
             if (outputStat != null) {
@@ -662,13 +661,13 @@ public class DataTree {
                 Set<String> nodes = ephemerals.get(eowner);
                 AtomicInteger totalEphemeralsByteSize = ephemeralsByteSizeMap.get(eowner);
                 if (nodes != null) {
+                    Boolean nodeExisted;
                     synchronized (nodes) {
-                        nodes.remove(path);
+                        nodeExisted = nodes.remove(path);
                     }
                     //  Only store sum of ephemeral node byte sizes if we're enforcing a limit
-                    if (totalEphemeralsByteSize != null && ZooKeeperServer.getEphemeralCountLimit() != 1) {
-                        int byteSize = totalEphemeralsByteSize.addAndGet(-(BinaryOutputArchive.getSerializedStringByteSize(path)));
-                        System.out.println("----- total byte size is " + byteSize + " after adding path" + path + " -----");
+                    if (ZooKeeperServer.getEphemeralNodesTotalByteLimit() != 1 && nodeExisted && totalEphemeralsByteSize != null) {
+                        totalEphemeralsByteSize.addAndGet(-(BinaryOutputArchive.getSerializedStringByteSize(path)));
                     }
                 }
             }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -223,7 +223,8 @@ public class DataTree {
     }
 
     public int getTotalEphemeralsByteSize(long sessionID) {
-        return ephemeralsByteSizeMap.getOrDefault(sessionID, new AtomicInteger()).get();
+        AtomicInteger byteSize = ephemeralsByteSizeMap.get(sessionID);
+        return byteSize != null ? byteSize.get() : 0;
     }
 
     public Set<String> getContainers() {
@@ -567,7 +568,7 @@ public class DataTree {
                     list.add(path);
                 }
                 //  Only store sum of ephemeral node byte sizes if we're enforcing a limit
-                if (ZooKeeperServer.getEphemeralNodesTotalByteLimit() != 1) {
+                if (ZooKeeperServer.getEphemeralNodesTotalByteLimit() != -1) {
                     if (totalEphemeralsByteSize == null) {
                         totalEphemeralsByteSize = new AtomicInteger();
                         ephemeralsByteSizeMap.put(ephemeralOwner, totalEphemeralsByteSize);
@@ -665,7 +666,7 @@ public class DataTree {
                         nodeExisted = nodes.remove(path);
                     }
                     //  Only store sum of ephemeral node byte sizes if we're enforcing a limit
-                    if (ZooKeeperServer.getEphemeralNodesTotalByteLimit() != 1 && nodeExisted && totalEphemeralsByteSize != null) {
+                    if (ZooKeeperServer.getEphemeralNodesTotalByteLimit() != -1 && nodeExisted && totalEphemeralsByteSize != null) {
                         totalEphemeralsByteSize.addAndGet(-(BinaryOutputArchive.getSerializedStringByteSize(path)));
                     }
                 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -722,7 +722,6 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
             if (ZooKeeperServer.getEphemeralNodesTotalByteLimit() != -1 && currentByteSize + BinaryOutputArchive.getSerializedStringByteSize(path)
                     > ZooKeeperServer.getEphemeralNodesTotalByteLimit()) {
                 ServerMetrics.getMetrics().EPHEMERAL_NODE_LIMIT_VIOLATION.inc();
-                System.out.println("-------- EPHEMERAL NODE VIOLATION METRIC INCREMENTED -------");
                 throw new KeeperException.TotalEphemeralLimitExceeded();
             }
         }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -108,7 +108,6 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
     private final RequestProcessor nextProcessor;
     private final boolean digestEnabled;
     private DigestCalculator digestCalculator;
-    private int ephemeralCountLimit;
 
     ZooKeeperServer zks;
 
@@ -127,7 +126,6 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
         if (this.digestEnabled) {
             this.digestCalculator = new DigestCalculator();
         }
-        this.ephemeralCountLimit = Integer.getInteger("zookeeper.ephemeral.count.limit", 7500);
     }
 
     /**
@@ -721,8 +719,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
             ephemeralOwner = request.sessionId;
 
             int count = zks.getZKDatabase().getDataTree().getEphemerals(ephemeralOwner).size();
-
-            if (ephemeralCountLimit != -1 && count >= ephemeralCountLimit) {
+            if (ZooKeeperServer.getEphemeralCountLimit() != -1 && count >= ZooKeeperServer.getEphemeralCountLimit()) {
                 ServerMetrics.getMetrics().EPHEMERAL_NODE_MAX_COUNT_VIOLATION.inc();
                 throw new KeeperException.EphemeralCountExceededException();
             }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -719,8 +719,8 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
         } else if (createMode.isEphemeral()) {
             ephemeralOwner = request.sessionId;
             int currentByteSize = zks.getZKDatabase().getDataTree().getTotalEphemeralsByteSize(ephemeralOwner);
-            if (ZooKeeperServer.getEphemeralCountLimit() != -1 && currentByteSize + path.getBytes(StandardCharsets.UTF_8).length
-                    > ZooKeeperServer.getEphemeralCountLimit()) {
+            if (ZooKeeperServer.getEphemeralNodesTotalByteLimit() != -1 && currentByteSize + BinaryOutputArchive.getSerializedStringByteSize(path)
+                    > ZooKeeperServer.getEphemeralNodesTotalByteLimit()) {
                 ServerMetrics.getMetrics().EPHEMERAL_NODE_LIMIT_VIOLATION.inc();
                 throw new KeeperException.TotalEphemeralLimitExceeded();
             }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -718,8 +719,15 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
         } else if (createMode.isEphemeral()) {
             ephemeralOwner = request.sessionId;
 
-            int count = zks.getZKDatabase().getDataTree().getEphemerals(ephemeralOwner).size();
-            if (ZooKeeperServer.getEphemeralCountLimit() != -1 && count >= ZooKeeperServer.getEphemeralCountLimit()) {
+            // int count = zks.getZKDatabase().getDataTree().getEphemerals(ephemeralOwner).size();
+            // if (ZooKeeperServer.getEphemeralCountLimit() != -1 && count >= ZooKeeperServer.getEphemeralCountLimit()) {
+            //     ServerMetrics.getMetrics().EPHEMERAL_NODE_MAX_COUNT_VIOLATION.inc();
+            //     throw new KeeperException.EphemeralCountExceededException();
+            // }
+
+            int count = zks.getZKDatabase().getDataTree().getTotalEphemeralsByteSize(ephemeralOwner);
+            if (ZooKeeperServer.getEphemeralCountLimit() != -1 && count + path.getBytes(StandardCharsets.UTF_8).length
+                    > ZooKeeperServer.getEphemeralCountLimit()) {
                 ServerMetrics.getMetrics().EPHEMERAL_NODE_MAX_COUNT_VIOLATION.inc();
                 throw new KeeperException.EphemeralCountExceededException();
             }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -722,6 +722,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
             if (ZooKeeperServer.getEphemeralNodesTotalByteLimit() != -1 && currentByteSize + BinaryOutputArchive.getSerializedStringByteSize(path)
                     > ZooKeeperServer.getEphemeralNodesTotalByteLimit()) {
                 ServerMetrics.getMetrics().EPHEMERAL_NODE_LIMIT_VIOLATION.inc();
+                System.out.println("-------- EPHEMERAL NODE VIOLATION METRIC INCREMENTED -------");
                 throw new KeeperException.TotalEphemeralLimitExceeded();
             }
         }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -719,7 +719,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
             ephemeralOwner = request.sessionId;
 
             int count = zks.getZKDatabase().getDataTree().getEphemerals(ephemeralOwner).size();
-            int limit = Integer.getInteger("zookeeper.ephemeral.count.limit", 10000);
+            int limit = Integer.getInteger("zookeeper.ephemeral.count.limit", 7500);
             if (limit != -1 && count >= limit) {
                 ServerMetrics.getMetrics().EPHEMERAL_NODE_MAX_COUNT_VIOLATION.inc();
                 throw new KeeperException.EphemeralCountExceededException();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -108,6 +108,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
     private final RequestProcessor nextProcessor;
     private final boolean digestEnabled;
     private DigestCalculator digestCalculator;
+    private int ephemeralCountLimit;
 
     ZooKeeperServer zks;
 
@@ -126,6 +127,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
         if (this.digestEnabled) {
             this.digestCalculator = new DigestCalculator();
         }
+        this.ephemeralCountLimit = Integer.getInteger("zookeeper.ephemeral.count.limit", 7500);
     }
 
     /**
@@ -719,8 +721,8 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
             ephemeralOwner = request.sessionId;
 
             int count = zks.getZKDatabase().getDataTree().getEphemerals(ephemeralOwner).size();
-            int limit = Integer.getInteger("zookeeper.ephemeral.count.limit", 7500);
-            if (limit != -1 && count >= limit) {
+
+            if (ephemeralCountLimit != -1 && count >= ephemeralCountLimit) {
                 ServerMetrics.getMetrics().EPHEMERAL_NODE_MAX_COUNT_VIOLATION.inc();
                 throw new KeeperException.EphemeralCountExceededException();
             }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerMetrics.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerMetrics.java
@@ -156,7 +156,7 @@ public final class ServerMetrics {
         COMMITS_QUEUED = metricsContext.getCounter("request_commit_queued");
         READS_ISSUED_IN_COMMIT_PROC = metricsContext.getSummary("read_commit_proc_issued", DetailLevel.BASIC);
         WRITES_ISSUED_IN_COMMIT_PROC = metricsContext.getSummary("write_commit_proc_issued", DetailLevel.BASIC);
-        EPHEMERAL_NODE_MAX_COUNT_VIOLATION = metricsContext.getCounter("ephemeral_node_max_count_violation");
+        EPHEMERAL_NODE_LIMIT_VIOLATION = metricsContext.getCounter("ephemeral_node_limit_violation");
 
         /**
          * Time spent by a read request in the commit processor.
@@ -387,7 +387,7 @@ public final class ServerMetrics {
     public final Counter COMMITS_QUEUED;
     public final Summary READS_ISSUED_IN_COMMIT_PROC;
     public final Summary WRITES_ISSUED_IN_COMMIT_PROC;
-    public final Counter EPHEMERAL_NODE_MAX_COUNT_VIOLATION;
+    public final Counter EPHEMERAL_NODE_LIMIT_VIOLATION;
 
     /**
      * Time spent by a read request in the commit processor.

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerMetrics.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ServerMetrics.java
@@ -156,6 +156,7 @@ public final class ServerMetrics {
         COMMITS_QUEUED = metricsContext.getCounter("request_commit_queued");
         READS_ISSUED_IN_COMMIT_PROC = metricsContext.getSummary("read_commit_proc_issued", DetailLevel.BASIC);
         WRITES_ISSUED_IN_COMMIT_PROC = metricsContext.getSummary("write_commit_proc_issued", DetailLevel.BASIC);
+        EPHEMERAL_NODE_MAX_COUNT_VIOLATION = metricsContext.getCounter("ephemeral_node_max_count_violation");
 
         /**
          * Time spent by a read request in the commit processor.
@@ -386,6 +387,7 @@ public final class ServerMetrics {
     public final Counter COMMITS_QUEUED;
     public final Summary READS_ISSUED_IN_COMMIT_PROC;
     public final Summary WRITES_ISSUED_IN_COMMIT_PROC;
+    public final Counter EPHEMERAL_NODE_MAX_COUNT_VIOLATION;
 
     /**
      * Time spent by a read request in the commit processor.

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -99,6 +99,9 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
 
     public static final String ENABLE_EAGER_ACL_CHECK = "zookeeper.enableEagerACLCheck";
     public static final String SKIP_ACL = "zookeeper.skipACL";
+    public static final String EPHEMERAL_COUNT_LIMIT_KEY = "zookeeper.ephemeral.count.limit";
+    public static final int DEFAULT_EPHEMERAL_COUNT_LIMIT = 7500;
+    private static int ephemeralCountLimit;
 
     // When enabled, will check ACL constraints appertained to the requests first,
     // before sending the requests to the quorum.
@@ -139,6 +142,9 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
         closeSessionTxnEnabled = Boolean.parseBoolean(
                 System.getProperty(CLOSE_SESSION_TXN_ENABLED, "true"));
         LOG.info("{} = {}", CLOSE_SESSION_TXN_ENABLED, closeSessionTxnEnabled);
+
+        ephemeralCountLimit = Integer.getInteger(EPHEMERAL_COUNT_LIMIT_KEY, DEFAULT_EPHEMERAL_COUNT_LIMIT);
+        LOG.info("{} = {}",EPHEMERAL_COUNT_LIMIT_KEY, ephemeralCountLimit);
     }
 
     // @VisibleForTesting
@@ -161,6 +167,8 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
         LOG.info("Update {} to {}", CLOSE_SESSION_TXN_ENABLED,
                 ZooKeeperServer.closeSessionTxnEnabled);
     }
+
+    public static int getEphemeralCountLimit() {return ephemeralCountLimit;}
 
     protected ZooKeeperServerBean jmxServerBean;
     protected DataTreeBean jmxDataTreeBean;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -99,9 +99,10 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
 
     public static final String ENABLE_EAGER_ACL_CHECK = "zookeeper.enableEagerACLCheck";
     public static final String SKIP_ACL = "zookeeper.skipACL";
-    public static final String EPHEMERAL_COUNT_LIMIT_KEY = "zookeeper.ephemeral.count.limit";
-    public static final int DEFAULT_EPHEMERAL_COUNT_LIMIT = 7500;
+    public static final String EPHEMERAL_NODES_TOTAL_BYTE_LIMIT_KEY = "zookeeper.ephemeralNodes.total.byte.limit";
+    public static final int DEFAULT_EPHEMERAL_NODES_TOTAL_BYTE_LIMIT = -1;
     private static int ephemeralCountLimit;
+    private static int ephemeralNodesTotalByteLimit;
 
     // When enabled, will check ACL constraints appertained to the requests first,
     // before sending the requests to the quorum.
@@ -143,8 +144,8 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
                 System.getProperty(CLOSE_SESSION_TXN_ENABLED, "true"));
         LOG.info("{} = {}", CLOSE_SESSION_TXN_ENABLED, closeSessionTxnEnabled);
 
-        ephemeralCountLimit = Integer.getInteger(EPHEMERAL_COUNT_LIMIT_KEY, DEFAULT_EPHEMERAL_COUNT_LIMIT);
-        LOG.info("{} = {}",EPHEMERAL_COUNT_LIMIT_KEY, ephemeralCountLimit);
+        ephemeralNodesTotalByteLimit = Integer.getInteger(EPHEMERAL_NODES_TOTAL_BYTE_LIMIT_KEY, DEFAULT_EPHEMERAL_NODES_TOTAL_BYTE_LIMIT);
+        LOG.info("{} = {}",EPHEMERAL_NODES_TOTAL_BYTE_LIMIT_KEY, ephemeralNodesTotalByteLimit);
     }
 
     // @VisibleForTesting
@@ -168,7 +169,7 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
                 ZooKeeperServer.closeSessionTxnEnabled);
     }
 
-    public static int getEphemeralCountLimit() {return ephemeralCountLimit;}
+    public static int getEphemeralNodesTotalByteLimit() {return ephemeralNodesTotalByteLimit;}
 
     protected ZooKeeperServerBean jmxServerBean;
     protected DataTreeBean jmxDataTreeBean;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeThrottlingMultithreadTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeThrottlingMultithreadTest.java
@@ -1,0 +1,125 @@
+package org.apache.zookeeper.server.quorum;
+
+import org.apache.jute.BinaryOutputArchive;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+public class EphemeralNodeThrottlingMultithreadTest extends QuorumPeerTestBase {
+
+    public static final String EPHEMERAL_BYTE_LIMIT_KEY = "zookeeper.ephemeralNodes.total.byte.limit";
+    static final String TEST_PATH = "/ephemeral-throttling-multithread-test";
+    static final int DEFAULT_EPHEMERALNODES_TOTAL_BYTE_LIMIT = (int) (Math.pow(2d, 20d) * .5);
+    static final int NUM_SERVERS = 5;
+
+    @BeforeClass
+    public static void setUpClass() {
+        System.setProperty(EPHEMERAL_BYTE_LIMIT_KEY, Integer.toString(DEFAULT_EPHEMERALNODES_TOTAL_BYTE_LIMIT));
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        System.clearProperty(EPHEMERAL_BYTE_LIMIT_KEY);
+    }
+
+    // Tests multithreaded creates and deletes against the leader and a follower server
+    @Test
+    public void multithreadedRequestsTest() throws Exception {
+        // 50% of 1mb jute max buffer
+        int totalEphemeralNodesByteLimit = (int) (Math.pow(2d, 20d) * .5);
+        System.setProperty("zookeeper.ephemeralNodes.total.byte.limit", Integer.toString(totalEphemeralNodesByteLimit));
+
+        servers = LaunchServers(NUM_SERVERS);
+        ZooKeeper leaderServer = servers.zk[servers.findLeader()];
+        ZooKeeper followerServer = servers.zk[servers.findAnyFollower()];
+
+        runMultithreadedRequests(leaderServer);
+        runMultithreadedRequests(followerServer);
+
+        // TODO: What % delta do we want to allow here?
+        // Expensive calculation of total byte size for session ephemerals
+        long time = System.currentTimeMillis();
+        int leaderSessionEphemeralsByteSum = 0;
+        for (String nodePath : leaderServer.getEphemerals()) {
+            leaderSessionEphemeralsByteSum += BinaryOutputArchive.getSerializedStringByteSize(nodePath);
+        }
+        assertEquals(totalEphemeralNodesByteLimit, leaderSessionEphemeralsByteSum, totalEphemeralNodesByteLimit/20d);
+
+        int followerSessionEphemeralsByteSum = 0;
+        for (String nodePath : leaderServer.getEphemerals()) {
+            followerSessionEphemeralsByteSum += BinaryOutputArchive.getSerializedStringByteSize(nodePath);
+        }
+        assertEquals(totalEphemeralNodesByteLimit, followerSessionEphemeralsByteSum, totalEphemeralNodesByteLimit/20d);
+
+        System.out.println("--- total time to calculate sizes was : " + (System.currentTimeMillis() - time) + " ms -----");
+        servers.shutDownAllServers();
+        // waitForAll(servers, ZooKeeper.States.CONNECTING);
+        // ServerMetrics.DEFAULT_METRICS_FOR_TESTS.resetAll();
+    }
+
+    private void runMultithreadedRequests(ZooKeeper server) {
+        int threadPoolCount = 8;
+        int deleteRequestThreads = 2;
+        int createRequestThreads = threadPoolCount - deleteRequestThreads;
+        // Spin up threads to repeatedly send CREATE requests to server
+        ExecutorService executor = Executors.newFixedThreadPool(threadPoolCount);
+        for (int i = 0; i < createRequestThreads; i++) {
+            final int threadID = i;
+            executor.submit(() ->{
+                long startTime = System.currentTimeMillis();
+                while (System.currentTimeMillis() - startTime < 10000) {
+                    try {
+                        server.create(TEST_PATH +"_"+threadID+"_", new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
+                    } catch (KeeperException.TotalEphemeralLimitExceeded expectedException) {
+                        //  Ignore Ephemeral Count exceeded exception, as this is expected to occur
+                    } catch (Exception e) {
+                        LOG.warn("Thread encountered an exception but ignored it:\n" + e.getMessage());
+                    }
+                }
+            });
+        }
+
+        // Spin up threads to repeatedly send DELETE requests to server
+        // After a 1-second sleep, this should run concurrently with the create threads, but then end before create threads
+        // so that we still have time to hit the limit and can then assert that limit was upheld correctly
+        for (int i = 0; i < deleteRequestThreads; i++) {
+            executor.submit(() -> {
+                long startTime = System.currentTimeMillis();
+                try {
+                    // Brief sleep to reduce chance that ephemeral nodes not yet created
+                    Thread.sleep(1000);
+                    while (System.currentTimeMillis() - startTime < 6000) {
+                        for (String ephemeralNode : server.getEphemerals()) {
+                            server.delete(ephemeralNode, -1);
+                        }
+                    }
+                } catch (KeeperException.TotalEphemeralLimitExceeded expectedException) {
+                    //  Ignore Ephemeral Count exceeded exception, as this is expected to occur
+                } catch (Exception e) {
+                    LOG.warn("Thread encountered an exception but ignored it:\n" + e.getMessage());
+                }
+            });
+        }
+
+        executor.shutdown();
+        try {
+            if(!executor.awaitTermination(12000, TimeUnit.MILLISECONDS)) {
+                LOG.warn("Threads did not finish in the given time!");
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            LOG.error(e.getMessage());
+            executor.shutdownNow();
+        }
+    }
+}

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeThrottlingMultithreadTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeThrottlingMultithreadTest.java
@@ -46,13 +46,11 @@ public class EphemeralNodeThrottlingMultithreadTest extends QuorumPeerTestBase {
         runMultithreadedRequests(leaderServer);
         runMultithreadedRequests(followerServer);
 
-        // TODO: What % delta do we want to allow here?
-        // Expensive calculation of total byte size for session ephemerals
-        long time = System.currentTimeMillis();
         int leaderSessionEphemeralsByteSum = 0;
         for (String nodePath : leaderServer.getEphemerals()) {
             leaderSessionEphemeralsByteSum += BinaryOutputArchive.getSerializedStringByteSize(nodePath);
         }
+        // TODO: What % delta do we want to allow here?
         assertEquals(totalEphemeralNodesByteLimit, leaderSessionEphemeralsByteSum, totalEphemeralNodesByteLimit/20d);
 
         int followerSessionEphemeralsByteSum = 0;
@@ -61,10 +59,7 @@ public class EphemeralNodeThrottlingMultithreadTest extends QuorumPeerTestBase {
         }
         assertEquals(totalEphemeralNodesByteLimit, followerSessionEphemeralsByteSum, totalEphemeralNodesByteLimit/20d);
 
-        System.out.println("--- total time to calculate sizes was : " + (System.currentTimeMillis() - time) + " ms -----");
         servers.shutDownAllServers();
-        // waitForAll(servers, ZooKeeper.States.CONNECTING);
-        // ServerMetrics.DEFAULT_METRICS_FOR_TESTS.resetAll();
     }
 
     private void runMultithreadedRequests(ZooKeeper server) {
@@ -90,7 +85,7 @@ public class EphemeralNodeThrottlingMultithreadTest extends QuorumPeerTestBase {
         }
 
         // Spin up threads to repeatedly send DELETE requests to server
-        // After a 1-second sleep, this should run concurrently with the create threads, but then end before create threads
+        // After a 1-second sleep, this should run concurrently with the create threads, but then end before create threads end
         // so that we still have time to hit the limit and can then assert that limit was upheld correctly
         for (int i = 0; i < deleteRequestThreads; i++) {
             executor.submit(() -> {
@@ -98,7 +93,7 @@ public class EphemeralNodeThrottlingMultithreadTest extends QuorumPeerTestBase {
                 try {
                     // Brief sleep to reduce chance that ephemeral nodes not yet created
                     Thread.sleep(1000);
-                    while (System.currentTimeMillis() - startTime < 6000) {
+                    while (System.currentTimeMillis() - startTime < 4000) {
                         for (String ephemeralNode : server.getEphemerals()) {
                             server.delete(ephemeralNode, -1);
                         }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeThrottlingTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeThrottlingTest.java
@@ -24,14 +24,9 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.metrics.MetricsUtils;
-import org.apache.zookeeper.server.ServerMetrics;
 import org.junit.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.*;
 
@@ -83,10 +78,6 @@ public class EphemeralNodeThrottlingTest extends QuorumPeerTestBase {
         long actual = (long) MetricsUtils.currentServerMetrics().get(EPHEMERAL_BYTE_LIMIT_VIOLATION_KEY);
         System.out.println("byte limit property is: " + Integer.getInteger(EPHEMERAL_BYTE_LIMIT_KEY));
         assertEquals(1, actual);
-
-
-        // waitForAll(servers, ZooKeeper.States.CONNECTING);
-        // ServerMetrics.DEFAULT_METRICS_FOR_TESTS.resetAll();
     }
 
     @Test
@@ -103,9 +94,6 @@ public class EphemeralNodeThrottlingTest extends QuorumPeerTestBase {
         // Assert both servers emitted failure metric
         long actual = (long) MetricsUtils.currentServerMetrics().get(EPHEMERAL_BYTE_LIMIT_VIOLATION_KEY);
         assertEquals(2, actual);
-
-        // waitForAll(servers, ZooKeeper.States.CONNECTING);
-        // ServerMetrics.DEFAULT_METRICS_FOR_TESTS.resetAll();
     }
 
     @Test
@@ -122,9 +110,6 @@ public class EphemeralNodeThrottlingTest extends QuorumPeerTestBase {
         // Assert both servers emitted failure metric
         long actual = (long) MetricsUtils.currentServerMetrics().get(EPHEMERAL_BYTE_LIMIT_VIOLATION_KEY);
         assertEquals(2, actual);
-
-        // waitForAll(servers, ZooKeeper.States.CONNECTING);
-        // ServerMetrics.DEFAULT_METRICS_FOR_TESTS.resetAll();
     }
 
     public boolean checkLimitEnforcedForServer(ZooKeeper server, String subPath, CreateMode mode) throws Exception {
@@ -187,8 +172,5 @@ public class EphemeralNodeThrottlingTest extends QuorumPeerTestBase {
 
         long actual = (long) MetricsUtils.currentServerMetrics().get(EPHEMERAL_BYTE_LIMIT_VIOLATION_KEY);
         assertEquals(expectedLimitExceededAttempts, actual);
-
-        // waitForAll(servers, ZooKeeper.States.CONNECTING);
-        // ServerMetrics.DEFAULT_METRICS_FOR_TESTS.resetAll();
     }
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeThrottlingTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeThrottlingTest.java
@@ -58,7 +58,7 @@ public class EphemeralNodeThrottlingTest extends QuorumPeerTestBase {
                 break;
             }
         }
-        long actual = (long) MetricsUtils.currentServerMetrics().get("ephemeral_node_max_count_violation");
+        long actual = (long) MetricsUtils.currentServerMetrics().get("ephemeral_node_limit_violation");
         assertEquals(1, actual);
 
         servers.shutDownAllServers();
@@ -76,7 +76,7 @@ public class EphemeralNodeThrottlingTest extends QuorumPeerTestBase {
         String followerSubPath = PATH + "-follower-";
         assertTrue(checkLimitEnforcedForServer(followerServer, followerSubPath));
 
-        long actual = (long) MetricsUtils.currentServerMetrics().get("ephemeral_node_max_count_violation");
+        long actual = (long) MetricsUtils.currentServerMetrics().get("ephemeral_node_limit_violation");
         assertEquals(2, actual);
 
         servers.shutDownAllServers();
@@ -100,17 +100,17 @@ public class EphemeralNodeThrottlingTest extends QuorumPeerTestBase {
 
         try {
             leaderServer.create(PATH + "-leader-", new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
-        } catch (KeeperException.EphemeralCountExceededException e) {
+        } catch (KeeperException.TotalEphemeralLimitExceeded e) {
             leaderThrewError = true;
         }
         try {
             followerServer.create(PATH + "-follower-", new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
-        } catch (KeeperException.EphemeralCountExceededException e) {
+        } catch (KeeperException.TotalEphemeralLimitExceeded e) {
             followerThrewError = true;
         }
         assertTrue(leaderThrewError && followerThrewError);
 
-        long actual = (long) MetricsUtils.currentServerMetrics().get("ephemeral_node_max_count_violation");
+        long actual = (long) MetricsUtils.currentServerMetrics().get("ephemeral_node_limit_violation");
         assertEquals(2, actual);
 
         servers.shutDownAllServers();
@@ -128,7 +128,7 @@ public class EphemeralNodeThrottlingTest extends QuorumPeerTestBase {
 
         try {
             server.create(subPath + "-follower-" + i, new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
-        } catch (KeeperException.EphemeralCountExceededException e) {
+        } catch (KeeperException.TotalEphemeralLimitExceeded e) {
             return true;
         }
         return false;
@@ -142,12 +142,12 @@ public class EphemeralNodeThrottlingTest extends QuorumPeerTestBase {
         for (int i = 0; i < DEFAULT_MAX_EPHEMERAL_NODES + ephemeralExcess; i++) {
             try {
                 servers.zk[0].create(PATH + "-" + i, new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
-            } catch (KeeperException.EphemeralCountExceededException e) {
-                LOG.info("Encountered EphemeralCountExceededException as expected, continuing...");
+            } catch (KeeperException.TotalEphemeralLimitExceeded e) {
+                LOG.info("Encountered TotalEphemeralLimitExceeded as expected, continuing...");
             }
         }
 
-        long actual = (long) MetricsUtils.currentServerMetrics().get("ephemeral_node_max_count_violation");
+        long actual = (long) MetricsUtils.currentServerMetrics().get("ephemeral_node_limit_violation");
         assertEquals(ephemeralExcess, actual);
 
         servers.shutDownAllServers();
@@ -186,7 +186,7 @@ public class EphemeralNodeThrottlingTest extends QuorumPeerTestBase {
                 while (System.currentTimeMillis() - startTime < 10000) {
                     try {
                         server.create(PATH+"_"+threadID+"_", new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
-                    } catch (KeeperException.EphemeralCountExceededException expectedException) {
+                    } catch (KeeperException.TotalEphemeralLimitExceeded expectedException) {
                         //  Ignore Ephemeral Count exceeded exception, as this is expected to occur
                     } catch (Exception e) {
                         LOG.error("Thread encountered an exception but ignored it:\n" + e.getMessage());
@@ -209,7 +209,7 @@ public class EphemeralNodeThrottlingTest extends QuorumPeerTestBase {
                             System.out.println("deleted node: " + ephemeralNode);
                         }
                     }
-                } catch (KeeperException.EphemeralCountExceededException expectedException) {
+                } catch (KeeperException.TotalEphemeralLimitExceeded expectedException) {
                     //  Ignore Ephemeral Count exceeded exception, as this is expected to occur
                 } catch (Exception e) {
                     LOG.error("Thread encountered an exception but ignored it:\n" + e.getMessage());

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeThrottlingTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeThrottlingTest.java
@@ -18,100 +18,98 @@
 
 package org.apache.zookeeper.server.quorum;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.metrics.MetricsUtils;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
 
 public class EphemeralNodeThrottlingTest extends QuorumPeerTestBase {
 
     protected static final Logger LOG = LoggerFactory.getLogger(EphemeralNodeThrottlingTest.class);
 
-    static final int MAX_EPHEMERAL_NODES = 20;
+    static final int DEFAULT_MAX_EPHEMERAL_NODES = 20;
     static final int NUM_SERVERS = 5;
     static final String PATH = "/ephemeral-throttling-test";
 
-    @Test()
-    public void limitingEphemeralsTest() throws Exception {
-        System.setProperty("zookeeper.ephemeral.count.limit", Integer.toString(MAX_EPHEMERAL_NODES));
-        servers = LaunchServers(NUM_SERVERS);
-        boolean threwError = false;
-        // Create nodes up to the limit
-        for (int i = 0; i < MAX_EPHEMERAL_NODES; i++) {
-            servers.zk[0].create(PATH + "-" + i, new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
-        }
-
-        try {
-            servers.zk[0].create(PATH + "-" + MAX_EPHEMERAL_NODES, new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
-        } catch (KeeperException.EphemeralCountExceededException e) {
-            threwError = true;
-        }
-        assertTrue(threwError);
-    }
-
-    @Test()
-    public void limitingSequentialEphemeralsTest() throws Exception {
-        System.setProperty("zookeeper.ephemeral.count.limit", Integer.toString(MAX_EPHEMERAL_NODES));
-        servers = LaunchServers(NUM_SERVERS);
-        boolean threwError = false;
-        // Create nodes up to the limit
-        for (int i = 0; i < MAX_EPHEMERAL_NODES; i++) {
-            servers.zk[0].create(PATH, new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
-        }
-
-        try {
-            servers.zk[0].create(PATH, new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
-        } catch (KeeperException.EphemeralCountExceededException e) {
-            threwError = true;
-        }
-        assertTrue(threwError);
-    }
-
-    /* Verify that the ephemeral limit enforced correctly when there are delete operations. */
     @Test
-    public void limitingEphemeralsWithDeletesTest() throws Exception {
-        System.setProperty("zookeeper.ephemeral.count.limit", Integer.toString(MAX_EPHEMERAL_NODES));
+    public void limitingEphemeralsTest() throws Exception {
+        System.setProperty("zookeeper.ephemeral.count.limit", Integer.toString(DEFAULT_MAX_EPHEMERAL_NODES));
         servers = LaunchServers(NUM_SERVERS);
-        for (int i = 0; i < MAX_EPHEMERAL_NODES; i++) {
-            servers.zk[0].create(PATH + "-" + i, new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
-        }
-        boolean threwError = false;
-
-        try {
-            servers.zk[0].create(PATH + "-foo", new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
-        } catch (KeeperException.EphemeralCountExceededException e) {
-            threwError = true;
-        }
-        assertTrue(threwError);
-        threwError = false;
-
-        for (int i = 0; i < MAX_EPHEMERAL_NODES / 2; i++) {
-            servers.zk[0].delete(PATH + "-" + i, -1);
-        }
-        for (int i = 0; i < MAX_EPHEMERAL_NODES / 2; i++) {
-            servers.zk[0].create(PATH, new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
+        boolean leaderThrewError = false;
+        boolean followerThrewError = false;
+        ZooKeeper leaderServer = servers.zk[servers.findLeader()];
+        ZooKeeper followerServer = servers.zk[servers.findAnyFollower()];
+        // Create nodes up to the limit
+        for (int i = 0; i < DEFAULT_MAX_EPHEMERAL_NODES; i++) {
+            leaderServer.create(PATH + "-leader-" + i, new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+            followerServer.create(PATH + "-follower-" + i, new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
         }
 
         try {
-            servers.zk[0].create(PATH, new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
+            leaderServer.create(PATH + "-follower-" + DEFAULT_MAX_EPHEMERAL_NODES, new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
         } catch (KeeperException.EphemeralCountExceededException e) {
-            threwError = true;
+            leaderThrewError = true;
         }
-        assertTrue(threwError);
+        try {
+            followerServer.create(PATH + "-follower-" + DEFAULT_MAX_EPHEMERAL_NODES, new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+        } catch (KeeperException.EphemeralCountExceededException e) {
+            followerThrewError = true;
+        }
+        assertTrue(leaderThrewError && followerThrewError);
+
+        long actual = (long) MetricsUtils.currentServerMetrics().get("ephemeral_node_max_count_violation");
+        assertEquals(2, actual);
+
+        servers.shutDownAllServers();
     }
 
-    /* Check that our emitted metric around the number of request rejections from too many ephemerals is accurate. */
+    @Test
+    public void limitingSequentialEphemeralsTest() throws Exception {
+        System.setProperty("zookeeper.ephemeral.count.limit", Integer.toString(DEFAULT_MAX_EPHEMERAL_NODES));
+        servers = LaunchServers(NUM_SERVERS);
+        boolean leaderThrewError = false;
+        boolean followerThrewError = false;
+        ZooKeeper leaderServer = servers.zk[servers.findLeader()];
+        ZooKeeper followerServer = servers.zk[servers.findAnyFollower()];
+        // Create nodes up to the limit
+        for (int i = 0; i < DEFAULT_MAX_EPHEMERAL_NODES; i++) {
+            leaderServer.create(PATH + "-leader-", new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
+            followerServer.create(PATH + "-follower-", new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
+        }
+
+        try {
+            leaderServer.create(PATH + "-leader-", new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
+        } catch (KeeperException.EphemeralCountExceededException e) {
+            leaderThrewError = true;
+        }
+        try {
+            followerServer.create(PATH + "-follower-", new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
+        } catch (KeeperException.EphemeralCountExceededException e) {
+            followerThrewError = true;
+        }
+        assertTrue(leaderThrewError && followerThrewError);
+
+        long actual = (long) MetricsUtils.currentServerMetrics().get("ephemeral_node_max_count_violation");
+        assertEquals(2, actual);
+
+        servers.shutDownAllServers();
+    }
+
     @Test
     public void rejectedEphemeralCreatesMetricsTest() throws Exception {
-        int ephemeralExcess = MAX_EPHEMERAL_NODES / 2;
-        System.setProperty("zookeeper.ephemeral.count.limit", Integer.toString(MAX_EPHEMERAL_NODES));
+        int ephemeralExcess = DEFAULT_MAX_EPHEMERAL_NODES / 2;
+        System.setProperty("zookeeper.ephemeral.count.limit", Integer.toString(DEFAULT_MAX_EPHEMERAL_NODES));
         servers = LaunchServers(NUM_SERVERS);
-        for (int i = 0; i < MAX_EPHEMERAL_NODES + ephemeralExcess; i++) {
+        for (int i = 0; i < DEFAULT_MAX_EPHEMERAL_NODES + ephemeralExcess; i++) {
             try {
                 servers.zk[0].create(PATH + "-" + i, new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
             } catch (KeeperException.EphemeralCountExceededException e) {
@@ -121,5 +119,83 @@ public class EphemeralNodeThrottlingTest extends QuorumPeerTestBase {
 
         long actual = (long) MetricsUtils.currentServerMetrics().get("ephemeral_node_max_count_violation");
         assertEquals(ephemeralExcess, actual);
+
+        servers.shutDownAllServers();
+    }
+
+    // Tests multithreaded creates and deletes against the leader and a follower server
+    @Test
+    public void multithreadedRequestsTest() throws Exception {
+        int ephemeralNodeLimit = 7500;
+        System.setProperty("zookeeper.ephemeral.count.limit", Integer.toString(ephemeralNodeLimit));
+
+        servers = LaunchServers(NUM_SERVERS);
+        ZooKeeper leaderServer = servers.zk[servers.findLeader()];
+        ZooKeeper followerServer = servers.zk[servers.findAnyFollower()];
+
+        runMultithreadedRequests(leaderServer);
+        runMultithreadedRequests(followerServer);
+
+        // TODO: What % delta do we want to allow here?
+        assertEquals(ephemeralNodeLimit, leaderServer.getEphemerals().size(), ephemeralNodeLimit/20d);
+        assertEquals(ephemeralNodeLimit, followerServer.getEphemerals().size(), ephemeralNodeLimit/20d);
+
+        servers.shutDownAllServers();
+    }
+
+    private void runMultithreadedRequests(ZooKeeper server) {
+        int threadPoolCount = 8;
+        int deleteRequestThreads = 2;
+        int createRequestThreads = threadPoolCount - deleteRequestThreads;
+        // Spin up threads to repeatedly send CREATE requests to server
+        ExecutorService executor = Executors.newFixedThreadPool(threadPoolCount);
+        for (int i = 0; i < createRequestThreads; i++) {
+            final int threadID = i;
+            executor.submit(() ->{
+                long startTime = System.currentTimeMillis();
+                while (System.currentTimeMillis() - startTime < 10000) {
+                    try {
+                        server.create(PATH+"_"+threadID+"_", new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
+                    } catch (KeeperException.EphemeralCountExceededException expectedException) {
+                        //  Ignore Ephemeral Count exceeded exception, as this is expected to occur
+                    } catch (Exception e) {
+                        LOG.error("Thread encountered an exception but ignored it:\n" + e.getMessage());
+                    }
+                }
+            });
+        }
+
+        // Spin up threads to repeatedly send DELETE requests to server
+        // After a 1-second sleep, this should run concurrently with the create threads
+        for (int i = 0; i < deleteRequestThreads; i++) {
+            executor.submit(() -> {
+                long startTime = System.currentTimeMillis();
+                try {
+                    // Brief sleep to reduce chance that ephemeral nodes not yet created
+                    Thread.sleep(1000);
+                    while (System.currentTimeMillis() - startTime < 6000) {
+                        for (String ephemeralNode : server.getEphemerals()) {
+                            server.delete(ephemeralNode, -1);
+                            System.out.println("deleted node: " + ephemeralNode);
+                        }
+                    }
+                } catch (KeeperException.EphemeralCountExceededException expectedException) {
+                    //  Ignore Ephemeral Count exceeded exception, as this is expected to occur
+                } catch (Exception e) {
+                    LOG.error("Thread encountered an exception but ignored it:\n" + e.getMessage());
+                }
+            });
+        }
+
+        executor.shutdown();
+        try {
+            if(!executor.awaitTermination(12000, TimeUnit.MILLISECONDS)) {
+                LOG.warn("Threads did not finish in the given time!");
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            LOG.error(e.getMessage());
+            executor.shutdownNow();
+        }
     }
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeThrottlingTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeThrottlingTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.zookeeper.server.quorum;
 
 import static org.junit.Assert.assertEquals;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeThrottlingTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeThrottlingTest.java
@@ -36,7 +36,6 @@ public class EphemeralNodeThrottlingTest extends QuorumPeerTestBase {
 
     public static final String EPHEMERAL_BYTE_LIMIT_KEY = "zookeeper.ephemeralNodes.total.byte.limit";
     public static final String EPHEMERAL_BYTE_LIMIT_VIOLATION_KEY = "ephemeral_node_limit_violation";
-    // static final int DEFAULT_MAX_EPHEMERAL_NODES = 20;
     static final int DEFAULT_EPHEMERALNODES_TOTAL_BYTE_LIMIT = 2000;
     static final int NUM_SERVERS = 5;
     static final String TEST_PATH = "/ephemeral-throttling-test";

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeThrottlingTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeThrottlingTest.java
@@ -2,18 +2,10 @@ package org.apache.zookeeper.server.quorum;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import java.io.File;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.ZooDefs;
-import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.metrics.MetricsUtils;
-import org.apache.zookeeper.server.ServerCnxnFactory;
-import org.apache.zookeeper.server.ServerMetrics;
-import org.apache.zookeeper.server.ZooKeeperServer;
-import org.apache.zookeeper.test.ClientBase;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeThrottlingTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/EphemeralNodeThrottlingTest.java
@@ -1,0 +1,158 @@
+package org.apache.zookeeper.server.quorum;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.PortAssignment;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.metrics.MetricsUtils;
+import org.apache.zookeeper.server.DataTree;
+import org.apache.zookeeper.server.Request;
+import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.apache.zookeeper.server.ServerMetrics;
+import org.apache.zookeeper.server.ZooKeeperServer;
+import org.apache.zookeeper.test.ClientBase;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EphemeralNodeThrottlingTest extends QuorumPeerTestBase {
+
+    protected static final Logger LOG = LoggerFactory.getLogger(EphemeralNodeThrottlingTest.class);
+
+    static final int MAX_EPHEMERAL_NODES = 32;
+    static final int NUM_SERVERS = 5;
+    static final String PATH = "/ephemeral-throttling-test";
+
+    @Test(expected = KeeperException.EphemeralCountExceededException.class)
+    public void limitingEphemeralsTest() throws Exception {
+        System.setProperty("zookeeper.ephemeral.count.limit", Integer.toString(MAX_EPHEMERAL_NODES));
+        servers = LaunchServers(NUM_SERVERS);
+        for (int i = 0; i < MAX_EPHEMERAL_NODES + 1; i++) {
+            servers.zk[0].create(PATH + "-" + i, new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+        }
+    }
+
+    @Test(expected = KeeperException.EphemeralCountExceededException.class)
+    public void limitingSequentialEphemeralsTest() throws Exception {
+        System.setProperty("zookeeper.ephemeral.count.limit", Integer.toString(MAX_EPHEMERAL_NODES));
+        servers = LaunchServers(NUM_SERVERS);
+        for (int i = 0; i < MAX_EPHEMERAL_NODES + 1; i++) {
+            servers.zk[0].create(PATH, new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
+        }
+    }
+
+    /**
+     *  Verify that the ephemeral limit enforced correctly when there are delete operations.
+     */
+    @Test
+    public void limitingEphemeralsWithDeletesTest() throws Exception {
+        int numDelete = 8;
+        System.setProperty("zookeeper.ephemeral.count.limit", Integer.toString(MAX_EPHEMERAL_NODES));
+        servers = LaunchServers(NUM_SERVERS);
+        for (int i = 0; i < MAX_EPHEMERAL_NODES / 2; i++) {
+            servers.zk[0].create(PATH + "-" + i, new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+        }
+        for (int i = 0; i < numDelete; i++) {
+            servers.zk[0].delete(PATH + "-" + i, -1);
+        }
+        for (int i = 0; i < (MAX_EPHEMERAL_NODES / 2) + numDelete; i++) {
+            servers.zk[0].create(PATH, new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
+        }
+
+        boolean threw = false;
+        try {
+            servers.zk[0].create(PATH, new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
+        } catch (KeeperException.EphemeralCountExceededException e) {
+            threw = true;
+        }
+        assertTrue(threw);
+    }
+
+    /**
+     *  Check that our emitted metric around the number of request rejections from too many ephemerals is accurate.
+     */
+    @Test
+    public void rejectedEphemeralCreatesMetricsTest() throws Exception {
+        int ephemeralExcess = 8;
+        System.setProperty("zookeeper.ephemeral.count.limit", Integer.toString(MAX_EPHEMERAL_NODES));
+        servers = LaunchServers(NUM_SERVERS);
+        for (int i = 0; i < MAX_EPHEMERAL_NODES + ephemeralExcess; i++) {
+            try {
+                servers.zk[0].create(PATH + "-" + i, new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+            } catch (KeeperException.EphemeralCountExceededException e) {
+                LOG.info("Encountered EphemeralCountExceededException as expected, continuing...");
+            }
+        }
+
+        long actual = (long) MetricsUtils.currentServerMetrics().get("ephemeral_node_max_count_violation");
+        assertEquals(ephemeralExcess, actual);
+    }
+
+    /**
+     *  Test that the ephemeral limit is accurate in the case where an ephemeral node is deleted before it is committed.
+     */
+    CountDownLatch latch = null;
+    @Test
+    public void createThenDeleteBeforeCommitTest() throws Exception {
+        System.setProperty("zookeeper.ephemeral.count.limit", Integer.toString(MAX_EPHEMERAL_NODES));
+
+        String hostPort = "127.0.0.1:" + PortAssignment.unique();
+        File tmpDir = ClientBase.createTmpDir();
+        ClientBase.setupTestEnv();
+        ZooKeeperServer server = new ZooKeeperServerWithLatch(tmpDir, tmpDir, 3000);
+        final int port = Integer.parseInt(hostPort.split(":")[1]);
+        ServerCnxnFactory cnxnFactory = ServerCnxnFactory.createFactory(port, -1);
+        ServerMetrics.getMetrics().resetAll();
+        cnxnFactory.startup(server);
+
+        latch = new CountDownLatch(1);
+
+        ZooKeeper zk = ClientBase.createZKClient(hostPort);
+        zk.create(PATH, new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+        zk.delete(PATH, -1);
+
+        latch.countDown();
+
+        boolean noException = true;
+        try {
+            for (int i = 0; i < MAX_EPHEMERAL_NODES; i++) {
+                zk.create(PATH, new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
+            }
+        } catch (KeeperException.EphemeralCountExceededException e) {
+            noException = false;
+        }
+        assertEquals(noException, true);
+
+        boolean threw = false;
+        try {
+            zk.create(PATH, new byte[512], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
+        } catch (KeeperException.EphemeralCountExceededException e) {
+            threw = true;
+        }
+        assertEquals(threw, true);
+    }
+
+    class ZooKeeperServerWithLatch extends ZooKeeperServer {
+        public ZooKeeperServerWithLatch(File snapDir, File logDir, int tickTime) throws IOException {
+            super(snapDir, logDir, tickTime);
+        }
+
+        @Override
+        public DataTree.ProcessTxnResult processTxn(Request request) {
+            if (latch != null) {
+                try {
+                    latch.await(10, TimeUnit.SECONDS);
+                } catch (Exception e) {}
+            }
+            DataTree.ProcessTxnResult res = super.processTxn(request);
+            return res;
+        }
+    }
+}


### PR DESCRIPTION
 ### Description
In Zookeeper, an ephemeral node is only kept alive while the session it was created in is still active. When a session is closed by the client, all ephemeral nodes created by that session are deleted. Currently, there is no limit on how many ephemeral nodes can be created in a single session and if a large enough number of ephemeral nodes are created, then the work needed to delete these nodes and communicate the deletion to all followers can overwhelm the zookeeper server. This behavior has caused two previous Zookeeper site-up issues at LinkedIn. 

My proposed solution to this problem is to throttle based on the cumulative bytes it takes to store all of the paths for the znodes created within that session. When a request comes into the PrepRequestProcessor, we check the DataTree and deny any create requests if we have already reached/exceeded the byte limit for that session. 

With this approach, it is important to note that when a request is accepted, it would not immediately affect the ephemeral node count as it would need to reach the FinalRequestProcessor before the request affects the DataTree. This lag between the accepting ephemeral node requests and updating our ephemeral node count can lead to us not strictly upholding the limit. However, I believe this inaccuracy is acceptable as this should only result in minor variances of the total # of nodes allowed to be created and would still achieve the primary goal of preventing a server being overwhelmed when a session closes. If we wanted to be extra cautious, we could also fail requests at the end of the request processing pipeline when the new node is actually added to the DataTree.  

4 years ago a PR (https://github.com/apache/zookeeper/pull/1144) for a similar feature was opened against the opensource Zookeeper, but was never merged. The approach in that PR is slightly different as it attempts to keep a counter in the PrepRequestProcessor to track the # of ephemeral nodes currently in the DataTree. This solution does not have the same "lag time" problem as my proposed solution, but it does not account for the request failing at any step other than the PrepRequestProcessor. This could lead to the counter desyncing from the actual DataTree and being in an error state until reboot. Attempting to cover all the areas where a request could fail would also add quite a bit of constant work to the server for a feature that is intended to prevent an infrequent occurrence. 

(Please let me know if this is not the correct repo/branch to target with these changes)


### Tests
 The following tests are written for this issue:
org/apache/zookeeper/server/quorum/EphemeralNodeThrottlingTest.java

The following is the result of the "mvn test" command on the appropriate module:
```
$ mvn test -o -Dtest=EphemeralNodeThrottlingTest -pl zookeeper-server/

[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.zookeeper.server.quorum.EphemeralNodeThrottlingTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 14.93 s - in org.apache.zookeeper.server.quorum.EphemeralNodeThrottlingTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  21.543 s
[INFO] Finished at: 2023-09-25T13:57:39-07:00
[INFO] ------------------------------------------------------------------------

```