### PR TITLE
Optimize paginated getChildren

### DIFF
--- a/zookeeper-jute/src/main/resources/zookeeper.jute
+++ b/zookeeper-jute/src/main/resources/zookeeper.jute
@@ -169,8 +169,8 @@ module org.apache.zookeeper.proto {
     class GetChildrenPaginatedRequest {
         ustring path;
         int maxReturned;
-        long minCzxId;
-        long czxIdOffset;
+        long minCzxid;
+        int czxidOffset;
         boolean watch;
      }
     class CheckVersionRequest {
@@ -245,8 +245,10 @@ module org.apache.zookeeper.proto {
         org.apache.zookeeper.data.Stat stat;
     }
     class GetChildrenPaginatedResponse {
-        vector<org.apache.zookeeper.data.PathWithStat> children;
+        vector<ustring> children;
         org.apache.zookeeper.data.Stat stat;
+        long nextPageCzxid;
+        int nextPageCzxidOffset;
     }
     class GetACLResponse {
         vector<org.apache.zookeeper.data.ACL> acl;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/PaginationNextPage.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/PaginationNextPage.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper;
+
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Represents the info used to fetch the next page of data for pagination.
+ */
+@InterfaceAudience.Public
+public class PaginationNextPage {
+    private long minCzxid;
+    private int minCzxidOffset;
+
+    public long getMinCzxid() {
+        return minCzxid;
+    }
+
+    public void setMinCzxid(long minCzxid) {
+        this.minCzxid = minCzxid;
+    }
+
+    public int getMinCzxidOffset() {
+        return minCzxidOffset;
+    }
+
+    public void setMinCzxidOffset(int minCzxidOffset) {
+        this.minCzxidOffset = minCzxidOffset;
+    }
+
+    @Override
+    public String toString() {
+        return "PaginationNextPage{"
+                + "minCzxid=" + minCzxid
+                + ", minCzxidOffset=" + minCzxidOffset
+                + '}';
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/RemoteIterator.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/RemoteIterator.java
@@ -27,16 +27,18 @@ public interface RemoteIterator<E> {
 
     /**
      * Returns true if the iterator has more elements.
+     *
      * @return true if the iterator has more elements, false otherwise.
      */
     boolean hasNext();
 
     /**
      * Returns the next element in the iteration.
+     *
      * @return the next element in the iteration.
      * @throws InterruptedException if the thread is interrupted
      * @throws KeeperException if an error is encountered server-side
      * @throws NoSuchElementException if the iteration has no more elements
      */
-    E next() throws InterruptedException, KeeperException, NoSuchElementException;
+    E next() throws InterruptedException, KeeperException;
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooDefs.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooDefs.java
@@ -163,6 +163,13 @@ public class ZooDefs {
         int persistentRecursive = 1;  // matches AddWatchMode.PERSISTENT_RECURSIVE
     }
 
+    @InterfaceAudience.Public
+    public interface GetChildrenPaginated {
+        // Represents the current fetched page is the final page, no more children left to fetch.
+        long lastPageMinCzxid = -1L;
+        int lastPageCzxidOffset = -1;
+    }
+
     public static final String[] opNames = {"notification", "create", "delete", "exists", "getData", "setData", "getACL", "setACL", "getChildren", "getChildren2", "getMaxChildren", "setMaxChildren", "ping", "reconfig", "getConfig"};
 
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeper.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeper.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.jute.Record;
-import org.apache.zookeeper.data.PathWithStat;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.zookeeper.AsyncCallback.ACLCallback;
 import org.apache.zookeeper.AsyncCallback.Children2Callback;
@@ -2375,7 +2374,10 @@ public class ZooKeeper implements AutoCloseable {
    * Returns the a subset (a "page") of the children node of the given path.
    *
    * <p>
-   * The returned list contains up to {@code maxReturned} ordered by czxid.
+   * The returned list contains children names up to {@code maxReturned}. The max number of returned children
+   * is limited by {@code jute.maxbuffer}. If the packet length of {@code maxReturned} children exceeds the limit,
+   * there will be less children returned, within the limit range. {@code outputNextPage} can be used in the next
+   * page to fetch the remaining children.
    * </p>
    *
    * <p>
@@ -2389,11 +2391,24 @@ public class ZooKeeper implements AutoCloseable {
    * @param maxReturned
    *            - the maximum number of children returned
    * @param minCzxId
-   *            - only return children whose creation zkid is equal or greater than {@code minCzxId}
-   * @param czxIdOffset
-   *            - how many children with zkid == minCzxId to skip server-side, as they were returned in previous pages
+   *            - only return children whose creation zxid is equal or greater than {@code minCzxId}
+   * @param czxidOffset
+   *            - how many children with zxid == minCzxId to skip server-side, as they were returned in previous pages
+   * @param outputStat
+   *            - output stat of the znode designated by path. It is the stat of the znode when the znode's single
+   *            page of children are returned. The {@code cversion} in stat could be used to validate data consistency
+   *            for multiple pages of children fetched.
+   * @param outputNextPage
+   *            - if not null, {@link PaginationNextPage} info returned from server will be copied to
+   *            {@code outputNextPage}. The info can be used for fetching the next page of remaining children,
+   *            or checking whether the returned page is the last page by comparing
+   *            {@link PaginationNextPage#getMinCzxid()} with
+   *            {@link org.apache.zookeeper.ZooDefs.GetChildrenPaginated#lastPageMinCzxid}
    * @return
-   *            an ordered list of children nodes, up to {@code maxReturned}, ordered by czxid
+   *            a list of children nodes, up to {@code maxReturned}.
+   *            <p>When params are set {@code maxReturned} = {@code Integer.MAX_VALUE}, {@code minCzxid} <= 0:
+   *            the children list is unordered if all the children can be returned in a page;
+   *            <p>Otherwise, the children list is ordered by czxid.
    * @throws KeeperException
    *            if the server signals an error with a non-zero error code.
    * @throws IllegalArgumentException
@@ -2408,10 +2423,15 @@ public class ZooKeeper implements AutoCloseable {
    *
    * @since 3.6.2
    */
-  public List<PathWithStat> getChildren(final String path, Watcher watcher, final int maxReturned, final long minCzxId, final int czxIdOffset)
-      throws KeeperException, InterruptedException {
-    final String clientPath = path;
-    PathUtils.validatePath(clientPath);
+  public List<String> getChildren(final String path,
+      Watcher watcher,
+      int maxReturned,
+      long minCzxId,
+      int czxidOffset,
+      Stat outputStat,
+      PaginationNextPage outputNextPage)    throws KeeperException, InterruptedException {
+
+    PathUtils.validatePath(path);
 
     if (maxReturned <= 0) {
       throw new IllegalArgumentException("Cannot return less than 1 children");
@@ -2420,10 +2440,10 @@ public class ZooKeeper implements AutoCloseable {
     // the watch contains the un-chroot path
     WatchRegistration wcb = null;
     if (watcher != null) {
-      wcb = new ChildWatchRegistration(watcher, clientPath);
+      wcb = new ChildWatchRegistration(watcher, path);
     }
 
-    final String serverPath = prependChroot(clientPath);
+    final String serverPath = prependChroot(path);
 
     RequestHeader h = new RequestHeader();
     h.setType(ZooDefs.OpCode.getChildrenPaginated);
@@ -2431,16 +2451,101 @@ public class ZooKeeper implements AutoCloseable {
     request.setPath(serverPath);
     request.setWatch(watcher != null);
     request.setMaxReturned(maxReturned);
-    request.setMinCzxId(minCzxId);
-    request.setCzxIdOffset(czxIdOffset);
+    request.setMinCzxid(minCzxId);
+    request.setCzxidOffset(czxidOffset);
     GetChildrenPaginatedResponse response = new GetChildrenPaginatedResponse();
     ReplyHeader r = cnxn.submitRequest(h, request, response, wcb);
     if (r.getErr() != 0) {
       throw KeeperException.create(KeeperException.Code.get(r.getErr()),
-          clientPath);
+          path);
     }
+    if (outputStat != null) {
+      DataTree.copyStat(response.getStat(), outputStat);
+    }
+    updateNextPage(outputNextPage, response.getNextPageCzxid(), response.getNextPageCzxidOffset());
     return response.getChildren();
   }
+
+  /**
+   * Returns a list of all the children given the path.
+   * <p>
+   * The difference between this API and {@link #getChildren(String, boolean)} is:
+   * when there are lots of children and the network buffer exceeds {@code jute.maxbuffer},
+   * this API will fetch the children using pagination and be able to return all children;
+   * while {@link #getChildren(String, boolean)} will fail.
+   * <p>
+   * The final list of children returned is NOT strongly consistent with the server's data:
+   * the list might contain some deleted children if some children are deleted before the last page is fetched.
+   * <p>
+   * If the watch is true and the call is successful (no exception is thrown),
+   # a watch will be left on the node with the given path. The watch will be
+   * triggered by a successful operation that deletes the node of the given
+   * path or creates/deletes a child under the node.
+   *
+   * @param path the path of the parent node
+   * @param watch whether or not leave a watch on the given node
+   * @return a unordered list of all children of the given path
+   * @throws KeeperException if the server signals an error with a non-zero error code.
+   * @throws InterruptedException if the server transaction is interrupted.
+   */
+  public List<String> getAllChildrenPaginated(String path, boolean watch)
+      throws KeeperException, InterruptedException {
+    PaginationNextPage nextPage = new PaginationNextPage();
+    Watcher watcher = watch ? getDefaultWatcher(watch) : null;
+    List<String> childrenPaginated = getChildren(path, watcher, Integer.MAX_VALUE, 0L, 0, null, nextPage);
+    if (nextPage.getMinCzxid() == ZooDefs.GetChildrenPaginated.lastPageMinCzxid) {
+      return childrenPaginated;
+    }
+
+    Set<String> childrenSet = getChildrenRemainingPages(path, watcher, nextPage, childrenPaginated);
+
+    return new ArrayList<>(childrenSet);
+  }
+
+  private Set<String> getChildrenRemainingPages(String path,
+      Watcher watcher,
+      PaginationNextPage nextPage,
+      List<String> childrenPage)
+      throws KeeperException, InterruptedException {
+    Set<String> allChildrenSet = new HashSet<>(childrenPage);
+    int retryCount = 0;
+
+    do {
+      long minCzxid = nextPage.getMinCzxid();
+      if (nextPage.getMinCzxidOffset() == 0) {
+        childrenPage = getChildren(path, watcher, Integer.MAX_VALUE, minCzxid,
+            nextPage.getMinCzxidOffset(), null, nextPage);
+      } else {
+        // If a child with the same czxid is returned in the previous page, and then deleted
+        // on the server, the children not in the previous page but offset is less than czxidOffset
+        // would be missed in the next page. Use the last child in the previous page to determine whether or not
+        // the deletion case happens. If it happens, retry fetching the page starting from offset 0.
+        String lastChild = childrenPage.isEmpty() ? "" : childrenPage.get(childrenPage.size() - 1);
+        childrenPage = getChildren(path, watcher, Integer.MAX_VALUE, minCzxid,
+            nextPage.getMinCzxidOffset() - 1, null, nextPage);
+        if (!lastChild.equals(childrenPage.get(0))) {
+          if (retryCount++ >= 5) {
+            LOG.warn("Failed to fetch children pages because of znode deletion and retries exceeding 5");
+            throw KeeperException.create(KeeperException.Code.OPERATIONTIMEOUT);
+          }
+          LOG.info("Due to znode deletion, retry fetching children from offset 0 for minCzxid={}, retries={}",
+              minCzxid, retryCount);
+          childrenPage = getChildren(path, watcher, Integer.MAX_VALUE, minCzxid, 0, null, nextPage);
+        }
+      }
+      allChildrenSet.addAll(childrenPage);
+    } while (nextPage.getMinCzxid() != ZooDefs.GetChildrenPaginated.lastPageMinCzxid);
+
+    return allChildrenSet;
+  }
+
+  private void updateNextPage(PaginationNextPage nextPage, long minCzxId, int czxIdOffset) {
+    if (nextPage != null) {
+      nextPage.setMinCzxid(minCzxId);
+      nextPage.setMinCzxidOffset(czxIdOffset);
+    }
+  }
+
 
   /**
    * Returns the a RemoteIterator over the children nodes of the given path.
@@ -2473,7 +2578,7 @@ public class ZooKeeper implements AutoCloseable {
    *
    * @since 3.6.2
    */
-  public RemoteIterator<PathWithStat> getChildrenIterator(String path, Watcher watcher, int batchSize, long minCzxId)
+  public RemoteIterator<String> getChildrenIterator(String path, Watcher watcher, int batchSize, long minCzxId)
       throws KeeperException, InterruptedException {
     return new ChildrenBatchIterator(this, path, watcher, batchSize, minCzxId);
   }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -33,10 +33,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+import org.apache.jute.BinaryInputArchive;
 import org.apache.jute.InputArchive;
 import org.apache.jute.OutputArchive;
 import org.apache.jute.Record;
@@ -45,6 +45,7 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.Code;
 import org.apache.zookeeper.KeeperException.NoNodeException;
 import org.apache.zookeeper.KeeperException.NodeExistsException;
+import org.apache.zookeeper.PaginationNextPage;
 import org.apache.zookeeper.Quotas;
 import org.apache.zookeeper.StatsTrack;
 import org.apache.zookeeper.WatchedEvent;
@@ -65,6 +66,9 @@ import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.PathWithStat;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.data.StatPersisted;
+import org.apache.zookeeper.proto.GetChildrenPaginatedResponse;
+import org.apache.zookeeper.proto.ReplyHeader;
+import org.apache.zookeeper.server.util.SerializeUtils;
 import org.apache.zookeeper.server.watch.IWatchManager;
 import org.apache.zookeeper.server.watch.WatchManagerFactory;
 import org.apache.zookeeper.server.watch.WatcherMode;
@@ -178,6 +182,18 @@ public class DataTree {
     // to align and compare between servers.
     public static final int DIGEST_LOG_INTERVAL = 128;
 
+    // Constants used to calculate response packet length for the paginated children list.
+    // packetLength = (childNameLength + PAGINATION_PACKET_CHILD_EXTRA_BYTES) * numChildren
+    //                + PAGINATION_PACKET_BASE_BYTES
+    public static final int PAGINATION_PACKET_BASE_BYTES;
+    public static final int PAGINATION_PACKET_CHILD_EXTRA_BYTES;
+
+    static {
+        PAGINATION_PACKET_BASE_BYTES = getPaginationPacketLength(Collections.emptyList());
+        PAGINATION_PACKET_CHILD_EXTRA_BYTES =
+                getPaginationPacketLength(Collections.singletonList("")) - PAGINATION_PACKET_BASE_BYTES;
+    }
+
     // If this is not null, we are actively looking for a target zxid that we
     // want to validate the digest for
     private ZxidDigest digestFromLoadedSnapshot;
@@ -263,6 +279,19 @@ public class DataTree {
         return (path == null ? 0 : path.length()) + (data == null ? 0 : data.length);
     }
 
+    private static int getPaginationPacketLength(List<String> children) {
+        try {
+            Record record = new GetChildrenPaginatedResponse(children, new Stat(), 0, 0);
+            ReplyHeader header = new ReplyHeader();
+            byte[] recordBytes = SerializeUtils.serializeRecord(record);
+            byte[] headerBytes = SerializeUtils.serializeRecord(header);
+            return recordBytes.length + headerBytes.length;
+        } catch (IOException e) {
+            LOG.warn("Unexpected exception. Destruction averted.", e);
+            return 0;
+        }
+    }
+
     public long cachedApproximateDataSize() {
         return nodeDataSize.get();
     }
@@ -313,6 +342,9 @@ public class DataTree {
             LOG.error("Unexpected exception when creating WatchManager, exiting abnormally", e);
             ServiceUtils.requestSystemExit(ExitCode.UNEXPECTED_ERROR.getValue());
         }
+
+        LOG.info("Pagination packet length formula constants: child extra = {} bytes, base = {} bytes",
+                PAGINATION_PACKET_CHILD_EXTRA_BYTES, PAGINATION_PACKET_BASE_BYTES);
     }
 
     /**
@@ -800,74 +832,178 @@ public class DataTree {
      * Produces a paginated list of the children of a given path
      * @param path path of node node to list
      * @param stat stat of the node to list
-     * @param watcher an optional watcher to attach to the node. The watcher is added only once when reaching the end of pagination
-     * @param maxReturned maximum number of children to return. Return one more than this number to indicate truncation
+     * @param watcher an optional watcher to attach to the node. The watcher is added only once
+     *                when reaching the end of pagination
+     * @param maxReturned maximum number of children to return.
      * @param minCzxId only return children whose creation zxid equal or greater than minCzxId
      * @param czxIdOffset how many children with zxid == minCzxId to skip (as returned in previous pages)
-     * @return A list of path with stats
+     * @param outputNextPage info to be used for the next page call
+     * @return A list of child names of the given path
      * @throws NoNodeException if the path does not exist
      */
-    public List<PathWithStat> getPaginatedChildren(String path, Stat stat, Watcher watcher, int maxReturned,
-                                                   long minCzxId, long czxIdOffset)
+    public List<String> getPaginatedChildren(String path, Stat stat, Watcher watcher, int maxReturned,
+                                             long minCzxId, int czxIdOffset, PaginationNextPage outputNextPage)
             throws NoNodeException {
         DataNode n = nodes.get(path);
         if (n == null) {
             throw new KeeperException.NoNodeException();
         }
+
+        if (maxReturned == Integer.MAX_VALUE && minCzxId <= 0) {
+            List<String> allChildren;
+            boolean canFitInMaxBuffer = false;
+            // Need to lock the parent node for the whole block between reading children list and adding watch
+            synchronized (n) {
+                if (stat != null) {
+                    n.copyStat(stat);
+                }
+                allChildren = new ArrayList<>(n.getChildren());
+                if (canPacketFitInMaxBuffer(computeChildrenPacketLength(allChildren))) {
+                    // If all children can be returned in the first page, just return them without sorting.
+                    canFitInMaxBuffer = true;
+                    if (watcher != null) {
+                        childWatches.addWatch(path, watcher);
+                    }
+                }
+            }
+            if (canFitInMaxBuffer) {
+                updateReadStat(path, countReadChildrenBytes(allChildren));
+                if (outputNextPage != null) {
+                    outputNextPage.setMinCzxid(ZooDefs.GetChildrenPaginated.lastPageMinCzxid);
+                    outputNextPage.setMinCzxidOffset(ZooDefs.GetChildrenPaginated.lastPageCzxidOffset);
+                }
+                return allChildren;
+            }
+        }
+
+        return getSortedPaginatedChildren(n, path, stat, watcher, maxReturned, minCzxId, czxIdOffset, outputNextPage);
+    }
+
+    private List<String> getSortedPaginatedChildren(DataNode node, String path, Stat stat, Watcher watcher,
+                                                    int maxReturned, long minCzxId, int czxIdOffset,
+                                                    PaginationNextPage outputNextPage) {
+        int index = 0;
+        List<PathWithStat> targetChildren = new ArrayList<PathWithStat>();
+        List<String> paginatedChildren = new ArrayList<String>();
+
+        // Need to lock the parent node for the whole block between reading children list and adding watch
+        synchronized (node) {
+            buildChildrenPathWithStat(node, path, stat, minCzxId, targetChildren);
+
+            targetChildren.sort(staticNodeCreationComparator);
+
+            // Go over the ordered list of children and skip the first czxIdOffset
+            // that have czxid equal to minCzxId, if any
+            while (index < targetChildren.size() && index < czxIdOffset) {
+                if (targetChildren.get(index).getStat().getCzxid() > minCzxId) {
+                    // We moved past the minCzxId, no point in looking further
+                    break;
+                }
+                index++;
+            }
+
+            // Return as list preserving older-to-newer order
+            // Add children up to maxReturned and just below the max network buffer
+            for (int packetLength = PAGINATION_PACKET_BASE_BYTES;
+                 index < targetChildren.size() && paginatedChildren.size() < maxReturned;
+                 index++) {
+                String child = targetChildren.get(index).getPath();
+                packetLength += child.length() + PAGINATION_PACKET_CHILD_EXTRA_BYTES;
+                if (!canPacketFitInMaxBuffer(packetLength)) {
+                    // Stop adding more children to ensure packet is below max buffer
+                    break;
+                }
+                paginatedChildren.add(child);
+            }
+
+            // Decrement index as it was incremented once before exiting the for-loop.
+            index--;
+
+            if (index == targetChildren.size() - 1 && watcher != null) {
+                // All children are added so this is the last page, set the watch
+                childWatches.addWatch(path, watcher);
+            }
+        }
+
+        updateNextPage(outputNextPage, targetChildren, index);
+        updateReadStat(path, countReadChildrenBytes(paginatedChildren));
+
+        return paginatedChildren;
+    }
+
+    private boolean canPacketFitInMaxBuffer(int packetLength) {
+        return packetLength <= BinaryInputArchive.maxBuffer;
+    }
+
+    private int countReadChildrenBytes(Collection<String> children) {
+        return children.stream().mapToInt(String::length).sum();
+    }
+
+    private void buildChildrenPathWithStat(DataNode n, String path, Stat stat, long minCzxId,
+                                           List<PathWithStat> targetChildren) {
         synchronized (n) {
             if (stat != null) {
                 n.copyStat(stat);
             }
-            PriorityQueue<PathWithStat> childrenQueue;
-            Set<String> actualChildren = n.getChildren();
-            if (actualChildren == null) {
-                childrenQueue = new PriorityQueue<PathWithStat>(1);
-            } else {
-                childrenQueue = new PriorityQueue<PathWithStat>(maxReturned + 1, staticNodeCreationComparator);
-                for (String child : actualChildren) {
-                    DataNode childNode = nodes.get(path + "/" + child);
-                    if (null != childNode) {
-                        final long czxId = childNode.stat.getCzxid();
+            for (String child : n.getChildren()) {
+                DataNode childNode = nodes.get(path + "/" + child);
+                if (null != childNode) {
+                    final long czxId = childNode.stat.getCzxid();
 
-                        if (czxId < minCzxId) {
-                            // Filter out nodes that are below minCzxId
-                            continue;
-                        }
-
-                        Stat childStat = new Stat();
-                        childNode.copyStat(childStat);
-
-                        // Cannot discard before having sorted and removed offset
-                        childrenQueue.add(new PathWithStat(child, childStat));
+                    if (czxId < minCzxId) {
+                        // Filter out nodes that are below minCzxId
+                        continue;
                     }
+
+                    Stat childStat = new Stat();
+                    childNode.copyStat(childStat);
+
+                    // Cannot discard before having sorted and removed offset
+                    targetChildren.add(new PathWithStat(child, childStat));
                 }
             }
-
-            // Go over the ordered list of children and skip the first czxIdOffset that have czxid equal to minCzxId, if any
-            int skipped = 0;
-            while (!childrenQueue.isEmpty() && skipped < czxIdOffset) {
-                PathWithStat head = childrenQueue.peek();
-                if (head.getStat().getCzxid() > minCzxId) {
-                    // We moved past the minCzxId, no point in looking further
-                    break;
-                } else {
-                    childrenQueue.poll();
-                    ++skipped;
-                }
-            }
-
-            // Return as list preserving newer-to-older order
-            LinkedList<PathWithStat> result = new LinkedList<PathWithStat>();
-            while (!childrenQueue.isEmpty() && result.size() < maxReturned) {
-                result.addLast(childrenQueue.poll());
-            }
-
-            // This is the last page, set the watch
-            if (childrenQueue.isEmpty()) {
-                childWatches.addWatch(path, watcher);
-            }
-            return result;
         }
+    }
+
+    /*
+     * totalLength = (PAGINATION_PACKET_CHILD_EXTRA_BYTES + childLength) * numChildren + PAGINATION_PACKET_BASE_BYTES
+     */
+    private int computeChildrenPacketLength(Collection<String> children) {
+        int length = children.stream().mapToInt(child -> PAGINATION_PACKET_CHILD_EXTRA_BYTES + child.length()).sum();
+        return length + PAGINATION_PACKET_BASE_BYTES;
+    }
+
+    private void updateNextPage(PaginationNextPage nextPage, List<PathWithStat> children, int lastAddedIndex) {
+        if (nextPage == null) {
+            return;
+        }
+        if (lastAddedIndex == children.size() - 1) {
+            // All children are added, so this is the last page
+            nextPage.setMinCzxid(ZooDefs.GetChildrenPaginated.lastPageMinCzxid);
+            nextPage.setMinCzxidOffset(ZooDefs.GetChildrenPaginated.lastPageCzxidOffset);
+            return;
+        }
+
+        long lastCzxid = children.get(lastAddedIndex).getStat().getCzxid();
+        long nextCzxid = children.get(lastAddedIndex + 1).getStat().getCzxid();
+        int nextCzixdOffset = 0;
+
+        if (nextCzxid == lastCzxid) {
+            // Find the minCzxidOffset next next page by searching the index (startIndex) of czxid
+            // that is not equal to current czxid.
+            // minCzxidOffset of next page = lastAddedIndex - startIndex
+            int startIndex = lastAddedIndex;
+            while (startIndex >= 0) {
+                if (children.get(startIndex).getStat().getCzxid() != lastCzxid) {
+                    break;
+                }
+                startIndex--;
+            }
+            nextCzixdOffset = lastAddedIndex - startIndex;
+        }
+
+        nextPage.setMinCzxid(nextCzxid);
+        nextPage.setMinCzxidOffset(nextCzixdOffset);
     }
 
     public Stat setACL(String path, List<ACL> acl, int version) throws KeeperException.NoNodeException {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/FinalRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/FinalRequestProcessor.java
@@ -42,6 +42,7 @@ import org.apache.zookeeper.OpResult.ErrorResult;
 import org.apache.zookeeper.OpResult.GetChildrenResult;
 import org.apache.zookeeper.OpResult.GetDataResult;
 import org.apache.zookeeper.OpResult.SetDataResult;
+import org.apache.zookeeper.PaginationNextPage;
 import org.apache.zookeeper.Watcher.WatcherType;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooDefs.OpCode;
@@ -49,7 +50,6 @@ import org.apache.zookeeper.audit.AuditHelper;
 import org.apache.zookeeper.common.Time;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Id;
-import org.apache.zookeeper.data.PathWithStat;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.proto.AddWatchRequest;
 import org.apache.zookeeper.proto.CheckWatchesRequest;
@@ -605,13 +605,15 @@ public class FinalRequestProcessor implements RequestProcessor {
                         request.authInfo, path,
                         null);
                 final int maxReturned = getChildrenPaginatedRequest.getMaxReturned();
-                List<PathWithStat> list = zks.getZKDatabase().getPaginatedChildren(
+                final PaginationNextPage nextPage = new PaginationNextPage();
+                List<String> list = zks.getZKDatabase().getPaginatedChildren(
                         getChildrenPaginatedRequest.getPath(), stat,
                         getChildrenPaginatedRequest.getWatch() ? cnxn : null,
                         maxReturned,
-                        getChildrenPaginatedRequest.getMinCzxId(),
-                        getChildrenPaginatedRequest.getCzxIdOffset());
-                rsp = new GetChildrenPaginatedResponse(list, stat);
+                        getChildrenPaginatedRequest.getMinCzxid(),
+                        getChildrenPaginatedRequest.getCzxidOffset(),
+                        nextPage);
+                rsp = new GetChildrenPaginatedResponse(list, stat, nextPage.getMinCzxid(), nextPage.getMinCzxidOffset());
                 break;
             }
             }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -921,6 +921,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
             case OpCode.getChildren:
             case OpCode.getAllChildrenNumber:
             case OpCode.getChildren2:
+            case OpCode.getChildrenPaginated:
             case OpCode.ping:
             case OpCode.setWatches:
             case OpCode.setWatches2:

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZKDatabase.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZKDatabase.java
@@ -41,12 +41,12 @@ import org.apache.jute.OutputArchive;
 import org.apache.jute.Record;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.NoNodeException;
+import org.apache.zookeeper.PaginationNextPage;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.Watcher.WatcherType;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.common.Time;
 import org.apache.zookeeper.data.ACL;
-import org.apache.zookeeper.data.PathWithStat;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.server.DataTree.ProcessTxnResult;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
@@ -581,12 +581,12 @@ public class ZKDatabase {
      * @param maxReturned the maximum number of nodes to be returned
      * @param minCzxId only return children whose creation zxid greater than minCzxId
      * @param czxIdOffset how many children with zxid == minCzxId to skip (as returned in previous pages)
-     * @return  A list of PathWithStat for the children. Size is bound to maxReturned (maxReturned+1 indicates truncation)
+     * @return  A list of children. Size is bound to maxReturned (maxReturned+1 indicates truncation)
      * @throws NoNodeException if the given path does not exist
      */
-    public List<PathWithStat> getPaginatedChildren(String path, Stat stat, Watcher watcher, int maxReturned,
-                                                   long minCzxId, long czxIdOffset) throws NoNodeException {
-        return dataTree.getPaginatedChildren(path, stat, watcher, maxReturned, minCzxId, czxIdOffset);
+    public List<String> getPaginatedChildren(String path, Stat stat, Watcher watcher, int maxReturned,
+                                             long minCzxId, int czxIdOffset, PaginationNextPage nextPage) throws NoNodeException {
+        return dataTree.getPaginatedChildren(path, stat, watcher, maxReturned, minCzxId, czxIdOffset, nextPage);
     }
 
     /**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/SerializeUtils.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/util/SerializeUtils.java
@@ -19,12 +19,14 @@
 package org.apache.zookeeper.server.util;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import org.apache.jute.BinaryInputArchive;
+import org.apache.jute.BinaryOutputArchive;
 import org.apache.jute.InputArchive;
 import org.apache.jute.OutputArchive;
 import org.apache.jute.Record;
@@ -184,4 +186,17 @@ public class SerializeUtils {
         return data;
     }
 
+    /**
+     * Serializes a {@link Record} into a byte array.
+     *
+     * @param record the {@link Record} to be serialized
+     * @return a new byte array
+     * @throws IOException if there is an error during serialization
+     */
+    public static byte[] serializeRecord(Record record) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream(ZooKeeperServer.intBufferStartingSizeBytes);
+        BinaryOutputArchive bos = BinaryOutputArchive.getArchive(baos);
+        bos.writeRecord(record, null);
+        return baos.toByteArray();
+    }
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/DataTreeTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/DataTreeTest.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -44,13 +45,13 @@ import org.apache.jute.InputArchive;
 import org.apache.jute.Record;
 import org.apache.zookeeper.KeeperException.NoNodeException;
 import org.apache.zookeeper.KeeperException.NodeExistsException;
+import org.apache.zookeeper.PaginationNextPage;
 import org.apache.zookeeper.Quotas;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.common.PathTrie;
-import org.apache.zookeeper.data.PathWithStat;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.metrics.MetricsUtils;
 import org.apache.zookeeper.txn.CreateTxn;
@@ -313,7 +314,7 @@ public class DataTreeTest extends ZKTestCase {
 
     @Test
     @Timeout(value = 60)
-    public void getChildrenPaginated() throws NodeExistsException, NoNodeException {
+    public void testGetChildrenPaginated() throws NodeExistsException, NoNodeException {
         final String rootPath = "/children";
         final int firstCzxId = 1000;
         final int countNodes = 10;
@@ -323,64 +324,102 @@ public class DataTreeTest extends ZKTestCase {
         dt.createNode(rootPath, new byte[0], null, 0, dt.getNode("/").stat.getCversion() + 1, 1, 1);
 
         //  Create 10 child nodes
+        List<String> childrenCreated = new ArrayList<>(countNodes);
         for (int i = 0; i < countNodes; ++i) {
             dt.createNode(rootPath + "/test-" + i, new byte[0], null, 0, dt.getNode(rootPath).stat.getCversion() + i + 1, firstCzxId + i, 1);
+            childrenCreated.add("test-" + i);
         }
 
         //  Asking from a negative for 5 nodes should return the 5, and not set the watch
         int curWatchCount = dt.getWatchCount();
-        List<PathWithStat> result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), 5, -1, 0);
+        PaginationNextPage nextPage = new PaginationNextPage();
+        List<String> result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), 5, -1, 0, nextPage);
         assertEquals(5, result.size());
+        assertEquals(firstCzxId + 5, nextPage.getMinCzxid());
+        assertEquals(0, nextPage.getMinCzxidOffset());
         assertEquals(curWatchCount, dt.getWatchCount(), "The watch not should have been set");
         //  Verify that the list is sorted
         String before = "";
-        for (final PathWithStat s : result) {
-            final String path = s.getPath();
+        for (final String path : result) {
             assertTrue(
-                    path.compareTo(before) > 0, String.format("The next path (%s) should be > previons (%s)", path, before));
+                    path.compareTo(before) > 0, String.format("The next path (%s) should be > previous (%s)", path, before));
             before = path;
         }
 
         //  Asking from a negative would give me all children, and set the watch
         curWatchCount = dt.getWatchCount();
-        result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), countNodes, -1, 0);
+        result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), countNodes, -1, 0, nextPage);
         assertEquals(countNodes, result.size());
+        assertEquals(ZooDefs.GetChildrenPaginated.lastPageMinCzxid, nextPage.getMinCzxid());
+        assertEquals(ZooDefs.GetChildrenPaginated.lastPageCzxidOffset, nextPage.getMinCzxidOffset());
         assertEquals(curWatchCount + 1, dt.getWatchCount(), "The watch should have been set");
         //  Verify that the list is sorted
         before = "";
-        for (final PathWithStat s : result) {
-            final String path = s.getPath();
+        for (final String path : result) {
             assertTrue(
-                    path.compareTo(before) > 0, String.format("The next path (%s) should be > previons (%s)", path, before));
+                    path.compareTo(before) > 0, String.format("The next path (%s) should be > previous (%s)", path, before));
             before = path;
         }
 
-        //  Asking from the last one should return only onde node
+        //  Asking with maxReturned = MAX_INT would give me all children with no sorting, and set the watch
         curWatchCount = dt.getWatchCount();
-        result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), 2, 1000 + countNodes - 1, 0);
+        result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), Integer.MAX_VALUE, 0, 0, nextPage);
+        assertEquals(countNodes, result.size());
+        assertEquals(ZooDefs.GetChildrenPaginated.lastPageMinCzxid, nextPage.getMinCzxid());
+        assertEquals(ZooDefs.GetChildrenPaginated.lastPageCzxidOffset, nextPage.getMinCzxidOffset());
+        assertEquals(curWatchCount + 1, dt.getWatchCount(), "The watch should have been set");
+        //  Verify that the list is not sorted
+        assertNotEquals(childrenCreated, result, "The returned list of children should not be sorted");
+
+        // Passing a null watch when fetching all children should not set the watch
+        curWatchCount = dt.getWatchCount();
+        result = dt.getPaginatedChildren(rootPath, null, null, Integer.MAX_VALUE, 0, 0, nextPage);
+        assertEquals(countNodes, result.size());
+        assertEquals(ZooDefs.GetChildrenPaginated.lastPageMinCzxid, nextPage.getMinCzxid());
+        assertEquals(ZooDefs.GetChildrenPaginated.lastPageCzxidOffset, nextPage.getMinCzxidOffset());
+        assertEquals(curWatchCount, dt.getWatchCount(), "The watch should have been set");
+
+        // Passing a null watch when fetching all children should not set the watch
+        curWatchCount = dt.getWatchCount();
+        result = dt.getPaginatedChildren(rootPath, null, null, countNodes, 0, 0, nextPage);
+        // Returned result is ordered
+        assertEquals(childrenCreated, result);
+        assertEquals(ZooDefs.GetChildrenPaginated.lastPageMinCzxid, nextPage.getMinCzxid());
+        assertEquals(ZooDefs.GetChildrenPaginated.lastPageCzxidOffset, nextPage.getMinCzxidOffset());
+        assertEquals(curWatchCount, dt.getWatchCount(), "The watch should have been set");
+
+        //  Asking from the last one should return only one node
+        curWatchCount = dt.getWatchCount();
+        result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), 2, 1000 + countNodes - 1, 0, nextPage);
         assertEquals(1, result.size());
-        assertEquals("test-" + (countNodes - 1), result.get(0).getPath());
-        assertEquals(firstCzxId + countNodes - 1, result.get(0).getStat().getMzxid());
+        assertEquals("test-" + (countNodes - 1), result.get(0));
+        assertEquals(ZooDefs.GetChildrenPaginated.lastPageMinCzxid, nextPage.getMinCzxid());
+        assertEquals(ZooDefs.GetChildrenPaginated.lastPageCzxidOffset, nextPage.getMinCzxidOffset());
         assertEquals(curWatchCount + 1, dt.getWatchCount(), "The watch should have been set");
 
         //  Asking from the last created node+1 should return an empty list and set the watch
         curWatchCount = dt.getWatchCount();
-        result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), 2, 1000 + countNodes, 0);
+        result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), 2, 1000 + countNodes, 0, nextPage);
         assertTrue(result.isEmpty(), "The result should be an empty list");
+        assertEquals(ZooDefs.GetChildrenPaginated.lastPageMinCzxid, nextPage.getMinCzxid());
+        assertEquals(ZooDefs.GetChildrenPaginated.lastPageCzxidOffset, nextPage.getMinCzxidOffset());
         assertEquals(curWatchCount + 1, dt.getWatchCount(), "The watch should have been set");
 
         //  Asking from -1 for one node should return two, and NOT set the watch
         curWatchCount = dt.getWatchCount();
-        result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), 1, -1, 0);
+        result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), 1, -1, 0, nextPage);
         assertEquals(curWatchCount, dt.getWatchCount(), "No watch should be set");
         assertEquals(1, result.size(), "We only return up to ");
         //  Check that we ordered correctly
