### PR TITLE
add ephemeral node creation throttled log message

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -719,8 +719,11 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
         } else if (createMode.isEphemeral()) {
             ephemeralOwner = request.sessionId;
             int currentByteSize = zks.getZKDatabase().getDataTree().getTotalEphemeralsByteSize(ephemeralOwner);
-            if (ZooKeeperServer.getEphemeralNodesTotalByteLimit() != -1 && currentByteSize + BinaryOutputArchive.getSerializedStringByteSize(path)
+            int proposedByteSize = currentByteSize + BinaryOutputArchive.getSerializedStringByteSize(path);
+            if (ZooKeeperServer.getEphemeralNodesTotalByteLimit() != -1 && proposedByteSize
                     > ZooKeeperServer.getEphemeralNodesTotalByteLimit()) {
+                LOG.error(String.format("Rejecting ephemeral node creation for session %s, zxid %s, path %s.",
+                        request.sessionId, request.getHdr().getZxid(), path));
                 ServerMetrics.getMetrics().EPHEMERAL_NODE_LIMIT_VIOLATION.inc();
                 throw new KeeperException.TotalEphemeralLimitExceeded();
             }


### PR DESCRIPTION
### Description
Add log message when server throttles ephemeral node creation due to byte limit exceeded. 

### Tests
```
2024-02-06 11:27:02,455 [myid:] - ERROR [ProcessThread(sid:4 cport:-1)::o.a.z.s.PrepRequestProcessor@725] - Rejecting ephemeral node creation for session 288232840712159232, zxid 4294967343, path /ephemeral-throttling-test-leader-0000000041.
```

```
2024-02-06 11:27:12,904 [myid:] - ERROR [ProcessThread(sid:4 cport:-1)::o.a.z.s.PrepRequestProcessor@725] - Rejecting ephemeral node creation for session 2465340325888, zxid 4294967385, path /ephemeral-throttling-test-leader-0000000082.

```

### Changes that Break Backward Compatibility (Optional)
N/A

### Documentation (Optional)
N/A
