### PR TITLE
ZOOKEEPER-5046: Upgrade burningwave-tools to 0.27.2 to fix StaticHost…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -572,7 +572,7 @@
     <checkstyle.version>8.39</checkstyle.version>
     <enforcer.version>3.0.0-M3</enforcer.version>
     <commons-io.version>2.11.0</commons-io.version>
-    <burningwave.mockdns.version>0.25.4</burningwave.mockdns.version>
+    <burningwave.mockdns.version>0.27.2</burningwave.mockdns.version>
     <clover-maven-plugin.version>4.4.1</clover-maven-plugin.version>
     <sonar-maven-plugin.version>3.7.0.1746</sonar-maven-plugin.version>
 


### PR DESCRIPTION
…ProviderTest on Java 21+

<!-- 
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at
http://www.apache.org/licenses/LICENSE-2.0
Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
--> 
    
### Description
Upgrade burningwave-tools dependency from "0.25.4 "to "0.27.2" to fix 
StaticHostProviderTest failing on Java 21+. The older version (0.25.4) 
cannot initialize its NativeDriver on JVM version 21+, causing an 
ExceptionInInitializerError in the @BeforeAll setup of StaticHostProviderTest.

### Tests
 The following tests are written for this issue:
Test fixed: org.apache.zookeeper.test.StaticHostProviderTest

mvn test -pl zookeeper-server -Dtest=StaticHostProviderTest

Tests run: 26, Failures: 0, Errors: 0, Skipped: 0 ✅
Tested on: OpenJDK 26.0.1 (build 26.0.1+8-34)

The following is the result of the "mvn test" command on the appropriate module:
(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)
My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:
None. This is a test-scoped dependency upgrade only. No production code is affected.

### Documentation (Optional)
In case of new functionality, my PR adds documentation in the following wiki page:
N/A - This is a bug fix, no new documentation required.