-        assertEquals("test-0", result.get(0).getPath());
+        assertEquals("test-0", result.get(0));
+        // Check next page info is returned correctly
+        assertEquals(firstCzxId + 1, nextPage.getMinCzxid());
+        assertEquals(0, nextPage.getMinCzxidOffset());
     }
 
     @Test
     @Timeout(value = 60)
-    public void getChildrenPaginatedWithOffset() throws NodeExistsException, NoNodeException {
+    public void testGetChildrenPaginatedWithOffset() throws NodeExistsException, NoNodeException {
         final String rootPath = "/children";
         final int childrenCzxId = 1000;
         final int countNodes = 9;
@@ -405,76 +444,112 @@ public class DataTreeTest extends ZKTestCase {
 
         //  Asking from a negative would give me all children, and set the watch
         int curWatchCount = dt.getWatchCount();
-        List<PathWithStat> result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), 1000, -1, 0);
+        PaginationNextPage nextPage = new PaginationNextPage();
+        List<String> result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), 1000, -1, 0, nextPage);
         assertEquals(allNodes, result.size());
+        assertEquals(ZooDefs.GetChildrenPaginated.lastPageMinCzxid, nextPage.getMinCzxid());
+        assertEquals(ZooDefs.GetChildrenPaginated.lastPageCzxidOffset, nextPage.getMinCzxidOffset());
         assertEquals(curWatchCount + 1, dt.getWatchCount(), "The watch should have been set");
         //  Verify that the list is sorted
         String before = "";
