### PR TITLE
ZOOKEEPER-4415 + ZOOKEEPER-4912: enable TLSv1.3 and remove default cipher overrides

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1453,19 +1453,19 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
     (Java system properties: **zookeeper.ssl.protocol** and **zookeeper.ssl.quorum.protocol**)
     **New in 3.5.5:**
     Specifies to protocol to be used in client and quorum TLS negotiation.
-    Default: TLSv1.2
+    Default: TLSv1.3 when the running JDK supports it, TLSv1.2 otherwise.
 
 * *ssl.enabledProtocols* and *ssl.quorum.enabledProtocols* :
     (Java system properties: **zookeeper.ssl.enabledProtocols** and **zookeeper.ssl.quorum.enabledProtocols**)
     **New in 3.5.5:**
     Specifies the enabled protocols in client and quorum TLS negotiation.
-    Default: value of `protocol` property
+    Default: when unset, the JDK's default enabled protocols for the configured `protocol` are used. On a JDK that supports TLSv1.3 this is `TLSv1.3, TLSv1.2`; otherwise it is `TLSv1.2`.
 
 * *ssl.ciphersuites* and *ssl.quorum.ciphersuites* :
     (Java system properties: **zookeeper.ssl.ciphersuites** and **zookeeper.ssl.quorum.ciphersuites**)
     **New in 3.5.5:**
     Specifies the enabled cipher suites to be used in client and quorum TLS negotiation.
-    Default: Enabled cipher suites depend on the Java runtime version being used.    
+    Default: when unset, the JDK's default cipher suites are used. This adapts automatically to the JDK in use and avoids freezing a cipher list that may not match the running JDK.
 
 * *ssl.context.supplier.class* and *ssl.quorum.context.supplier.class* :
     (Java system properties: **zookeeper.ssl.context.supplier.class** and **zookeeper.ssl.quorum.context.supplier.class**)

--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1454,6 +1454,7 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
     **New in 3.5.5:**
     Specifies to protocol to be used in client and quorum TLS negotiation.
     Default: TLSv1.3 when the running JDK supports it, TLSv1.2 otherwise.
+    Setting only this property selects the `SSLContext` protocol but does not by itself restrict the enabled-protocol set — the JDK's default enabled list for the chosen context applies. To pin an ensemble to a single TLS protocol (e.g. TLSv1.2 only), set `ssl.enabledProtocols` (or `ssl.quorum.enabledProtocols`) explicitly.
 
 * *ssl.enabledProtocols* and *ssl.quorum.enabledProtocols* :
     (Java system properties: **zookeeper.ssl.enabledProtocols** and **zookeeper.ssl.quorum.enabledProtocols**)

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/SSLContextAndOptions.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/SSLContextAndOptions.java
@@ -173,6 +173,9 @@ public class SSLContextAndOptions {
             // Use JDK defaults for enabled protocols:
             //   Protocol TLSv1.3 -> enabled protocols TLSv1.3 and TLSv1.2
             //   Protocol TLSv1.2 -> enabled protocols TLSv1.2
+            // Note: setting only ssl.protocol selects the SSLContext protocol but does
+            // not by itself restrict the enabled-protocol set. To strictly pin to a
+            // single protocol, the operator must set ssl.enabledProtocols explicitly.
             return sslContext.getDefaultSSLParameters().getProtocols();
         }
         return enabledProtocolsInput.split(",");

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/SSLContextAndOptions.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/SSLContextAndOptions.java
@@ -67,7 +67,7 @@ public class SSLContextAndOptions {
         this.enabledProtocols = getEnabledProtocols(requireNonNull(config), sslContext);
         String[] ciphers = getCipherSuites(config);
         this.cipherSuites = ciphers;
-        this.cipherSuitesAsList = Collections.unmodifiableList(Arrays.asList(ciphers));
+        this.cipherSuitesAsList = ciphers == null ? null : Collections.unmodifiableList(Arrays.asList(ciphers));
         this.clientAuth = getClientAuth(config);
         this.handshakeDetectionTimeoutMillis = getHandshakeDetectionTimeoutMillis(config);
     }
