### PR TITLE
Log remote socket address when we have auth fail

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,15 +74,22 @@ jobs:
         MAVEN_OPTS: -Djansi.force=true
     - name: Upload unit test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: surefire-reports-${{ matrix.profile.name }}
         path: ./**/target/surefire-reports/
         if-no-files-found: ignore
     - name: Upload integration test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: failsafe-reports-${{ matrix.profile.name }}
         path: ./**/target/failsafe-reports/
+        if-no-files-found: ignore
+    - name: Upload cppunit test logs
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: cppunit-logs-${{ matrix.profile.name }}
+        path: ./zookeeper-client/zookeeper-client-c/target/c/TEST-*.txt
         if-no-files-found: ignore

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxnFactory.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NettyServerCnxnFactory.java
@@ -455,7 +455,7 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
                     }
                     if (KeeperException.Code.OK != code) {
                         zkServer.serverStats().incrementAuthFailedCount();
-                        LOG.error("Authentication failed for session 0x{}", Long.toHexString(cnxn.getSessionId()));
+                        LOG.error("Authentication failed for session 0x{} from address '{}'", Long.toHexString(cnxn.getSessionId()), cnxn.getRemoteSocketAddress());
                         cnxn.close(ServerCnxn.DisconnectReason.SASL_AUTH_FAILURE);
                         return;
                     }
@@ -466,7 +466,7 @@ public class NettyServerCnxnFactory extends ServerCnxnFactory {
                 addCnxn(cnxn);
             } else {
                 zkServer.serverStats().incrementAuthFailedCount();
-                LOG.error("Unsuccessful handshake with session 0x{}", Long.toHexString(cnxn.getSessionId()));
+                LOG.error("Unsuccessful handshake with session 0x{} from address '{}'", Long.toHexString(cnxn.getSessionId()), cnxn.getRemoteSocketAddress());
                 cnxn.close(ServerCnxn.DisconnectReason.FAILED_HANDSHAKE);
             }
         }


### PR DESCRIPTION
<!-- 
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at
http://www.apache.org/licenses/LICENSE-2.0
Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
--> 
    
### Description
Currently, when there's an auth failure, we only see:
```
2025-02-11 20:50:25,628 [myid:] - ERROR [nioEventLoopGroup-4-13:?@?] - Unsuccessful handshake with session 0x0
```
in logs. This does not provide any actionable information to debug the issue. Session ID is 0x0 when there's an issue at the SSL layer (expired client cert for example), so no useful info there either.

In this PR, we add log the remote socket address in addition to the error message, so the operator can find out who is making the request and work on resolving the issue (check remote certs).


### Tests
None. This is a logging change only.

### Changes that Break Backward Compatibility (Optional)
None. This is a logging change only.

### Documentation (Optional)
None. This is a logging change only.