-        for (final PathWithStat s : result) {
-            final String path = s.getPath();
+        for (final String path : result) {
             assertTrue(
-                    path.compareTo(before) > 0, String.format("The next path (%s) should be > previons (%s)", path, before));
+                    path.compareTo(before) > 0, String.format("The next path (%s) should be > previous (%s)", path, before));
             before = path;
         }
 
+        // Asking with minCzxid = 0, offset = 0 should not skip anything.
+        // maxReturned = 1, the returned nextPage should be: minCzxid = next czxid, offset = 0.
+        curWatchCount = dt.getWatchCount();
+        result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), 1, 0, 0, nextPage);
+        assertEquals(1, result.size());
+        assertEquals("test-0", result.get(0));
+        assertEquals(childrenCzxId, nextPage.getMinCzxid());
+        assertEquals(0, nextPage.getMinCzxidOffset());
+        assertEquals(curWatchCount, dt.getWatchCount(), "The watch should not have been set");
+
         //  Asking with offset minCzxId below childrenCzxId should not skip anything, regardless of offset
         curWatchCount = dt.getWatchCount();
-        result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), 2, childrenCzxId - 1, 3);
+        result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), 2, childrenCzxId - 1, 3, nextPage);
         assertEquals(2, result.size());
-        assertEquals("test-1", result.get(0).getPath());
-        assertEquals("test-2", result.get(1).getPath());
+        assertEquals("test-1", result.get(0));
+        assertEquals("test-2", result.get(1));
+        assertEquals(childrenCzxId, nextPage.getMinCzxid());
+        assertEquals(2, nextPage.getMinCzxidOffset());
         assertEquals(curWatchCount, dt.getWatchCount(), "The watch should not have been set");
 
         //  Asking with offset 5 should skip nodes 1, 2, 3, 4, 5
         curWatchCount = dt.getWatchCount();
