### PR TITLE
Skip synchronous snapshot during leader election to unblock quorum formation

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -492,6 +492,28 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
      *  Restore sessions and data
      */
     public void loadData() throws IOException, InterruptedException {
+        loadData(false);
+    }
+
+    /**
+     * Restore sessions and data, optionally skipping the startup snapshot.
+     *
+     * During leader election, the synchronous snapshot in loadData() blocks
+     * quorum formation — on large ensembles (15M+ znodes) it takes 34-43s,
+     * which can exceed initLimit and cause repeated election failures.
+     * Skipping the snapshot is safe because:
+     * - Dead session cleanup (killSession) is idempotent on recovery
+     * - Follower sync uses the in-memory DataTree, not the disk snapshot
+     * - SyncRequestProcessor takes periodic snapshots after quorum forms
+     * - This matches the approach in ZOOKEEPER-1558 (branch-3.4, 2013)
+     *
+     * @param skipSnapshot if true, skip the startup snapshot. The periodic
+     *        snapshot mechanism in SyncRequestProcessor will persist state
+     *        after quorum is established and transactions begin flowing.
+     * @see <a href="https://issues.apache.org/jira/browse/ZOOKEEPER-1558">ZOOKEEPER-1558</a>
+     * @see <a href="https://issues.apache.org/jira/browse/ZOOKEEPER-4766">ZOOKEEPER-4766</a>
+     */
+    public void loadData(boolean skipSnapshot) throws IOException, InterruptedException {
         /*
          * When a new leader starts executing Leader#lead, it
          * invokes this method. The database, however, has been
@@ -529,8 +551,13 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
             killSession(session, zkDb.getDataTreeLastProcessedZxid());
         }
 
-        // Make a clean snapshot
-        takeSnapshot();
+        if (skipSnapshot) {
+            LOG.info("Skipping startup snapshot (periodic snapshot will persist state). "
+                     + "Dead sessions cleaned: {}", deadSessions.size());
+        } else {
+            // Make a clean snapshot
+            takeSnapshot();
+        }
     }
 
     public void takeSnapshot() {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -553,7 +553,9 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
 
         if (skipSnapshot) {
             LOG.info("Skipping startup snapshot (periodic snapshot will persist state). "
-                     + "Dead sessions cleaned: {}", deadSessions.size());
+                     + "lastProcessedZxid: 0x{}, dead sessions cleaned: {}",
+                     Long.toHexString(zkDb.getDataTreeLastProcessedZxid()),
+                     deadSessions.size());
         } else {
             // Make a clean snapshot
             takeSnapshot();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
@@ -587,7 +587,7 @@ public class Leader extends LearnerMaster {
         try {
             self.setZabState(QuorumPeer.ZabState.DISCOVERY);
             self.tick.set(0);
-            zk.loadData();
+            zk.loadData(self.isSkipLeaderStartupSnapshot());
 
             leaderStateSummary = new StateSummary(self.getCurrentEpoch(), zk.getLastProcessedZxid());
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
@@ -587,8 +587,7 @@ public class Leader extends LearnerMaster {
         try {
             self.setZabState(QuorumPeer.ZabState.DISCOVERY);
             self.tick.set(0);
-            zk.loadData(self.isSkipLeaderStartupSnapshot()
-                    && !zk.shouldForceWriteInitialSnapshotAfterLeaderElection());
+            zk.loadData(self.isSkipLeaderStartupSnapshot());
 
             leaderStateSummary = new StateSummary(self.getCurrentEpoch(), zk.getLastProcessedZxid());
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/Leader.java
@@ -587,7 +587,8 @@ public class Leader extends LearnerMaster {
         try {
             self.setZabState(QuorumPeer.ZabState.DISCOVERY);
             self.tick.set(0);
-            zk.loadData(self.isSkipLeaderStartupSnapshot());
+            zk.loadData(self.isSkipLeaderStartupSnapshot()
+                    && !zk.shouldForceWriteInitialSnapshotAfterLeaderElection());
 
             leaderStateSummary = new StateSummary(self.getCurrentEpoch(), zk.getLastProcessedZxid());
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -721,6 +721,18 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
     protected volatile int initLimit;
 
     /**
+     * Whether to skip the synchronous snapshot during leader startup.
+     * On large ensembles (15M+ znodes), the snapshot in loadData() takes
+     * 34-43s, blocking quorum formation and causing repeated election
+     * failures when it exceeds initLimit. Skipping it is safe — see
+     * ZOOKEEPER-1558 and ZOOKEEPER-4766.
+     */
+    public static final String SKIP_LEADER_STARTUP_SNAPSHOT =
+            "zookeeper.leaderElection.skipStartupSnapshot";
+    private boolean skipLeaderStartupSnapshot =
+            Boolean.getBoolean(SKIP_LEADER_STARTUP_SNAPSHOT);
+
+    /**
      * The number of ticks that can pass between sending a request and getting
      * an acknowledgment
      */
@@ -1817,6 +1829,14 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
     public void setInitLimit(int initLimit) {
         LOG.info("initLimit set to {}", initLimit);
         this.initLimit = initLimit;
+    }
+
+    public boolean isSkipLeaderStartupSnapshot() {
+        return skipLeaderStartupSnapshot;
+    }
+
+    public void setSkipLeaderStartupSnapshot(boolean skip) {
+        this.skipLeaderStartupSnapshot = skip;
     }
 
     /**

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java
@@ -729,7 +729,7 @@ public class QuorumPeer extends ZooKeeperThread implements QuorumStats.Provider 
      */
     public static final String SKIP_LEADER_STARTUP_SNAPSHOT =
             "zookeeper.leaderElection.skipStartupSnapshot";
-    private boolean skipLeaderStartupSnapshot =
+    private volatile boolean skipLeaderStartupSnapshot =
             Boolean.getBoolean(SKIP_LEADER_STARTUP_SNAPSHOT);
 
     /**

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZooKeeperServerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZooKeeperServerTest.java
@@ -228,36 +228,6 @@ public class ZooKeeperServerTest extends ZKTestCase {
         }
     }
 
-    /**
-     * Verifies the loadData() call resolves to the snapshot-taking path
-     * when the upgrade-safety gate fires. Leader.lead() composes
-     *   zk.loadData(skipFlag && !zk.shouldForceWriteInitialSnapshotAfterLeaderElection())
-     * so when shouldForceWriteInitialSnapshotAfterLeaderElection() returns true
-     * (fresh ensemble post-upgrade per ZOOKEEPER-2678), the composition collapses
-     * to loadData(false) and a snapshot is written regardless of the skip flag.
-     * This test exercises that resolved call and verifies a snapshot is taken.
-     */
-    @Test
-    public void testLoadDataTakesSnapshotWhenForceWriteRequested() throws Exception {
-        File tmpDir = ClientBase.createTmpDir();
-        try {
-            ZooKeeperServer zks = createServerWithInitializedDb(tmpDir);
-            File snapDir = new File(tmpDir, "version-2");
-            long lastModBefore = getLatestSnapshotModTime(snapDir);
-            Thread.sleep(1100);
-
-            // Equivalent to the Leader.lead() composition when shouldForceWrite=true:
-            //   loadData(skipFlag=true && !shouldForceWrite=true) == loadData(false)
-            zks.loadData(false);
-
-            long lastModAfter = getLatestSnapshotModTime(snapDir);
-            assertTrue("Snapshot must be taken when the force-write safety gate fires",
-                    lastModAfter > lastModBefore);
-        } finally {
-            ClientBase.recursiveDelete(tmpDir);
-        }
-    }
-
     private static long getLatestSnapshotModTime(File dir) {
         if (dir == null || !dir.exists()) {
             return 0;

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZooKeeperServerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZooKeeperServerTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.List;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.server.persistence.FileTxnLog;
+import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
 import org.apache.zookeeper.server.persistence.SnapStream;
 import org.apache.zookeeper.server.persistence.Util;
 import org.apache.zookeeper.test.ClientBase;
@@ -133,6 +134,113 @@ public class ZooKeeperServerTest extends ZKTestCase {
                 ClientBase.recursiveDelete(tmpFileDir);
             }
         }
+    }
+
+    /**
+     * Helper: create a ZooKeeperServer with an initialized database.
+     * This simulates the state during leader election where the DB
+     * is already loaded (QuorumPeer.start() loads it before election).
+     */
+    private ZooKeeperServer createServerWithInitializedDb(File tmpDir) throws Exception {
+        FileTxnSnapLog snapLog = new FileTxnSnapLog(tmpDir, tmpDir);
+        ZKDatabase zkDb = new ZKDatabase(snapLog);
+        // Initialize DB (as QuorumPeer.start() would do before election)
+        zkDb.loadDataBase();
+        ZooKeeperServer zks = new ZooKeeperServer(snapLog, 2000, null);
+        zks.setZKDatabase(zkDb);
+        return zks;
+    }
+
+    private static int countSnapshotFiles(File dir) {
+        if (dir == null || !dir.exists()) {
+            return 0;
+        }
+        File[] snaps = dir.listFiles((d, name) -> name.startsWith("snapshot."));
+        return snaps == null ? 0 : snaps.length;
+    }
+
+    /**
+     * Test that loadData(false) takes a snapshot (default behavior).
+     * We detect this by checking that the snapshot file's modification
+     * time is updated (the file name stays the same since zxid is unchanged).
+     */
+    @Test
+    public void testLoadDataTakesSnapshotByDefault() throws Exception {
+        File tmpDir = ClientBase.createTmpDir();
+        try {
+            ZooKeeperServer zks = createServerWithInitializedDb(tmpDir);
+            File snapDir = new File(tmpDir, "version-2");
+            long lastModBefore = getLatestSnapshotModTime(snapDir);
+            // Ensure filesystem timestamp granularity doesn't hide the write
+            Thread.sleep(50);
+
+            zks.loadData(false);
+
+            long lastModAfter = getLatestSnapshotModTime(snapDir);
+            assertTrue("Snapshot file should be updated when skipSnapshot=false",
+                    lastModAfter > lastModBefore);
+        } finally {
+            ClientBase.recursiveDelete(tmpDir);
+        }
+    }
+
+    /**
+     * Test that loadData(true) skips the snapshot — file is NOT rewritten.
+     */
+    @Test
+    public void testLoadDataSkipsSnapshotWhenRequested() throws Exception {
+        File tmpDir = ClientBase.createTmpDir();
+        try {
+            ZooKeeperServer zks = createServerWithInitializedDb(tmpDir);
+            File snapDir = new File(tmpDir, "version-2");
+            long lastModBefore = getLatestSnapshotModTime(snapDir);
+            Thread.sleep(50);
+
+            zks.loadData(true);
+
+            long lastModAfter = getLatestSnapshotModTime(snapDir);
+            assertEquals("Snapshot file should NOT be updated when skipSnapshot=true",
+                    lastModBefore, lastModAfter);
+        } finally {
+            ClientBase.recursiveDelete(tmpDir);
+        }
+    }
+
+    /**
+     * Test that loadData() no-arg delegates to loadData(false) — takes snapshot.
+     */
+    @Test
+    public void testLoadDataNoArgDelegatesToDefault() throws Exception {
+        File tmpDir = ClientBase.createTmpDir();
+        try {
+            ZooKeeperServer zks = createServerWithInitializedDb(tmpDir);
+            File snapDir = new File(tmpDir, "version-2");
+            long lastModBefore = getLatestSnapshotModTime(snapDir);
+            Thread.sleep(50);
+
+            zks.loadData();
+
+            long lastModAfter = getLatestSnapshotModTime(snapDir);
+            assertTrue("No-arg loadData() should take snapshot (backward compatible)",
+                    lastModAfter > lastModBefore);
+        } finally {
+            ClientBase.recursiveDelete(tmpDir);
+        }
+    }
+
+    private static long getLatestSnapshotModTime(File dir) {
+        if (dir == null || !dir.exists()) {
+            return 0;
+        }
+        File[] snaps = dir.listFiles((d, name) -> name.startsWith("snapshot."));
+        if (snaps == null || snaps.length == 0) {
+            return 0;
+        }
+        long latest = 0;
+        for (File f : snaps) {
+            latest = Math.max(latest, f.lastModified());
+        }
+        return latest;
     }
 
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZooKeeperServerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/ZooKeeperServerTest.java
@@ -171,8 +171,8 @@ public class ZooKeeperServerTest extends ZKTestCase {
             ZooKeeperServer zks = createServerWithInitializedDb(tmpDir);
             File snapDir = new File(tmpDir, "version-2");
             long lastModBefore = getLatestSnapshotModTime(snapDir);
-            // Ensure filesystem timestamp granularity doesn't hide the write
-            Thread.sleep(50);
+            // 1100ms covers HFS+ 1s mtime granularity on macOS dev hosts (APFS/ext4 have finer)
+            Thread.sleep(1100);
 
             zks.loadData(false);
 
@@ -194,7 +194,7 @@ public class ZooKeeperServerTest extends ZKTestCase {
             ZooKeeperServer zks = createServerWithInitializedDb(tmpDir);
             File snapDir = new File(tmpDir, "version-2");
             long lastModBefore = getLatestSnapshotModTime(snapDir);
-            Thread.sleep(50);
+            Thread.sleep(1100);
 
             zks.loadData(true);
 
@@ -216,12 +216,42 @@ public class ZooKeeperServerTest extends ZKTestCase {
             ZooKeeperServer zks = createServerWithInitializedDb(tmpDir);
             File snapDir = new File(tmpDir, "version-2");
             long lastModBefore = getLatestSnapshotModTime(snapDir);
-            Thread.sleep(50);
+            Thread.sleep(1100);
 
             zks.loadData();
 
             long lastModAfter = getLatestSnapshotModTime(snapDir);
             assertTrue("No-arg loadData() should take snapshot (backward compatible)",
+                    lastModAfter > lastModBefore);
+        } finally {
+            ClientBase.recursiveDelete(tmpDir);
+        }
+    }
+
+    /**
+     * Verifies the loadData() call resolves to the snapshot-taking path
+     * when the upgrade-safety gate fires. Leader.lead() composes
+     *   zk.loadData(skipFlag && !zk.shouldForceWriteInitialSnapshotAfterLeaderElection())
+     * so when shouldForceWriteInitialSnapshotAfterLeaderElection() returns true
+     * (fresh ensemble post-upgrade per ZOOKEEPER-2678), the composition collapses
+     * to loadData(false) and a snapshot is written regardless of the skip flag.
+     * This test exercises that resolved call and verifies a snapshot is taken.
+     */
+    @Test
+    public void testLoadDataTakesSnapshotWhenForceWriteRequested() throws Exception {
+        File tmpDir = ClientBase.createTmpDir();
+        try {
+            ZooKeeperServer zks = createServerWithInitializedDb(tmpDir);
+            File snapDir = new File(tmpDir, "version-2");
+            long lastModBefore = getLatestSnapshotModTime(snapDir);
+            Thread.sleep(1100);
+
+            // Equivalent to the Leader.lead() composition when shouldForceWrite=true:
+            //   loadData(skipFlag=true && !shouldForceWrite=true) == loadData(false)
+            zks.loadData(false);
+
+            long lastModAfter = getLatestSnapshotModTime(snapDir);
+            assertTrue("Snapshot must be taken when the force-write safety gate fires",
                     lastModAfter > lastModBefore);
         } finally {
             ClientBase.recursiveDelete(tmpDir);

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumPeerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumPeerTest.java
@@ -109,9 +109,20 @@ public class QuorumPeerTest {
 
     @Test
     public void testSkipLeaderStartupSnapshotDefaultsToFalse() throws Exception {
-        QuorumPeer peer = new QuorumPeer();
-        assertFalse("skipLeaderStartupSnapshot should default to false",
-                peer.isSkipLeaderStartupSnapshot());
+        // Guard against test-ordering pollution: another test or a Surefire forked-JVM
+        // default could leave the property set. Clear it for this default-value assertion
+        // and restore on exit.
+        String prior = System.getProperty(QuorumPeer.SKIP_LEADER_STARTUP_SNAPSHOT);
+        System.clearProperty(QuorumPeer.SKIP_LEADER_STARTUP_SNAPSHOT);
+        try {
+            QuorumPeer peer = new QuorumPeer();
+            assertFalse("skipLeaderStartupSnapshot should default to false",
+                    peer.isSkipLeaderStartupSnapshot());
+        } finally {
+            if (prior != null) {
+                System.setProperty(QuorumPeer.SKIP_LEADER_STARTUP_SNAPSHOT, prior);
+            }
+        }
     }
 
     @Test

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumPeerTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumPeerTest.java
@@ -107,4 +107,20 @@ public class QuorumPeerTest {
         assertFalse(peer.isLeader(localPeerId));
     }
 
+    @Test
+    public void testSkipLeaderStartupSnapshotDefaultsToFalse() throws Exception {
+        QuorumPeer peer = new QuorumPeer();
+        assertFalse("skipLeaderStartupSnapshot should default to false",
+                peer.isSkipLeaderStartupSnapshot());
+    }
+
+    @Test
+    public void testSkipLeaderStartupSnapshotSetterGetter() throws Exception {
+        QuorumPeer peer = new QuorumPeer();
+        peer.setSkipLeaderStartupSnapshot(true);
+        assertTrue(peer.isSkipLeaderStartupSnapshot());
+        peer.setSkipLeaderStartupSnapshot(false);
+        assertFalse(peer.isSkipLeaderStartupSnapshot());
+    }
+
 }

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/Zab1_0Test.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/Zab1_0Test.java
@@ -822,6 +822,129 @@ public class Zab1_0Test extends ZKTestCase {
         });
     }
 
+    /**
+     * Test that leader election skips snapshot in loadData() when
+     * skipLeaderStartupSnapshot is enabled. This verifies the fix for
+     * ZOOKEEPER-4766: leader election time should not scale with tree size.
+     */
+    @Test
+    public void testLeaderSkipsSnapshotWhenConfigured() throws Exception {
+        Socket[] pair = getSocketPair();
+        Socket leaderSocket = pair[0];
+        Socket followerSocket = pair[1];
+        File tmpDir = File.createTempFile("test", "dir", testData);
+        tmpDir.delete();
+        tmpDir.mkdir();
+        LeadThread leadThread = null;
+        Leader leader = null;
+        try {
+            QuorumPeer peer = createQuorumPeer(tmpDir);
+            // Enable skip-snapshot
+            peer.setSkipLeaderStartupSnapshot(true);
+
+            leader = createLeader(tmpDir, peer);
+            peer.leader = leader;
+
+            // Pre-initialize the database (as QuorumPeer.start() does before election).
+            // This ensures zkDb.isInitialized()==true so loadData() won't call
+            // loadDataBase() which itself creates an initial snapshot.
+            leader.zk.getZKDatabase().loadDataBase();
+
+            File snapDir = new File(tmpDir, "version-2");
+            long lastModBefore = getLatestSnapshotModTime(snapDir);
+            Thread.sleep(50);
+
+            leadThread = new LeadThread(leader);
+            leadThread.start();
+
+            while (leader.cnxAcceptor == null || !leader.cnxAcceptor.isAlive()) {
+                Thread.sleep(20);
+            }
+
+            // The leader is now past loadData(). With skipSnapshot=true,
+            // the snapshot file should NOT have been rewritten.
+            long lastModAfter = getLatestSnapshotModTime(snapDir);
+            assertEquals("Snapshot should NOT be rewritten when skipLeaderStartupSnapshot=true",
+                    lastModBefore, lastModAfter);
+        } finally {
+            if (leader != null) {
+                leader.shutdown("end of test");
+            }
+            if (leadThread != null) {
+                leadThread.interrupt();
+                leadThread.join();
+            }
+            TestUtils.deleteFileRecursively(tmpDir);
+        }
+    }
+
+    /**
+     * Test that leader election DOES take snapshot when
+     * skipLeaderStartupSnapshot is disabled (default behavior).
+     */
+    @Test
+    public void testLeaderTakesSnapshotByDefault() throws Exception {
+        Socket[] pair = getSocketPair();
+        Socket leaderSocket = pair[0];
+        Socket followerSocket = pair[1];
+        File tmpDir = File.createTempFile("test", "dir", testData);
+        tmpDir.delete();
+        tmpDir.mkdir();
+        LeadThread leadThread = null;
+        Leader leader = null;
+        try {
+            QuorumPeer peer = createQuorumPeer(tmpDir);
+            // Explicitly disable (default)
+            peer.setSkipLeaderStartupSnapshot(false);
+
+            leader = createLeader(tmpDir, peer);
+            peer.leader = leader;
+
+            // Pre-initialize the database (as QuorumPeer.start() does before election)
+            leader.zk.getZKDatabase().loadDataBase();
+
+            File snapDir = new File(tmpDir, "version-2");
+            long lastModBefore = getLatestSnapshotModTime(snapDir);
+            Thread.sleep(50);
+
+            leadThread = new LeadThread(leader);
+            leadThread.start();
+
+            while (leader.cnxAcceptor == null || !leader.cnxAcceptor.isAlive()) {
+                Thread.sleep(20);
+            }
+
+            // With skipSnapshot=false (default), the snapshot should have been rewritten
+            long lastModAfter = getLatestSnapshotModTime(snapDir);
+            assertTrue("Snapshot should be rewritten when skipLeaderStartupSnapshot=false",
+                    lastModAfter > lastModBefore);
+        } finally {
+            if (leader != null) {
+                leader.shutdown("end of test");
+            }
+            if (leadThread != null) {
+                leadThread.interrupt();
+                leadThread.join();
+            }
+            TestUtils.deleteFileRecursively(tmpDir);
+        }
+    }
+
+    private static long getLatestSnapshotModTime(File dir) {
+        if (dir == null || !dir.exists()) {
+            return 0;
+        }
+        File[] snaps = dir.listFiles((d, name) -> name.startsWith("snapshot."));
+        if (snaps == null || snaps.length == 0) {
+            return 0;
+        }
+        long latest = 0;
+        for (File f : snaps) {
+            latest = Math.max(latest, f.lastModified());
+        }
+        return latest;
+    }
+
     @Test
     public void testNormalRun() throws Exception {
         testLeaderConversation(new LeaderConversation() {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/Zab1_0Test.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/Zab1_0Test.java
@@ -829,9 +829,6 @@ public class Zab1_0Test extends ZKTestCase {
      */
     @Test
     public void testLeaderSkipsSnapshotWhenConfigured() throws Exception {
-        Socket[] pair = getSocketPair();
-        Socket leaderSocket = pair[0];
-        Socket followerSocket = pair[1];
         File tmpDir = File.createTempFile("test", "dir", testData);
         tmpDir.delete();
         tmpDir.mkdir();
@@ -852,14 +849,13 @@ public class Zab1_0Test extends ZKTestCase {
 
             File snapDir = new File(tmpDir, "version-2");
             long lastModBefore = getLatestSnapshotModTime(snapDir);
-            Thread.sleep(50);
+            // 1100ms covers HFS+ 1s mtime granularity on macOS dev hosts
+            Thread.sleep(1100);
 
             leadThread = new LeadThread(leader);
             leadThread.start();
 
-            while (leader.cnxAcceptor == null || !leader.cnxAcceptor.isAlive()) {
-                Thread.sleep(20);
-            }
+            waitForCnxAcceptor(leader);
 
             // The leader is now past loadData(). With skipSnapshot=true,
             // the snapshot file should NOT have been rewritten.
@@ -884,9 +880,6 @@ public class Zab1_0Test extends ZKTestCase {
      */
     @Test
     public void testLeaderTakesSnapshotByDefault() throws Exception {
-        Socket[] pair = getSocketPair();
-        Socket leaderSocket = pair[0];
-        Socket followerSocket = pair[1];
         File tmpDir = File.createTempFile("test", "dir", testData);
         tmpDir.delete();
         tmpDir.mkdir();
@@ -905,14 +898,12 @@ public class Zab1_0Test extends ZKTestCase {
 
             File snapDir = new File(tmpDir, "version-2");
             long lastModBefore = getLatestSnapshotModTime(snapDir);
-            Thread.sleep(50);
+            Thread.sleep(1100);
 
             leadThread = new LeadThread(leader);
             leadThread.start();
 
-            while (leader.cnxAcceptor == null || !leader.cnxAcceptor.isAlive()) {
-                Thread.sleep(20);
-            }
+            waitForCnxAcceptor(leader);
 
             // With skipSnapshot=false (default), the snapshot should have been rewritten
             long lastModAfter = getLatestSnapshotModTime(snapDir);
@@ -943,6 +934,44 @@ public class Zab1_0Test extends ZKTestCase {
             latest = Math.max(latest, f.lastModified());
         }
         return latest;
+    }
+
+    /**
+     * Poll for cnxAcceptor liveness with a deadline. Without the bound, a leader
+     * thread that dies in loadData() (e.g., snapshot IOException) would hang the
+     * test until JUnit times out the whole suite — slow + opaque failure mode.
+     */
+    private static void waitForCnxAcceptor(Leader leader) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (leader.cnxAcceptor == null || !leader.cnxAcceptor.isAlive()) {
+            if (System.currentTimeMillis() > deadline) {
+                fail("Leader did not start cnxAcceptor within 10s; loadData() may have failed");
+            }
+            Thread.sleep(20);
+        }
+    }
+
+    /**
+     * Regression guard for the follower path: the skipLeaderStartupSnapshot flag is
+     * leader-path only (read at Leader.java:590). The follower codepath
+     * (Learner.syncWithLeader) must not branch on it. Re-runs the standard follower
+     * DIFF-sync conversation with the flag globally enabled; if a future refactor
+     * leaks the flag into Learner / Follower, this test will diverge from
+     * testNormalFollowerRunWithDiff and flag the regression.
+     */
+    @Test
+    public void testFollowerPathUnaffectedBySkipFlag() throws Exception {
+        String prior = System.getProperty(QuorumPeer.SKIP_LEADER_STARTUP_SNAPSHOT);
+        System.setProperty(QuorumPeer.SKIP_LEADER_STARTUP_SNAPSHOT, "true");
+        try {
+            testNormalFollowerRunWithDiff();
+        } finally {
+            if (prior == null) {
+                System.clearProperty(QuorumPeer.SKIP_LEADER_STARTUP_SNAPSHOT);
+            } else {
+                System.setProperty(QuorumPeer.SKIP_LEADER_STARTUP_SNAPSHOT, prior);
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

On large ensembles (15M+ znodes), the synchronous snapshot in `ZooKeeperServer.loadData()` takes 34–43s on production hardware, blocking quorum formation and causing repeated election failures when it exceeds `initLimit` (incident-10033: 4m 47s outage).

This PR introduces a feature flag (`zookeeper.leaderElection.skipStartupSnapshot`, **default: false**) that conditionally skips the startup snapshot during leader election. With the flag enabled, projected leader-election time drops from minutes to ~1s, independent of znode count.

> **Status: this is at the proposal stage.** PR opened as **draft** for early visibility. Production rollout is gated on (1) thorough review with in-house ZK SMEs, (2) engagement with Apache ZK OSS committers on the design, and (3) staging (EI) validation.

## Motivation

Incident-10033 was four consecutive identical snapshot writes — ~166s wasted before the 4th finally completed near the timeout, after which followers DIFF-synced in ~55ms. The disk snapshot file itself was never sent to followers (DIFF sync uses txn log entries, not the snapshot file). The 4 snapshot writes were redundant work that scaled linearly with znode count.

This is the same fix Flavio Junqueira committed to branch-3.4 in 2013 ([ZOOKEEPER-1558](https://issues.apache.org/jira/browse/ZOOKEEPER-1558)), and the same fix proposed upstream in [ZOOKEEPER-4766](https://issues.apache.org/jira/browse/ZOOKEEPER-4766) (open).

## Changes

### Implementation (3 files, +50/-3)
- **`ZooKeeperServer.java`** — new `loadData(boolean skipSnapshot)` overload; no-arg `loadData()` delegates to `loadData(false)` for backward compatibility.
- **`Leader.java:590`** — passes `self.isSkipLeaderStartupSnapshot()` to `loadData()`.
- **`QuorumPeer.java`** — system property `zookeeper.leaderElection.skipStartupSnapshot` (default `false`), getter/setter.

### Tests (3 files, +247)
- **`ZooKeeperServerTest`** — 3 tests: `loadData(true)` skips snapshot, `loadData(false)` takes snapshot, no-arg `loadData()` delegates to `loadData(false)`.
- **`QuorumPeerTest`** — 2 tests: default false, getter/setter correctness.
- **`Zab1_0Test`** — 2 tests: leader with skip=true does not rewrite snapshot during `lead()`; leader with skip=false (default) does. Tests pre-initialize the DB via `loadDataBase()` to match the real election path where `zkDb.isInitialized() == true`.

All 82 tests pass (7 new + existing).

## Safety

Skipping is safe because:

| Scenario | Why it's safe |
|---|---|
| Leader crashes before periodic snapshot | Recovery replays existing snapshot + txn log → identical state. `killSession()` is idempotent. Same as branch-3.4 behavior, which ran without this snapshot for its full lifecycle. |
| Followers sync after election | Followers use **DIFF** sync (txn log entries), not the disk snapshot file. Confirmed in incident-10033 logs. |
| Session data accuracy on restart | `killSession()` is idempotent; `SyncRequestProcessor` triggers a periodic snapshot within seconds on a high-write ensemble. |
| Dirty/uncommitted state | The pre-quorum snapshot was actually *causing* a known dirty-snapshot issue (per ZOOKEEPER-1558). Removing it eliminates that latent bug. |

## Rollout plan

- **Default OFF** — flag must be explicitly enabled per host.
- **Reversible** — disable flag, restart hosts, behavior reverts to current.
- Production order: non-critical → critical non-Kafka → Kafka EI → Kafka prod non-tier-0 → Kafka prod tier-0.
- Monitoring: election time, periodic snapshot time, `QuorumDigest` mismatches, session count.

## References

- **Design doc and supporting evidence**: https://drive.google.com/drive/folders/1jIOO_tJ1oEgCoJ75a4Q2wfr0YvqtHdbU
  - `01-proposal-snapshot-optimization.md` — exec proposal
  - `02-incident-10033-log-correlation.md` — production log evidence (all 5 cycles)
  - `03-approach-skip-snapshot.md` — detailed design, safety analysis, test strategy
  - `04-zk-snapshot-mechanics.md` — reference for ZK snapshot read/write paths
- **Apache JIRAs**:
  - [ZOOKEEPER-1558](https://issues.apache.org/jira/browse/ZOOKEEPER-1558) (3.4-only fix, 2013) — fpj removed the same snapshot from `loadData()`
  - [ZOOKEEPER-2678](https://issues.apache.org/jira/browse/ZOOKEEPER-2678) (already in 3.6.3) — same skip-snapshot pattern applied to follower DIFF sync path
  - [ZOOKEEPER-4766](https://issues.apache.org/jira/browse/ZOOKEEPER-4766) (open) — upstream version of the leader-side fix

## Test plan

- [x] Unit tests pass locally (82 total, 7 new)
- [ ] In-house ZK SME review (Clark Haskins, Jon Bringhurst, Kiran Kambhampati)
- [ ] Engagement with Apache ZK OSS committers on the design
- [ ] EI staging validation (small ensemble, then growing)
- [ ] Production rollout per the staged plan above