@@ -170,7 +170,10 @@ public class SSLContextAndOptions {
     private String[] getEnabledProtocols(final ZKConfig config, final SSLContext sslContext) {
         String enabledProtocolsInput = config.getProperty(x509Util.getSslEnabledProtocolsProperty());
         if (enabledProtocolsInput == null) {
-            return new String[]{sslContext.getProtocol()};
+            // Use JDK defaults for enabled protocols:
+            //   Protocol TLSv1.3 -> enabled protocols TLSv1.3 and TLSv1.2
+            //   Protocol TLSv1.2 -> enabled protocols TLSv1.2
+            return sslContext.getDefaultSSLParameters().getProtocols();
         }
         return enabledProtocolsInput.split(",");
     }
@@ -178,7 +181,10 @@ public class SSLContextAndOptions {
     private String[] getCipherSuites(final ZKConfig config) {
         String cipherSuitesInput = config.getProperty(x509Util.getSslCipherSuitesProperty());
         if (cipherSuitesInput == null) {
-            return X509Util.getDefaultCipherSuites();
+            // Returning null lets the JDK pick its own default cipher list at
+            // SSLEngine construction time. Avoids freezing a hardcoded list
+            // that may not match the running JDK (ZOOKEEPER-4912).
+            return null;
         } else {
             return cipherSuitesInput.split(",");
         }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/X509Util.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/X509Util.java
@@ -33,7 +33,9 @@ import java.security.NoSuchAlgorithmException;
 import java.security.Security;
 import java.security.cert.PKIXBuilderParameters;
 import java.security.cert.X509CertSelector;
-import java.util.Objects;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import javax.net.ssl.CertPathTrustManagerParameters;
@@ -55,17 +57,15 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Utility code for X509 handling
- *
- * Default cipher suites:
- *
- *   Performance testing done by Facebook engineers shows that on Intel x86_64 machines, Java9 performs better with
- *   GCM and Java8 performs better with CBC, so these seem like reasonable defaults.
  */
 public abstract class X509Util implements Closeable, AutoCloseable {
 
     private static final Logger LOG = LoggerFactory.getLogger(X509Util.class);
 
     private static final String REJECT_CLIENT_RENEGOTIATION_PROPERTY = "jdk.tls.rejectClientInitiatedRenegotiation";
+    public static final String TLS_1_1 = "TLSv1.1";
+    public static final String TLS_1_2 = "TLSv1.2";
+    public static final String TLS_1_3 = "TLSv1.3";
 
     static {
         // Client-initiated renegotiation in TLS is unsafe and
@@ -79,27 +79,26 @@ public abstract class X509Util implements Closeable, AutoCloseable {
         }
     }
 
-    public static final String DEFAULT_PROTOCOL = "TLSv1.2";
-    private static String[] getGCMCiphers() {
-        return new String[]{"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"};
-    }
+    public static final String DEFAULT_PROTOCOL = defaultTlsProtocol();
 
-    private static String[] getCBCCiphers() {
-        return new String[]{"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256", "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384", "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"};
+    /**
+     * Return TLSv1.3 or TLSv1.2 depending on Java runtime version being used.
+     * TLSv1.3 was first introduced in JDK11 and back-ported to OpenJDK 8u272.
+     */
+    private static String defaultTlsProtocol() {
+        String defaultProtocol = TLS_1_2;
+        List<String> supported = new ArrayList<>();
+        try {
+            supported = Arrays.asList(SSLContext.getDefault().getSupportedSSLParameters().getProtocols());
+            if (supported.contains(TLS_1_3)) {
+                defaultProtocol = TLS_1_3;
+            }
+        } catch (NoSuchAlgorithmException e) {
+            // Ignore. SSLContext.getDefault() should not normally fail; fall back to TLSv1.2.
+        }
+        LOG.info("Default TLS protocol is {}, supported TLS protocols are {}", defaultProtocol, supported);
+        return defaultProtocol;
     }
-
-    private static String[] concatArrays(String[] left, String[] right) {
-        String[] result = new String[left.length + right.length];
-        System.arraycopy(left, 0, result, 0, left.length);
-        System.arraycopy(right, 0, result, left.length, right.length);
-        return result;
-    }
-
-    // On Java 8, prefer CBC ciphers since AES-NI support is lacking and GCM is slower than CBC.
-    private static final String[] DEFAULT_CIPHERS_JAVA8 = concatArrays(getCBCCiphers(), getGCMCiphers());
-    // On Java 9 and later, prefer GCM ciphers due to improved AES-NI support.
-    // Note that this performance assumption might not hold true for architectures other than x86_64.
-    private static final String[] DEFAULT_CIPHERS_JAVA9 = concatArrays(getGCMCiphers(), getCBCCiphers());
 
     public static final int DEFAULT_HANDSHAKE_DETECTION_TIMEOUT_MILLIS = 5000;
 
@@ -527,26 +526,6 @@ public abstract class X509Util implements Closeable, AutoCloseable {
 
     public SSLServerSocket createSSLServerSocket(int port) throws X509Exception, IOException {
         return getDefaultSSLContextAndOptions().createSSLServerSocket(port);
-    }
-
-    static String[] getDefaultCipherSuites() {
-        return getDefaultCipherSuitesForJavaVersion(System.getProperty("java.specification.version"));
-    }
-
-    static String[] getDefaultCipherSuitesForJavaVersion(String javaVersion) {
-        Objects.requireNonNull(javaVersion);
-        if (javaVersion.matches("\\d+")) {
-            // Must be Java 9 or later
-            LOG.debug("Using Java9+ optimized cipher suites for Java version {}", javaVersion);
-            return DEFAULT_CIPHERS_JAVA9;
-        } else if (javaVersion.startsWith("1.")) {
-            // Must be Java 1.8 or earlier
-            LOG.debug("Using Java8 optimized cipher suites for Java version {}", javaVersion);
-            return DEFAULT_CIPHERS_JAVA8;
-        } else {
-            LOG.debug("Could not parse java version {}, using Java8 optimized cipher suites", javaVersion);
-            return DEFAULT_CIPHERS_JAVA8;
-        }
     }
 
     private FileChangeWatcher newFileChangeWatcher(String fileLocation) throws IOException {

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509UtilTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509UtilTest.java
@@ -29,7 +29,9 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.security.NoSuchAlgorithmException;
 import java.security.Security;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -118,11 +120,23 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
     public void testCreateSSLContextWithoutCustomProtocol() throws Exception {
         SSLContext sslContext = x509Util.getDefaultSSLContext();
         assertEquals(X509Util.DEFAULT_PROTOCOL, sslContext.getProtocol());
+
+        // Check that TLSv1.3 is selected on JDKs that support it (OpenJDK 8u272 and later).
+        List<String> supported = Arrays.asList(SSLContext.getDefault().getSupportedSSLParameters().getProtocols());
+        if (supported.contains(X509Util.TLS_1_3)) {
+            assertEquals(X509Util.TLS_1_3, sslContext.getProtocol());
+            List<String> protos = Arrays.asList(sslContext.getDefaultSSLParameters().getProtocols());
+            assertTrue(protos.contains(X509Util.TLS_1_2));
+            assertTrue(protos.contains(X509Util.TLS_1_3));
+        } else {
+            assertEquals(X509Util.TLS_1_2, sslContext.getProtocol());
+            assertArrayEquals(new String[]{X509Util.TLS_1_2}, sslContext.getDefaultSSLParameters().getProtocols());
+        }
     }
 
     @Test(timeout = 5000)
     public void testCreateSSLContextWithCustomProtocol() throws Exception {
-        final String protocol = "TLSv1.1";
+        final String protocol = X509Util.TLS_1_1;
         System.setProperty(x509Util.getSslProtocolProperty(), protocol);
         SSLContext sslContext = x509Util.getDefaultSSLContext();
         assertEquals(protocol, sslContext.getProtocol());
@@ -531,7 +545,9 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
     }
 
     // This test makes sure that client-initiated TLS renegotiation does not
-    // succeed. We explicitly disable it at the top of X509Util.java.
+    // succeed when using TLSv1.2. We explicitly disable it at the top of X509Util.java.
+    // Force TLSv1.2 since the renegotiation feature is not supported in TLSv1.3, which
+    // would make this test invalid when the JDK picks TLSv1.3 by default.
     @Test(expected = SSLHandshakeException.class)
     public void testClientRenegotiationFails() throws Throwable {
         int port = PortAssignment.unique();
@@ -549,6 +565,7 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
                 @Override
                 public SSLSocket call() throws Exception {
                     SSLSocket sslSocket = (SSLSocket) listeningSocket.accept();
+                    sslSocket.setEnabledProtocols(new String[]{X509Util.TLS_1_2});
                     sslSocket.addHandshakeCompletedListener(new HandshakeCompletedListener() {
                         @Override
                         public void handshakeCompleted(HandshakeCompletedEvent handshakeCompletedEvent) {
@@ -589,46 +606,6 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
             handshakeCompleted.await(5, TimeUnit.SECONDS);
             assertEquals(1, handshakesCompleted.get());
         }
-    }
-
-    @Test
-    public void testGetDefaultCipherSuitesJava8() {
-        String[] cipherSuites = X509Util.getDefaultCipherSuitesForJavaVersion("1.8");
-        // Java 8 default should have the CBC suites first
-        assertTrue(cipherSuites[0].contains("CBC"));
-    }
-
-    @Test
-    public void testGetDefaultCipherSuitesJava9() {
-        String[] cipherSuites = X509Util.getDefaultCipherSuitesForJavaVersion("9");
-        // Java 9+ default should have the GCM suites first
-        assertTrue(cipherSuites[0].contains("GCM"));
-    }
-
-    @Test
-    public void testGetDefaultCipherSuitesJava10() {
-        String[] cipherSuites = X509Util.getDefaultCipherSuitesForJavaVersion("10");
-        // Java 9+ default should have the GCM suites first
-        assertTrue(cipherSuites[0].contains("GCM"));
-    }
-
-    @Test
-    public void testGetDefaultCipherSuitesJava11() {
-        String[] cipherSuites = X509Util.getDefaultCipherSuitesForJavaVersion("11");
-        // Java 9+ default should have the GCM suites first
-        assertTrue(cipherSuites[0].contains("GCM"));
-    }
-
-    @Test
-    public void testGetDefaultCipherSuitesUnknownVersion() {
-        String[] cipherSuites = X509Util.getDefaultCipherSuitesForJavaVersion("notaversion");
-        // If version can't be parsed, use the more conservative Java 8 default
-        assertTrue(cipherSuites[0].contains("CBC"));
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testGetDefaultCipherSuitesNullVersion() {
-        X509Util.getDefaultCipherSuitesForJavaVersion(null);
     }
 
     // Warning: this will reset the x509Util

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509UtilTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509UtilTest.java
@@ -147,13 +147,25 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
     // SSLContextAndOptions.getCipherSuites() returns null and the constructor
     // must null-guard cipherSuitesAsList. A regression that re-wrapped null
     // via Arrays.asList(null) would NPE before the SSLContext is returned.
+    // Exercises both ClientX509Util (zookeeper.ssl.* prefix) and
+    // QuorumX509Util (zookeeper.ssl.quorum.* prefix) so the guard catches a
+    // future change to either subclass's config prefix or defaults path.
     @Test(timeout = 5000)
     public void testCreateSSLContextWithoutCipherSuites() throws Exception {
-        System.clearProperty(x509Util.getCipherSuitesProperty());
-        x509Util.close();
-        x509Util = new ClientX509Util();
-        SSLContext sslContext = x509Util.getDefaultSSLContext();
-        assertNotNull(sslContext);
+        X509Util[] utils = {new ClientX509Util(), new QuorumX509Util()};
+        try {
+            for (X509Util util : utils) {
+                x509TestContext.setSystemProperties(util, KeyStoreFileType.JKS, KeyStoreFileType.JKS);
+                System.clearProperty(util.getCipherSuitesProperty());
+                SSLContext sslContext = util.getDefaultSSLContext();
+                assertNotNull("SSLContext null for " + util.getClass().getSimpleName(), sslContext);
+                x509TestContext.clearSystemProperties(util);
+            }
+        } finally {
+            for (X509Util util : utils) {
+                util.close();
+            }
+        }
     }
 
     @Test(timeout = 5000)

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509UtilTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/X509UtilTest.java
@@ -21,6 +21,7 @@ package org.apache.zookeeper.common;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -140,6 +141,19 @@ public class X509UtilTest extends BaseX509ParameterizedTestCase {
         System.setProperty(x509Util.getSslProtocolProperty(), protocol);
         SSLContext sslContext = x509Util.getDefaultSSLContext();
         assertEquals(protocol, sslContext.getProtocol());
+    }
+
+    // Regression guard for ZOOKEEPER-4912: when ssl.ciphersuites is unset,
+    // SSLContextAndOptions.getCipherSuites() returns null and the constructor
+    // must null-guard cipherSuitesAsList. A regression that re-wrapped null
+    // via Arrays.asList(null) would NPE before the SSLContext is returned.
+    @Test(timeout = 5000)
+    public void testCreateSSLContextWithoutCipherSuites() throws Exception {
+        System.clearProperty(x509Util.getCipherSuitesProperty());
+        x509Util.close();
+        x509Util = new ClientX509Util();
+        SSLContext sslContext = x509Util.getDefaultSSLContext();
+        assertNotNull(sslContext);
     }
 
     @Test(timeout = 5000)

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumSSLTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/quorum/QuorumSSLTest.java
@@ -56,6 +56,7 @@ import javax.net.ssl.SSLServerSocketFactory;
 import org.apache.zookeeper.PortAssignment;
 import org.apache.zookeeper.client.ZKClientConfig;
 import org.apache.zookeeper.common.QuorumX509Util;
+import org.apache.zookeeper.common.X509Util;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.test.ClientBase;
 import org.bouncycastle.asn1.ocsp.OCSPResponse;
@@ -879,7 +880,7 @@ public class QuorumSSLTest extends QuorumPeerTestBase {
 
     @Test
     public void testProtocolVersion() throws Exception {
-        System.setProperty(quorumX509Util.getSslProtocolProperty(), "TLSv1.2");
+        System.setProperty(quorumX509Util.getSslProtocolProperty(), X509Util.TLS_1_2);
 
         q1 = new MainThread(1, clientPortQp1, quorumConfiguration, SSL_QUORUM_ENABLED);
         q2 = new MainThread(2, clientPortQp2, quorumConfiguration, SSL_QUORUM_ENABLED);
@@ -890,7 +891,7 @@ public class QuorumSSLTest extends QuorumPeerTestBase {
         assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp1, CONNECTION_TIMEOUT));
         assertTrue(ClientBase.waitForServerUp("127.0.0.1:" + clientPortQp2, CONNECTION_TIMEOUT));
 
-        System.setProperty(quorumX509Util.getSslProtocolProperty(), "TLSv1.1");
+        System.setProperty(quorumX509Util.getSslProtocolProperty(), X509Util.TLS_1_1);
 
         // This server should fail to join the quorum as it is not using TLSv1.2
         q3 = new MainThread(3, clientPortQp3, quorumConfiguration, SSL_QUORUM_ENABLED);


### PR DESCRIPTION
## Summary

Combined backport of two upstream Apache ZooKeeper fixes to `branch-3.6`:

- **[ZOOKEEPER-4415](https://issues.apache.org/jira/browse/ZOOKEEPER-4415)** (Apache `66771be4d`, released in 3.9.2): server-side TLSv1.3 support. Picks TLSv1.3 as the default SSLContext protocol when the running JDK supports it, and returns the JDK's default enabled protocols (TLSv1.3 + TLSv1.2 on JDK 11+; TLSv1.2-only on older JDKs) when `ssl.enabledProtocols` is unset.
- **[ZOOKEEPER-4912](https://issues.apache.org/jira/browse/ZOOKEEPER-4912)** (Apache master `2aaeff840`, not yet in any 3.9.x release): removes the hardcoded TLSv1.2-only default cipher list. `SSLContextAndOptions.getCipherSuites()` now returns `null` when `ssl.ciphersuites` is unset, letting the JDK supply its own default cipher list at SSLEngine construction time.

These two changes were a clean hand-craft against `branch-3.6` rather than cherry-picks, because the upstream commits live on top of the JUnit 5 migration that `branch-3.6` does not carry — cherry-picking pulled in unrelated test-framework refactoring noise. The substantive TLS logic is unchanged from upstream.

## Motivation

With `branch-3.6` today, the server installs a fixed TLSv1.2-only cipher set on every SSLEngine even when the JDK supports more recent ciphers and protocols. Two problems block TLSv1.3:

1. The hardcoded cipher list contains no TLSv1.3 ciphers, so TLSv1.3 handshakes have no overlap on the server side and fail.
2. The default protocol is pinned to TLSv1.2 regardless of what the JDK supports.

A downstream workaround of shipping `ssl.ciphersuites` with explicit TLSv1.3 cipher names is brittle against JDK drift: if the running JDK does not recognise a cipher name (e.g. `TLS_CHACHA20_POLY1305_SHA256` on OpenJDK 11.0.8, which only added it in 11.0.11), `SSLEngine.setEnabledCipherSuites()` throws `IllegalArgumentException: Unsupported CipherSuite` at engine setup and every TLS handshake fails. We hit exactly this in an internal deployment.

After this backport, neither X509Util nor any downstream config has to carry a cipher list at all. The JDK is the single source of truth for both protocol selection and cipher selection, so JDK upgrades automatically pull in new ciphers and protocols without any code change. Per-deployment overrides via `ssl.enabledProtocols` / `ssl.ciphersuites` continue to work exactly as before.

## Changes

**`X509Util.java`**
- Add `TLS_1_1` / `TLS_1_2` / `TLS_1_3` string constants.
- Replace `DEFAULT_PROTOCOL = "TLSv1.2"` with `defaultTlsProtocol()`, which returns TLSv1.3 when the JDK supports it, TLSv1.2 otherwise.
- Delete `getGCMCiphers` / `getCBCCiphers` / `concatArrays` / `DEFAULT_CIPHERS_JAVA8` / `DEFAULT_CIPHERS_JAVA9` / `getDefaultCipherSuites` / `getDefaultCipherSuitesForJavaVersion`.
- Drop the now-irrelevant "Default cipher suites" class doc-comment and the unused `Objects` import.

**`SSLContextAndOptions.java`**
- `getCipherSuites()`: return `null` when `ssl.ciphersuites` is unset, instead of falling back to `X509Util.getDefaultCipherSuites()`.
- Constructor: null-guard `cipherSuitesAsList` (`Collections.unmodifiableList(Arrays.asList(null))` would NPE; both `configureSslParameters` and `createNettyJdkSslContext` already accept `null` = "use JDK defaults").
- `getEnabledProtocols()`: return `sslContext.getDefaultSSLParameters().getProtocols()` (the JDK's curated default list for the chosen protocol) instead of `new String[]{sslContext.getProtocol()}`.

**`X509UtilTest.java`**
- Augment `testCreateSSLContextWithoutCustomProtocol` to assert TLSv1.3 is selected on JDKs that support it (and the enabled-protocol list contains both TLSv1.2 and TLSv1.3); otherwise assert TLSv1.2-only. Mirrors the upstream ZOOKEEPER-4415 test additions, in JUnit 4 style.
- Switch the `"TLSv1.1"` string literal in `testCreateSSLContextWithCustomProtocol` to the new `X509Util.TLS_1_1` constant.
- Pin `testClientRenegotiationFails` to TLSv1.2 — renegotiation is not a TLSv1.3 feature, so this test must explicitly force 1.2 to stay meaningful once 1.3 becomes the default.
- Delete the six obsolete `testGetDefaultCipherSuites*` tests that exercised the now-deleted Java-version-aware cipher selector.
- Add `testCreateSSLContextWithoutCipherSuites` as a focused regression guard for the null-handling chain — clears `ssl.ciphersuites`, rebuilds the X509Util, and asserts the `SSLContextAndOptions` constructor returns without NPE. Pre-fix, `Collections.unmodifiableList(Arrays.asList(null))` would throw before the SSLContext was produced.

**`QuorumSSLTest.java`**
- `testProtocolVersion`: adopt the new `X509Util.TLS_1_1` / `X509Util.TLS_1_2` constants in place of raw `"TLSv1.x"` literals, for consistency with the new convention introduced in this PR. No behaviour change.

**`zookeeperAdmin.md`**
- Document the new defaults: TLSv1.3 when JDK supports it; JDK default protocol/cipher list when properties are unset.

## Compatibility notes

- **`X509Util.DEFAULT_PROTOCOL` is no longer a compile-time constant.** It is still declared `public static final String` but its value is computed at class-load time via `SSLContext.getDefault().getSupportedSSLParameters()`. Callers that were compiled against an earlier `branch-3.6` with the literal `"TLSv1.2"` *inlined* by `javac` will keep seeing `"TLSv1.2"` until recompiled against the new JAR. For this fork, all consumers ship together as part of the same release, so this is a non-issue — flagged for anyone backporting further.
- **`X509Util.getDefaultCipherSuites()` and `getDefaultCipherSuitesForJavaVersion()` are removed.** Both were package-private (`static`, not `public static`). The only intra-repo caller was `SSLContextAndOptions.getCipherSuites()`, which is updated in the same commit. A `grep -rn 'getDefaultCipherSuites' zookeeper-server/src/main` confirms no other callers. Anyone calling these via reflection from outside this repo will break; we are not aware of such callers in the LinkedIn ZK ecosystem.
- **Per-deployment overrides are preserved.** `ssl.enabledProtocols` and `ssl.ciphersuites` continue to honour user-supplied values exactly as before. Setting `ssl.enabledProtocols=TLSv1.2` on a specific ensemble pins that ensemble to TLSv1.2 even on a JDK that supports TLSv1.3.

## Testing done

Verified locally with Maven 3.6.3 / OpenJDK 17.0.5:

| Test class | Result |
|---|---|
| `X509UtilTest` | **312/312 pass** (304 from the existing suite + 8 parametrized invocations of the new null-cipher regression test, all on JDK 17 which exercises the TLSv1.3 path) |
| `QuorumSSLTest` | **12/13 pass**; only `testOCSP` fails — confirmed pre-existing on unmodified `branch-3.6` HEAD (same failure, same elapsed time), unrelated to TLS protocol/cipher logic |
| `X509SpiffeAuthIntegrationTest` | 6 failures, all `NoSuchMethodError` — pre-existing test-classpath issue, unrelated |
| Full `zookeeper-server` module compile | BUILD SUCCESS, 384 source files |

The `ClientX509Util.java` parts of upstream ZOOKEEPER-4912 are **not** included because `branch-3.6`'s `ClientX509Util` is a 39-line stub that does not own any of the Netty `SslContextBuilder` calls that the upstream commit modifies — there is nothing in `branch-3.6` to update there.

## Diff stat

```
zookeeper-docs/.../zookeeperAdmin.md                  |  6 +-
zookeeper-server/.../common/SSLContextAndOptions.java | 12 +++-
zookeeper-server/.../common/X509Util.java             | 69 ++++++++--------------
zookeeper-server/.../common/X509UtilTest.java         | 75 ++++++++++----------------
zookeeper-server/.../quorum/QuorumSSLTest.java        |  5 +-
5 files changed, 75 insertions(+), 92 deletions(-)
```