-        result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), 2, childrenCzxId, 5);
+        result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), 2, childrenCzxId, 5, nextPage);
         assertEquals(2, result.size());
-        assertEquals("test-6", result.get(0).getPath());
-        assertEquals("test-7", result.get(1).getPath());
+        assertEquals("test-6", result.get(0));
+        assertEquals("test-7", result.get(1));
+        assertEquals(childrenCzxId, nextPage.getMinCzxid());
+        assertEquals(7, nextPage.getMinCzxidOffset());
         assertEquals(curWatchCount, dt.getWatchCount(), "The watch should not have been set");
 
         //  Asking with offset 5 for more nodes than are there should skip nodes 1, 2, 3, 4, 5 (plus 0 due to zxid)
         curWatchCount = dt.getWatchCount();
-        result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), 10, childrenCzxId, 5);
+        result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), 10, childrenCzxId, 5, nextPage);
 
         assertEquals(5, result.size());
-        assertEquals("test-6", result.get(0).getPath());
-        assertEquals("test-7", result.get(1).getPath());
-        assertEquals("test-8", result.get(2).getPath());
-        assertEquals("test-9", result.get(3).getPath());
+        assertEquals("test-6", result.get(0));
+        assertEquals("test-7", result.get(1));
+        assertEquals("test-8", result.get(2));
+        assertEquals("test-9", result.get(3));
+        assertEquals("test-999", result.get(4));
+        assertEquals(ZooDefs.GetChildrenPaginated.lastPageMinCzxid, nextPage.getMinCzxid());
+        assertEquals(ZooDefs.GetChildrenPaginated.lastPageCzxidOffset, nextPage.getMinCzxidOffset());
         assertEquals(curWatchCount + 1, dt.getWatchCount(), "The watch should have been set");
 
         //  Asking with offset 5 for fewer nodes than are there should skip nodes 1, 2, 3, 4, 5 (plus 0 due to zxid)
