### PR TITLE
Fix CPP Unit Tests

### DIFF
--- a/zookeeper-client/zookeeper-client-c/tests/TestServerRequireClientSASLAuth.cc
+++ b/zookeeper-client/zookeeper-client-c/tests/TestServerRequireClientSASLAuth.cc
@@ -70,9 +70,21 @@ public:
 
     void setUp() {
         zoo_set_log_stream(logfile);
+        zoo_set_debug_level(ZOO_LOG_LEVEL_DEBUG);
+        stopServer();
+    }
+
+    void tearDown() {
+        startServer();
     }
 
     void startServer() {
+        char cmd[1024];
+        sprintf(cmd, "%s start", ZKSERVER_CMD);
+        CPPUNIT_ASSERT(system(cmd) == 0);
+    }
+
+    void startServerRequireSASLAuth() {
         char cmd[1024];
         sprintf(cmd, "%s startRequireSASLAuth", ZKSERVER_CMD);
         CPPUNIT_ASSERT(system(cmd) == 0);
@@ -85,7 +97,7 @@ public:
     }
 
     void testServerRequireClientSASL() {
-        startServer();
+        startServerRequireSASLAuth();
 
         watchctx_t ctx;
         int rc = 0;


### PR DESCRIPTION
`testServerRequireClientSASL` test in `Zookeeper_serverRequireClientSASL` test suite calls `zkServer.sh startRequireSASLAuth` at the beginning and calls `zkServer.sh stop` (`stopServer()`) at the end. Now, after this point no ZK server is running.

Now, the pattern that is followed in the rest of this repo is, tests requiring specialized ZK servers (`startCleanReadOnly`, `startRequireSASLAuth`) stop the regular ZK server first, start the required specialized ZK server, run the specialized tests applicable, stop the specialized ZK server and start regular ZK server once again for subsequent tests to use.

So in this case, the problem is, `Zookeeper_serverRequireClientSASL` test suite does not start a regular ZK server (`zkServer.sh start`) after all tests in the suite are complete, but subsequent tests/test suites expect a running ZK server. Since there is none, such tests fail (time out while connecting to non-existent ZK server). Example of failed run [here](https://github.com/linkedin/zookeeper/actions/runs/8714913328/job/24001744452).

This PR adds a `tearDown()` section in `Zookeeper_serverRequireClientSASL` test suite to start a regular ZK server after the test suite is complete.

This fix is similar to https://github.com/apache/zookeeper/pull/1983 

**Note:**
In local env, `Zookeeper_serverRequireClientSASL` test suite runs at the very end and we don't run into this situation because there's no subsequent tests which require a ZK server to be running. For some reason, in GitHub Actions runner environment, the test suites are re-ordered, causing a few tests to be run after `Zookeeper_serverRequireClientSASL` which expect a running ZK server.