### PR TITLE
Fix checkstyle error

### DIFF
--- a/zookeeper-jute/src/main/java/org/apache/jute/BinaryOutputArchive.java
+++ b/zookeeper-jute/src/main/java/org/apache/jute/BinaryOutputArchive.java
@@ -108,7 +108,7 @@ public class BinaryOutputArchive implements OutputArchive {
         }
 
         // Always add 4 bytes to size as we call writeInt(bb.remaining(), "len") when writing to DataOutput
-        int length_descriptor_size = 4;
+        int lengthDescriptorSize = 4;
 
         int size = 0;
         final int len = s.length();
@@ -122,7 +122,7 @@ public class BinaryOutputArchive implements OutputArchive {
                 size = Math.addExact(size, 3);
             }
         }
-        return Math.addExact(size, length_descriptor_size);
+        return Math.addExact(size, lengthDescriptorSize);
     }
 
     public void writeString(String s, String tag) throws IOException {


### PR DESCRIPTION
Fix checkstyle error related to variable naming convention:

```
[INFO] --- checkstyle:3.1.0:check (default-cli) @ zookeeper-jute ---
[INFO] Starting audit...
[ERROR] /Users/abkishor/code/opensource/li-zookeeper/zookeeper-jute/src/main/java/org/apache/jute/BinaryOutputArchive.java:111:13: Name 'length_descriptor_size' must match pattern '^[a-z][a-zA-Z0-9]*$'. [LocalVariableName]
Audit done.
[INFO] There is 1 error reported by Checkstyle 8.19 with checkstyle-strict.xml ruleset.
[ERROR] src/main/java/org/apache/jute/BinaryOutputArchive.java:[111,13] (naming) LocalVariableName: Name 'length_descriptor_size' must match pattern '^[a-z][a-zA-Z0-9]*$'.
```

`length_descriptor_size` was added in https://github.com/linkedin/zookeeper/pull/118