+        // Returned next page should be: minCzxid = next czxid, offset = 0
         curWatchCount = dt.getWatchCount();
-        result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), 4, childrenCzxId, 5);
+        result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), 4, childrenCzxId, 5, nextPage);
 
         assertEquals(4, result.size());
-        assertEquals("test-6", result.get(0).getPath());
-        assertEquals("test-7", result.get(1).getPath());
-        assertEquals("test-8", result.get(2).getPath());
-        assertEquals("test-9", result.get(3).getPath());
+        assertEquals("test-6", result.get(0));
+        assertEquals("test-7", result.get(1));
+        assertEquals("test-8", result.get(2));
+        assertEquals("test-9", result.get(3));
+        assertEquals(childrenCzxId + 100, nextPage.getMinCzxid());
+        assertEquals(0, nextPage.getMinCzxidOffset());
         assertEquals(curWatchCount, dt.getWatchCount(), "The watch should not have been set");
 
         //  Asking from the last created node+1 should return an empty list and set the watch
         curWatchCount = dt.getWatchCount();
-        result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), 2, 1000 + childrenCzxId, 0);
+        result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), 2, 1000 + childrenCzxId, 0, nextPage);
         assertTrue(result.isEmpty(), "The result should be an empty list");
+        assertEquals(ZooDefs.GetChildrenPaginated.lastPageMinCzxid, nextPage.getMinCzxid());
+        assertEquals(ZooDefs.GetChildrenPaginated.lastPageCzxidOffset, nextPage.getMinCzxidOffset());
         assertEquals(curWatchCount + 1, dt.getWatchCount(), "The watch should have been set");
     }
 
     @Test
     @Timeout(value = 60)
-    public void getChildrenPaginatedEmpty() throws NodeExistsException, NoNodeException {
+    public void testGetChildrenPaginatedEmpty() throws NodeExistsException, NoNodeException {
         final String rootPath = "/children";
 
         //  Create the parent node
         DataTree dt = new DataTree();
         dt.createNode(rootPath, new byte[0], null, 0, dt.getNode("/").stat.getCversion() + 1, 1, 1);
 
-        //  Asking from a negative would give me all children, and set the watch
+        // Asking from a negative would give me all children, and set the watch
+        // This goes to the pagination branch.
         int curWatchCount = dt.getWatchCount();
-        List<PathWithStat> result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), 100, -1, 0);
+        PaginationNextPage nextPage = new PaginationNextPage();
+        List<String> result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), 100, -1, 0, nextPage);
         assertTrue(result.isEmpty(), "The result should be empty");
+        assertEquals(ZooDefs.GetChildrenPaginated.lastPageMinCzxid, nextPage.getMinCzxid());
+        assertEquals(ZooDefs.GetChildrenPaginated.lastPageCzxidOffset, nextPage.getMinCzxidOffset());
+        assertEquals(curWatchCount + 1, dt.getWatchCount(), "The watch should have been set");
+
+        // Specify max int to fetch all children - trying to return all without sorting, and set the watch
+        curWatchCount = dt.getWatchCount();
+        result = dt.getPaginatedChildren(rootPath, null, new DummyWatcher(), Integer.MAX_VALUE, 0, 0, nextPage);
+        assertTrue(result.isEmpty(), "The result should be empty");
+        assertEquals(ZooDefs.GetChildrenPaginated.lastPageMinCzxid, nextPage.getMinCzxid());
+        assertEquals(ZooDefs.GetChildrenPaginated.lastPageCzxidOffset, nextPage.getMinCzxidOffset());
         assertEquals(curWatchCount + 1, dt.getWatchCount(), "The watch should have been set");
     }
 


### PR DESCRIPTION
<!-- 
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at
http://www.apache.org/licenses/LICENSE-2.0
Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
--> 
    
### Description
(Write a concise description including what, why, how)
Optimize paginated getChildren (https://github.com/apache/zookeeper/pull/8)
The optimizes the paginated getChildren API to satisfy use cases better. The changes include:
-  On zk server, uses a formulate to pre-calculate the children's packet length when adding the children to the returning list, so the children packet is ensured within the jute.maxbuffer limit.
- Adds an API getAllChildrenPaginated to fetch all children by leveraging the paginated getChildren API.
- Optimize the sorting logic for paginated getChildren in DataTree: only when pagination is needed, children are sorted. 99% of the case for returning all children, the children could be returned in the 1st page. No need to sort them to avoid performance downgrade.
- Returning a list of child name string for the API, instead of a list of PathWithStat
- Add more tests to cover the new logic

Ref pr :- https://github.com/apache/zookeeper/commit/1d95c2ea175e1b965626176f01f4729426ac28db

### Tests
 The following tests are written for this issue:
(List the names of added unit/integration tests)
`[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache ZooKeeper 3.8.4:
[INFO] 
[INFO] Apache ZooKeeper ................................... SUCCESS [  1.355 s]
[INFO] Apache ZooKeeper - Documentation ................... SUCCESS [  0.415 s]
[INFO] Apache ZooKeeper - Jute ............................ SUCCESS [  4.277 s]
[INFO] Apache ZooKeeper - Server .......................... SUCCESS [  8.660 s]
[INFO] Apache ZooKeeper - Metrics Providers ............... SUCCESS [  0.121 s]
[INFO] Apache ZooKeeper - Prometheus.io Metrics Provider .. SUCCESS [  1.043 s]
[INFO] Apache ZooKeeper - Client .......................... SUCCESS [  0.118 s]
[INFO] Apache ZooKeeper - Recipes ......................... SUCCESS [  0.304 s]
[INFO] Apache ZooKeeper - Recipes - Election .............. SUCCESS [  0.336 s]
[INFO] Apache ZooKeeper - Recipes - Lock .................. SUCCESS [  0.338 s]
[INFO] Apache ZooKeeper - Recipes - Queue ................. SUCCESS [  0.313 s]
[INFO] Apache ZooKeeper - Assembly ........................ SUCCESS [  1.447 s]
[INFO] Apache ZooKeeper - Compatibility Tests ............. SUCCESS [  0.099 s]
[INFO] Apache ZooKeeper - Compatibility Tests - Curator ... SUCCESS [  0.303 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  19.202 s
[INFO] Finished at: 2025-11-19T21:17:39+05:30
[INFO] ------------------------------------------------------------------------`

The following is the result of the "mvn test" command on the appropriate module:
(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)
My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:
(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)
In case of new functionality, my PR adds documentation in the following wiki page:
(Link the GitHub wiki you added)
